### PR TITLE
feat: Implement post navigation with previous/next links and styles

### DIFF
--- a/assets/js/post-nav.js
+++ b/assets/js/post-nav.js
@@ -1,0 +1,29 @@
+import { withLangParam, t } from './i18n.js';
+import { escapeHtml } from './utils.js';
+
+export function renderPostNav(container, postsIndex, postname) {
+  try {
+    const root = typeof container === 'string' ? document.querySelector(container) : container;
+    if (!root) return;
+    const entries = Object.entries(postsIndex || {});
+    const idx = entries.findIndex(([, meta]) => meta && meta.location === postname);
+    const prevTuple = (idx > 0) ? entries[idx - 1] : null;
+    const nextTuple = (idx >= 0 && idx < entries.length - 1) ? entries[idx + 1] : null;
+    const makeNavLink = (tuple, label, cls) => {
+      if (!tuple || !tuple[1] || !tuple[1].location) {
+        return `<span class="${cls} disabled" aria-disabled="true"><span class="nav-label">${label}</span></span>`;
+      }
+      const [title, meta] = tuple;
+      const href = withLangParam(`?id=${encodeURIComponent(meta.location)}`);
+      const safeTitle = escapeHtml(String(title || ''));
+      return `<a class="${cls}" href="${href}" aria-label="${label}: ${safeTitle}"><span class="nav-label">${label}</span><span class="nav-title">${safeTitle}</span></a>`;
+    };
+    const navHtml = `<nav class="post-nav" aria-label="Post navigation">${
+      makeNavLink(prevTuple, t('ui.prev'), 'post-nav-prev')
+    }${
+      makeNavLink(nextTuple, t('ui.next'), 'post-nav-next')
+    }</nav>`;
+    root.insertAdjacentHTML('beforeend', navHtml);
+  } catch (_) { /* silent */ }
+}
+

--- a/assets/main.js
+++ b/assets/main.js
@@ -11,6 +11,7 @@ import { initSyntaxHighlighting } from './js/syntax-highlight.js';
 import { applyMasonry, updateMasonryItem, calcAndSetSpan, toPx, debounce } from './js/masonry.js';
 import { aggregateTags, renderTagSidebar, setupTagTooltips } from './js/tags.js';
 import { installLightbox } from './js/lightbox.js';
+import { renderPostNav } from './js/post-nav.js';
 
 // Lightweight fetch helper
 const getFile = (filename) => fetch(filename).then(resp => { if (!resp.ok) throw new Error(`HTTP ${resp.status}`); return resp.text(); });
@@ -1258,6 +1259,7 @@ function displayPost(postname) {
   // Render outdated card + meta card + main content so we can read first heading reliably
   const mainEl = document.getElementById('mainview');
   if (mainEl) mainEl.innerHTML = outdatedCardHtml + metaCardHtml + output.post;
+  try { renderPostNav('#mainview', postsIndexCache, postname); } catch (_) {}
   try { hydratePostImages('#mainview'); } catch (_) {}
     try { applyLazyLoadingIn('#mainview'); } catch (_) {}
     // After images are in DOM, run large-image watchdog if enabled in site config

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -551,6 +551,60 @@ table tr:hover { background-color: color-mix(in srgb, var(--primary) 8%, transpa
 .pagination .active { background: color-mix(in srgb, var(--primary) 16%, transparent); color: var(--primary); border-color: color-mix(in srgb, var(--primary) 40%, var(--border)); font-weight: 700; }
 .pagination .disabled { opacity: .5; pointer-events: none; }
 
+/* Post bottom navigation (Prev/Next) */
+.post-nav {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+  /* Bigger vertical breathing room above and below */
+  margin: 3rem 0 3rem;
+}
+.post-nav a,
+.post-nav span {
+  display: inline-flex;
+  align-items: center;
+  /* Keep tight spacing between label and title to avoid a split-button feel */
+  gap: 0.35rem;
+  padding: .6rem .75rem;
+  border: 0.0625rem solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--card);
+  color: var(--text);
+  text-decoration: none;
+  min-height: 2.5rem;
+}
+.post-nav a:hover { 
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
+  color: var(--primary);
+  border-color: color-mix(in srgb, var(--primary) 35%, var(--border));
+}
+.post-nav .disabled { opacity: .5; pointer-events: none; justify-content: center; }
+.post-nav-prev { justify-content: flex-start; }
+.post-nav-next { justify-content: flex-end; }
+.post-nav .nav-label { font-weight: 700; opacity: .8; }
+.post-nav .nav-title { 
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 70%;
+}
+
+/* Ensure inner text elements never look like separate mini-buttons */
+.post-nav .nav-label,
+.post-nav .nav-title {
+  border: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+}
+
+@media (max-width: 520px) {
+  .post-nav { grid-template-columns: 1fr; }
+  .post-nav-next, .post-nav-prev { justify-content: center; }
+  .post-nav .nav-title { max-width: 60%; }
+}
+
 .hero { border:0.0625rem solid var(--border); background: radial-gradient(37.5rem 15rem at 0% -10%, rgba(37,99,235,.12), transparent 40%), var(--card); border-radius: 0.875rem; padding: 1.25rem; box-shadow: var(--shadow); margin-bottom: 1rem; }
 .hero h2 { margin: 0 0 .35rem; font-size: 1.6rem; }
 .hero p { margin: 0; color: var(--muted); }


### PR DESCRIPTION
This pull request adds a new "previous/next post" navigation component to the bottom of each post, improving user navigation between posts. It includes both the JavaScript logic to render the navigation and the corresponding CSS styles for a polished, responsive UI.

**New Post Navigation Feature**

* Added `renderPostNav` function in `post-nav.js` to generate and insert previous/next navigation links at the bottom of posts, including accessibility and HTML escaping for safety.
* Integrated the new navigation by calling `renderPostNav` after displaying a post in `main.js`.
* Imported `renderPostNav` in `main.js` to ensure the function is available.

**Styling and Responsiveness**

* Added comprehensive CSS styles in `styles.css` for the `.post-nav` component, including layout, button appearance, disabled states, and responsive adjustments for mobile screens.