### PR TITLE
feat: Add lightweight image lightbox functionality with styles and integration

### DIFF
--- a/assets/js/lightbox.js
+++ b/assets/js/lightbox.js
@@ -1,0 +1,363 @@
+// Simple, dependency-free image lightbox for #mainview
+// Usage: import { installLightbox } from './js/lightbox.js'; installLightbox({ root: '#mainview' });
+
+export function installLightbox(opts = {}) {
+  const rootSelector = opts.root || '#mainview';
+  const root = () => document.querySelector(rootSelector) || document;
+
+  // Create overlay once
+  let overlay = document.getElementById('ns-lightbox');
+  if (!overlay) {
+    overlay = document.createElement('div');
+    overlay.id = 'ns-lightbox';
+    overlay.setAttribute('aria-hidden', 'true');
+    overlay.setAttribute('role', 'dialog');
+    overlay.innerHTML = `
+      <button class="ns-lb-close" aria-label="Close">×</button>
+      <button class="ns-lb-reset" aria-label="Reset zoom">⤾</button>
+      <div class="ns-lb-stage">
+        <img class="ns-lb-img" alt="">
+        <div class="ns-lb-caption" aria-live="polite"></div>
+      </div>
+      <div class="ns-lb-zoom" aria-hidden="true"></div>
+      <button class="ns-lb-prev" aria-label="Previous">‹</button>
+      <button class="ns-lb-next" aria-label="Next">›</button>
+    `;
+    document.body.appendChild(overlay);
+  }
+
+  const imgEl = overlay.querySelector('.ns-lb-img');
+  const captionEl = overlay.querySelector('.ns-lb-caption');
+  const prevBtn = overlay.querySelector('.ns-lb-prev');
+  const nextBtn = overlay.querySelector('.ns-lb-next');
+  const closeBtn = overlay.querySelector('.ns-lb-close');
+  const resetBtn = overlay.querySelector('.ns-lb-reset');
+  const stageEl = overlay.querySelector('.ns-lb-stage');
+  const zoomEl = overlay.querySelector('.ns-lb-zoom');
+
+  let currentList = [];
+  let currentIndex = -1;
+  let lastActive = null;
+
+  // Zoom/Pan state
+  let scale = 1, tx = 0, ty = 0;
+  const minScale = 1, maxScale = 5;
+  let dragging = false; let dragX = 0, dragY = 0; let startTx = 0, startTy = 0;
+  let pinchStartDist = 0, pinchStartScale = 1;
+  let lastFit = { baseW: 0, baseH: 0, natW: 0, natH: 0 };
+  // Smooth zoom state
+  let targetScale = 1;
+  let zoomAnchor = null; // {x, y} in stage-centered coords
+  let zoomAnchorTimer = null;
+  let rafId = null;
+  // Pan animation (e.g., for reset)
+  let panAnimating = false;
+  let panTargetX = 0, panTargetY = 0;
+
+  function computeBaseFit() {
+    const natW = imgEl.naturalWidth || 0;
+    const natH = imgEl.naturalHeight || 0;
+    if (!natW || !natH) { lastFit = { baseW: 0, baseH: 0, natW, natH }; return lastFit; }
+    const capH = (captionEl && captionEl.offsetHeight) || 0;
+    const sw = stageEl.clientWidth || window.innerWidth;
+    const sh = Math.max(0, (stageEl.clientHeight || window.innerHeight) - capH - 8);
+    const fit = Math.min(sw / natW, sh / natH);
+    const baseW = natW * fit;
+    const baseH = natH * fit;
+    lastFit = { baseW, baseH, natW, natH };
+    return lastFit;
+  }
+
+  function clampPan() {
+    if (scale <= 1) { tx = 0; ty = 0; return; }
+    const { baseW, baseH } = lastFit.baseW ? lastFit : computeBaseFit();
+    const capH = (captionEl && captionEl.offsetHeight) || 0;
+    const sw = stageEl.clientWidth || window.innerWidth;
+    const sh = Math.max(0, (stageEl.clientHeight || window.innerHeight) - capH - 8);
+    const vw = sw; const vh = sh;
+    const dispW = baseW * scale;
+    const dispH = baseH * scale;
+    const maxX = Math.max(0, (dispW - vw) / 2);
+    const maxY = Math.max(0, (dispH - vh) / 2);
+    tx = Math.max(-maxX, Math.min(maxX, tx));
+    ty = Math.max(-maxY, Math.min(maxY, ty));
+  }
+
+  function applyTransform() {
+    clampPan();
+    imgEl.style.transform = `translate3d(${tx}px, ${ty}px, 0) scale(${scale})`;
+    if (scale > 1 && !imgEl.classList.contains('ns-lb-grab')) imgEl.classList.add('ns-lb-grab');
+    if (scale === 1) { imgEl.classList.remove('ns-lb-grab'); imgEl.classList.remove('ns-lb-grabbing'); }
+    if (zoomEl) zoomEl.textContent = `${Math.round(scale * 100)}%`;
+  }
+
+  function resetTransform() {
+    targetScale = scale = 1; tx = 0; ty = 0; applyTransform();
+  }
+
+  function setScaleImmediate(next, anchor) {
+    const prev = scale;
+    const s2 = Math.max(minScale, Math.min(maxScale, next));
+    if (anchor && typeof anchor.x === 'number' && typeof anchor.y === 'number' && prev > 0 && s2 !== prev) {
+      // Keep the point under the cursor/fingers stationary in screen space
+      const k = 1 - s2 / prev;
+      tx = tx + (anchor.x - tx) * k;
+      ty = ty + (anchor.y - ty) * k;
+    }
+    scale = s2;
+    if (scale === 1) { tx = 0; ty = 0; }
+    // Simple center-zoom; avoid complex anchor compensation for now
+    if (prev !== scale) applyTransform();
+  }
+
+  function setScaleTarget(next, anchor) {
+    targetScale = Math.max(minScale, Math.min(maxScale, next));
+    if (anchor) {
+      zoomAnchor = { x: anchor.x, y: anchor.y };
+      if (zoomAnchorTimer) clearTimeout(zoomAnchorTimer);
+      zoomAnchorTimer = setTimeout(() => { zoomAnchor = null; }, 180);
+    }
+    ensureRaf();
+  }
+
+  function animateReset() {
+    panAnimating = true;
+    panTargetX = 0; panTargetY = 0;
+    setScaleTarget(1, { x: 0, y: 0 });
+  }
+
+  function tick() {
+    rafId = null;
+    const prev = scale;
+    const diff = targetScale - prev;
+    if (Math.abs(diff) < 0.001) {
+      if (prev !== targetScale) setScaleImmediate(targetScale, zoomAnchor || null);
+      // continue to pan animate if needed
+    } else {
+      const step = prev + diff * 0.38; // snappier easing
+      setScaleImmediate(step, zoomAnchor || null);
+    }
+    if (panAnimating) {
+      const px = panTargetX - tx;
+      const py = panTargetY - ty;
+      tx += px * 0.25;
+      ty += py * 0.25;
+      if (Math.hypot(px, py) < 0.6 && Math.abs(targetScale - scale) < 0.01) {
+        tx = panTargetX; ty = panTargetY; panAnimating = false;
+      }
+      applyTransform();
+    }
+    ensureRaf();
+  }
+
+  function ensureRaf() {
+    if (rafId == null) rafId = requestAnimationFrame(tick);
+  }
+
+  function collectImages() {
+    const container = root();
+    const all = Array.from(container.querySelectorAll('img'))
+      .filter(el => !el.classList.contains('card-cover')) // ignore index cards
+      .filter(el => el.offsetParent !== null); // visible images only
+    return all;
+  }
+
+  function resolveSrc(el) {
+    if (!el) return '';
+    return el.getAttribute('src') || el.getAttribute('data-src') || '';
+  }
+
+  function openAt(index) {
+    if (!currentList.length) return;
+    currentIndex = Math.max(0, Math.min(index, currentList.length - 1));
+    const src = resolveSrc(currentList[currentIndex]);
+    const alt = currentList[currentIndex].getAttribute('alt') || '';
+    if (src) {
+      const ensureFit = () => { computeBaseFit(); applyTransform(); };
+      if (imgEl.complete && imgEl.naturalWidth > 0) { imgEl.src = src; ensureFit(); }
+      else { imgEl.addEventListener('load', ensureFit, { once: true }); imgEl.src = src; }
+    }
+    imgEl.alt = alt;
+    captionEl.textContent = alt;
+    overlay.classList.add('open');
+    overlay.setAttribute('aria-hidden', 'false');
+    document.documentElement.classList.add('ns-lb-lock');
+    resetTransform();
+    try { lastActive = document.activeElement; } catch (_) {}
+    closeBtn.focus({ preventScroll: true });
+    updateAriaForButtons();
+  }
+
+  function close() {
+    overlay.classList.remove('open');
+    overlay.setAttribute('aria-hidden', 'true');
+    document.documentElement.classList.remove('ns-lb-lock');
+    imgEl.removeAttribute('src');
+    captionEl.textContent = '';
+    try { if (lastActive && lastActive.focus) lastActive.focus({ preventScroll: true }); } catch (_) {}
+  }
+
+  function prev() { if (currentList.length) openAt((currentIndex - 1 + currentList.length) % currentList.length); }
+  function next() { if (currentList.length) openAt((currentIndex + 1) % currentList.length); }
+
+  function updateAriaForButtons() {
+    const total = currentList.length;
+    prevBtn.disabled = total < 2;
+    nextBtn.disabled = total < 2;
+  }
+
+  // Click to close when backdrop or close button is clicked
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay || e.target === closeBtn) {
+      e.preventDefault();
+      close();
+    }
+  });
+  prevBtn.addEventListener('click', (e) => { e.preventDefault(); prev(); });
+  nextBtn.addEventListener('click', (e) => { e.preventDefault(); next(); });
+  if (resetBtn) resetBtn.addEventListener('click', (e) => { e.preventDefault(); animateReset(); });
+
+  // Keyboard navigation when open
+  document.addEventListener('keydown', (e) => {
+    if (!overlay.classList.contains('open')) return;
+    if (e.key === 'Escape') { e.preventDefault(); close(); }
+    else if (e.key === 'ArrowLeft') { e.preventDefault(); prev(); }
+    else if (e.key === 'ArrowRight') { e.preventDefault(); next(); }
+  });
+
+  // Wheel zoom (desktop)
+  imgEl.addEventListener('wheel', (e) => {
+    if (!overlay.classList.contains('open')) return;
+    // Always prevent default to avoid page scrolling behind overlay
+    e.preventDefault();
+
+    const ua = (navigator.userAgent || '') + ' ' + (navigator.platform || '');
+    const isMac = /Mac|Macintosh|Mac OS/.test(ua);
+    const isPinch = !!e.ctrlKey; // Chrome/Safari set ctrlKey during trackpad pinch
+
+    // Two-finger pan on trackpad when not pinching and image is zoomed
+    if (!isPinch && scale > 1) {
+      // Use wheel deltas directly for panning; clamp and apply
+      // Invert to match scroll semantics (scroll down moves content up)
+      tx -= e.deltaX;
+      ty -= e.deltaY;
+      applyTransform();
+      return;
+    }
+
+    // Otherwise treat as zoom (mouse wheel or pinch)
+    const clamp = isPinch ? 600 : 320;
+    const dy = Math.max(-clamp, Math.min(clamp, e.deltaY));
+    let k = 0.008; // base sensitivity
+    if (isMac) k = 0.012; // faster on Mac
+    if (isPinch) k *= 1.5; // even faster for pinch
+    const eff = Math.abs(dy) < 1 ? Math.sign(dy || 1) * 1.5 : dy;
+    const factor = Math.exp(-eff * k);
+    const next = scale * factor;
+    if (next !== scale) {
+      const r = stageEl.getBoundingClientRect();
+      const dx = e.clientX - (r.left + r.width / 2);
+      const dy2 = e.clientY - (r.top + r.height / 2);
+      setScaleTarget(next, { x: dx, y: dy2 });
+    }
+  }, { passive: false });
+
+  // Double click/tap to toggle zoom
+  let lastTap = 0;
+  const toggleZoom = (anchor) => {
+    if (scale === 1) setScaleTarget(2, anchor); else setScaleTarget(1, anchor);
+  };
+  imgEl.addEventListener('dblclick', (e) => {
+    if (!overlay.classList.contains('open')) return;
+    e.preventDefault();
+    const r = stageEl.getBoundingClientRect();
+    const dx = e.clientX - (r.left + r.width / 2);
+    const dy = e.clientY - (r.top + r.height / 2);
+    const target = scale === 1 ? 2 : 1;
+    setScaleTarget(target, { x: dx, y: dy });
+  });
+  imgEl.addEventListener('click', (e) => {
+    if (!overlay.classList.contains('open')) return;
+    const now = Date.now();
+    if (now - lastTap < 280) {
+      e.preventDefault();
+      const r = stageEl.getBoundingClientRect();
+      const dx = e.clientX - (r.left + r.width / 2);
+      const dy = e.clientY - (r.top + r.height / 2);
+      const target = scale === 1 ? 2 : 1;
+      setScaleTarget(target, { x: dx, y: dy });
+    }
+    lastTap = now;
+  }, true);
+
+  // Drag to pan (mouse)
+  imgEl.addEventListener('mousedown', (e) => {
+    if (!overlay.classList.contains('open') || scale === 1) return;
+    dragging = true; dragX = e.clientX; dragY = e.clientY; startTx = tx; startTy = ty;
+    imgEl.classList.add('ns-lb-grabbing');
+    e.preventDefault();
+  });
+  window.addEventListener('mousemove', (e) => {
+    if (!dragging) return;
+    tx = startTx + (e.clientX - dragX);
+    ty = startTy + (e.clientY - dragY);
+    applyTransform();
+  });
+  window.addEventListener('mouseup', () => { if (dragging) { dragging = false; imgEl.classList.remove('ns-lb-grabbing'); } });
+
+  // Touch: pinch to zoom and drag to pan
+  imgEl.addEventListener('touchstart', (e) => {
+    if (!overlay.classList.contains('open')) return;
+    if (e.touches.length === 2) {
+      const dx = e.touches[0].clientX - e.touches[1].clientX;
+      const dy = e.touches[0].clientY - e.touches[1].clientY;
+      pinchStartDist = Math.hypot(dx, dy) || 1;
+      pinchStartScale = scale;
+    } else if (e.touches.length === 1 && scale > 1) {
+      dragging = true; dragX = e.touches[0].clientX; dragY = e.touches[0].clientY; startTx = tx; startTy = ty;
+    }
+  }, { passive: true });
+  imgEl.addEventListener('touchmove', (e) => {
+    if (!overlay.classList.contains('open')) return;
+    if (e.touches.length === 2) {
+      const dx = e.touches[0].clientX - e.touches[1].clientX;
+      const dy = e.touches[0].clientY - e.touches[1].clientY;
+      const dist = Math.hypot(dx, dy) || 1;
+      const next = pinchStartScale * (dist / pinchStartDist);
+      const cx = (e.touches[0].clientX + e.touches[1].clientX) / 2;
+      const cy = (e.touches[0].clientY + e.touches[1].clientY) / 2;
+      const r = stageEl.getBoundingClientRect();
+      setScaleImmediate(next, { x: cx - (r.left + r.width / 2), y: cy - (r.top + r.height / 2) });
+      e.preventDefault();
+    } else if (e.touches.length === 1 && dragging) {
+      tx = startTx + (e.touches[0].clientX - dragX);
+      ty = startTy + (e.touches[0].clientY - dragY);
+      applyTransform();
+      e.preventDefault();
+    }
+  }, { passive: false });
+  imgEl.addEventListener('touchend', () => { dragging = false; imgEl.classList.remove('ns-lb-grabbing'); }, { passive: true });
+
+  // Recompute bounds on resize
+  window.addEventListener('resize', () => { if (overlay.classList.contains('open')) { computeBaseFit(); applyTransform(); } });
+
+  // Delegate click from root to open images
+  document.addEventListener('click', (e) => {
+    const t = e.target;
+    if (!t || !(t instanceof Element)) return;
+    // Only within root container
+    if (!t.closest(rootSelector)) return;
+    const img = t.closest('img');
+    if (!img) return;
+    // Ignore images with explicit data-no-viewer
+    if (img.hasAttribute('data-no-viewer')) return;
+    // Ignore index cover images
+    if (img.classList.contains('card-cover')) return;
+    const src = resolveSrc(img);
+    if (!src) return;
+    e.preventDefault();
+    currentList = collectImages();
+    const idx = currentList.indexOf(img);
+    openAt(idx >= 0 ? idx : 0);
+  }, true);
+}

--- a/assets/main.js
+++ b/assets/main.js
@@ -10,6 +10,7 @@ import { initErrorReporter, setReporterContext, showErrorOverlay } from './js/er
 import { initSyntaxHighlighting } from './js/syntax-highlight.js';
 import { applyMasonry, updateMasonryItem, calcAndSetSpan, toPx, debounce } from './js/masonry.js';
 import { aggregateTags, renderTagSidebar, setupTagTooltips } from './js/tags.js';
+import { installLightbox } from './js/lightbox.js';
 
 // Lightweight fetch helper
 const getFile = (filename) => fetch(filename).then(resp => { if (!resp.ok) throw new Error(`HTTP ${resp.status}`); return resp.text(); });
@@ -1871,6 +1872,8 @@ applySavedTheme();
 bindThemeToggle();
 bindSeoGenerator();
 bindThemePackPicker();
+// Install lightweight image viewer (delegated; safe to call once)
+try { installLightbox({ root: '#mainview' }); } catch (_) {}
 // Localize search placeholder ASAP
 try { const input = document.getElementById('searchInput'); if (input) input.setAttribute('placeholder', t('sidebar.searchPlaceholder')); } catch (_) {}
 // Observe viewport changes for responsive tabs

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -235,6 +235,7 @@ pre.with-code-scroll { overflow: hidden; }
 /* Image style */
 img { max-width: 100%; height: auto; display: block; }
 h1 img, h2 img, h3 img, h4 img, h5 img, h6 img { display: inline-block; vertical-align: middle; max-width: 100%; height: auto; }
+#mainview img:not(.card-cover):not([data-no-viewer]) { cursor: zoom-in; }
 
 /* Strikethrough style */
 del {
@@ -311,6 +312,88 @@ table tr:hover { background-color: color-mix(in srgb, var(--primary) 8%, transpa
 /* Ensure list cover images sit flush to the card top (override #mainview img margins) */
 #mainview .index .card-cover { margin: 0; border-radius: 0; box-shadow: none; }
 .index a:hover .card-cover { transform: scale(1.03); }
+
+/* --- Lightbox (image viewer) --- */
+.ns-lb-lock { overflow: hidden; }
+#ns-lightbox { position: fixed; inset: 0; background: rgba(255,255,255,0.9); display: flex; align-items: center; justify-content: center; z-index: 9999; padding: 2rem; opacity: 0; visibility: hidden; pointer-events: none; transition: opacity .22s ease, visibility 0s linear .22s; }
+#ns-lightbox.open { opacity: 1; visibility: visible; pointer-events: auto; transition: opacity .22s ease; }
+#ns-lightbox .ns-lb-stage { max-width: 96vw; max-height: 92vh; display: flex; flex-direction: column; align-items: center; gap: 0.5rem; transform: scale(.985); opacity: .98; transition: transform .24s cubic-bezier(0.16, 1, 0.3, 1), opacity .24s ease; position: relative; z-index: 1; }
+#ns-lightbox.open .ns-lb-stage { transform: none; opacity: 1; }
+#ns-lightbox[data-theme="dark"], [data-theme="dark"] #ns-lightbox { background: rgba(0,0,0,0.9); }
+#ns-lightbox .ns-lb-img { max-width: 96vw; max-height: 86vh; object-fit: contain; border-radius: 0.5rem; box-shadow: 0 0.5rem 2rem rgba(0,0,0,.35); background: var(--card); }
+#ns-lightbox.open .ns-lb-img { cursor: zoom-out; }
+#ns-lightbox .ns-lb-img.ns-lb-grab { cursor: grab; }
+#ns-lightbox .ns-lb-img.ns-lb-grabbing { cursor: grabbing; }
+#ns-lightbox .ns-lb-caption {
+  position: relative;
+  z-index: 2;
+  color: #0b1220; /* dark text in light mode */
+  font-size: 0.95rem;
+  max-width: min(90vw, 56rem);
+  text-align: center;
+  /* No solid backdrop — rely on heavy text shadows */
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  padding: 0.15rem 0.35rem; /* tiny breathing room without looking boxed */
+  box-shadow: none;
+  /* Light-mode: soft light halo for readability over dark image areas */
+  text-shadow:
+    0 1px 2px rgba(255,255,255,0.55),
+    0 0 8px rgba(255,255,255,0.40),
+    0 0 20px rgba(255,255,255,0.30),
+    0 2px 6px rgba(0,0,0,0.18);
+  filter:
+    drop-shadow(0 2px 8px rgba(255,255,255,0.28))
+    drop-shadow(0 0 24px rgba(255,255,255,0.24));
+  -webkit-text-stroke: 0.25px rgba(255,255,255,0.35);
+}
+#ns-lightbox .ns-lb-close { position: absolute; top: 0.75rem; right: 0.75rem; width: 2rem; height: 2rem; border-radius: 999px; border: 1px solid rgba(255,255,255,0.32); background: rgba(17,24,39,0.82); color: #fff; cursor: pointer; font-size: 1.25rem; line-height: 1; display: inline-flex; align-items: center; justify-content: center; backdrop-filter: blur(6px); z-index: 3; box-shadow: 0 10px 24px rgba(0,0,0,0.5); }
+#ns-lightbox .ns-lb-prev,
+#ns-lightbox .ns-lb-next { position: absolute; top: 50%; transform: translateY(-50%); width: 2.5rem; height: 2.5rem; border-radius: 999px; border: 1px solid rgba(255,255,255,0.32); background: rgba(17,24,39,0.82); color: #fff; cursor: pointer; font-size: 1.5rem; line-height: 1; display: inline-flex; align-items: center; justify-content: center; backdrop-filter: blur(6px); z-index: 3; box-shadow: 0 10px 24px rgba(0,0,0,0.5); }
+#ns-lightbox .ns-lb-prev { left: 0.75rem; }
+#ns-lightbox .ns-lb-next { right: 0.75rem; }
+#ns-lightbox .ns-lb-prev:disabled,
+#ns-lightbox .ns-lb-next:disabled { opacity: 0.45; cursor: default; }
+/* Reset button next to close */
+#ns-lightbox .ns-lb-reset { position: absolute; top: 0.75rem; right: 3.1rem; width: 2rem; height: 2rem; border-radius: 999px; border: 1px solid rgba(255,255,255,0.32); background: rgba(17,24,39,0.82); color: #fff; cursor: pointer; font-size: 1rem; line-height: 1; display: inline-flex; align-items: center; justify-content: center; backdrop-filter: blur(6px); z-index: 3; box-shadow: 0 10px 24px rgba(0,0,0,0.5); }
+#ns-lightbox .ns-lb-close:hover,
+#ns-lightbox .ns-lb-reset:hover,
+#ns-lightbox .ns-lb-prev:hover,
+#ns-lightbox .ns-lb-next:hover { background: rgba(17,24,39,0.85); border-color: rgba(255,255,255,0.38); }
+#ns-lightbox .ns-lb-close:focus-visible,
+#ns-lightbox .ns-lb-reset:focus-visible,
+#ns-lightbox .ns-lb-prev:focus-visible,
+#ns-lightbox .ns-lb-next:focus-visible { outline: none; box-shadow: 0 0 0 0.14rem rgba(96,165,250,0.65), 0 6px 18px rgba(0,0,0,0.45); }
+/* Zoom level badge */
+#ns-lightbox .ns-lb-zoom { position: absolute; left: 0.75rem; bottom: 0.75rem; min-width: 2.4rem; height: 2rem; padding: 0 0.55rem; border-radius: 0.5rem; border: 1px solid rgba(255,255,255,0.28); background: rgba(17,24,39,0.82); color: #fff; display: inline-flex; align-items: center; justify-content: center; font-size: 0.88rem; letter-spacing: .02em; backdrop-filter: blur(6px); pointer-events: none; z-index: 3; box-shadow: 0 10px 24px rgba(0,0,0,0.5); }
+
+/* Larger, easier-to-tap controls */
+#ns-lightbox .ns-lb-close { width: 2.75rem; height: 2.75rem; font-size: 1.5rem; }
+#ns-lightbox .ns-lb-prev, #ns-lightbox .ns-lb-next { width: 3rem; height: 3rem; font-size: 1.75rem; }
+#ns-lightbox .ns-lb-reset { width: 2.75rem; height: 2.75rem; font-size: 1.5rem; right: 3.9rem; }
+#ns-lightbox .ns-lb-close, #ns-lightbox .ns-lb-reset, #ns-lightbox .ns-lb-prev, #ns-lightbox .ns-lb-next { transition: transform .14s ease, background-color .14s ease, box-shadow .14s ease; }
+#ns-lightbox .ns-lb-close:active, #ns-lightbox .ns-lb-reset:active, #ns-lightbox .ns-lb-prev:active, #ns-lightbox .ns-lb-next:active { transform: scale(0.96); }
+
+@media (max-width: 640px) {
+  #ns-lightbox .ns-lb-close { width: 2.4rem; height: 2.4rem; font-size: 1.4rem; }
+  #ns-lightbox .ns-lb-reset { width: 2.4rem; height: 2.4rem; right: 3.4rem; font-size: 1.4rem; }
+  #ns-lightbox .ns-lb-prev, #ns-lightbox .ns-lb-next { width: 2.6rem; height: 2.6rem; font-size: 1.6rem; }
+}
+
+[data-theme="dark"] #ns-lightbox .ns-lb-caption {
+  color: #ffffff; /* white text in dark mode */
+  text-shadow:
+    0 1px 2px rgba(0,0,0,0.30),
+    0 0 8px rgba(0,0,0,0.32),
+    0 0 20px rgba(0,0,0,0.28),
+    0 2px 6px rgba(0,0,0,0.28);
+  filter:
+    drop-shadow(0 2px 8px rgba(0,0,0,0.30))
+    drop-shadow(0 0 24px rgba(0,0,0,0.24));
+  -webkit-text-stroke: 0.2px rgba(0,0,0,0.25);
+}
+[data-theme="dark"] #ns-lightbox .ns-lb-img { background: #0f172a; }
 
 /* Post videos: wrapper ensures rounded clipping across browsers */
 .post-video-wrap { position: relative; width: 100%; margin: 1rem auto; border-radius: 0.5rem; overflow: hidden; box-shadow: var(--shadow); background: color-mix(in srgb, var(--text) 4%, transparent); }


### PR DESCRIPTION
This pull request introduces a new, dependency-free image lightbox (viewer) for images inside `#mainview`. Users can now click images (excluding covers and those with `data-no-viewer`) to open them in an accessible, modern overlay with zoom, pan, and navigation controls. The implementation includes both JavaScript and CSS changes to support the lightbox's functionality and appearance.

**New Feature: Image Lightbox Viewer**
- Added a new `installLightbox` function in `lightbox.js` that enables a modal image viewer with keyboard, mouse, and touch support, including zoom, pan, and image navigation. The lightbox is accessible and works on all images in `#mainview` except those explicitly excluded.

**Integration and Initialization**
- Imported and initialized the `installLightbox` function in `main.js`, ensuring the lightbox is installed on page load for the `#mainview` container. [[1]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295R13) [[2]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295R1875-R1876)

**User Experience and Styling**
- Updated `styles.css` to add a zoom-in cursor for images that can be opened in the lightbox and comprehensive styles for the lightbox overlay, controls, captions, and responsive behavior in both light and dark themes. [[1]](diffhunk://#diff-9bce12f93ec0640b44be69b747d96875ab88cd339ff1024423f4e2e64b37b2e1R238) [[2]](diffhunk://#diff-9bce12f93ec0640b44be69b747d96875ab88cd339ff1024423f4e2e64b37b2e1R316-R397)