### PR TITLE
improvements to language and configuration handling

### DIFF
--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -79,6 +79,7 @@ const translations = {
       toggleTheme: 'Toggle Theme',
       themePack: 'Theme pack',
       language: 'Language',
+      resetLanguage: 'Reset language',
       seoGenerator: 'SEO Generator'
     },
     toc: {
@@ -146,6 +147,7 @@ const translations = {
       toggleTheme: '切换主题',
       themePack: '主题包',
       language: '语言',
+      resetLanguage: '重置语言',
       seoGenerator: 'SEO 生成器'
     },
     toc: {
@@ -213,6 +215,7 @@ const translations = {
       toggleTheme: 'テーマ切替',
       themePack: 'テーマパック',
       language: '言語',
+      resetLanguage: '言語をリセット',
       seoGenerator: 'SEOジェネレーター'
     },
     toc: {
@@ -250,7 +253,12 @@ export function initI18n(opts = {}) {
   baseDefaultLang = def || DEFAULT_LANG;
   // If translation bundle missing, fall back to default bundle for UI
   if (!translations[currentLang]) currentLang = def;
-  try { localStorage.setItem(STORAGE_KEY, currentLang); } catch (_) {}
+  // Persist only when allowed (default: true). This enables callers to
+  // perform a non-persistent bootstrap before site config is loaded.
+  const shouldPersist = (opts && Object.prototype.hasOwnProperty.call(opts, 'persist')) ? !!opts.persist : true;
+  if (shouldPersist) {
+    try { localStorage.setItem(STORAGE_KEY, currentLang); } catch (_) {}
+  }
   // Reflect on <html lang>
   document.documentElement.setAttribute('lang', currentLang);
   // Update a few static DOM bits (placeholders, site card)

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -139,6 +139,9 @@ export function mountThemeControls() {
         <label for="langSelect" class="tool-label">${t('tools.language')}</label>
         <select id="langSelect" aria-label="${t('tools.language')}" title="${t('tools.language')}"></select>
       </div>
+      <div class="tool-item">
+        <button id="langReset" class="btn icon-btn" aria-label="${t('tools.resetLanguage')}" title="${t('tools.resetLanguage')}"><span class="icon">♻️</span><span class="btn-text">${t('tools.resetLanguage')}</span></button>
+      </div>
     </div>`;
 
   const toc = document.getElementById('tocview');
@@ -196,6 +199,21 @@ export function mountThemeControls() {
     langSel.addEventListener('change', () => {
       const val = langSel.value || 'en';
       switchLanguage(val);
+    });
+  }
+
+  // Bind language reset button
+  const resetBtn = wrapper.querySelector('#langReset');
+  if (resetBtn) {
+    resetBtn.addEventListener('click', () => {
+      // Clear saved language and drop URL param, then soft-reset without full reload
+      try { localStorage.removeItem('lang'); } catch (_) {}
+      try { const url = new URL(window.location.href); url.searchParams.delete('lang'); history.replaceState(history.state, document.title, url.toString()); } catch (_) {}
+      try { (window.__ns_softResetLang && window.__ns_softResetLang()); } catch (_) { /* fall through */ }
+      // If soft reset isn't available for some reason, fall back to reload
+      if (!window.__ns_softResetLang) {
+        try { window.location.reload(); } catch (_) {}
+      }
     });
   }
 }

--- a/assets/schema/index.json
+++ b/assets/schema/index.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://nanosite.schema/index.schema.json",
+  "title": "NanoSite Posts Index",
+  "type": "object",
+  "additionalProperties": { "$ref": "#/$defs/indexEntry" },
+  "$defs": {
+    "tags": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": ["string", "number"] } }
+      ]
+    },
+    "legacyEntry": {
+      "type": "object",
+      "properties": {
+        "location": { "type": "string" },
+        "title": { "type": "string" },
+        "tag": { "$ref": "#/$defs/tags" },
+        "tags": { "$ref": "#/$defs/tags" },
+        "date": { "type": ["string", "number"] },
+        "image": { "type": "string" },
+        "thumb": { "type": "string" },
+        "cover": { "type": "string" },
+        "excerpt": { "type": "string" }
+      },
+      "required": ["location"],
+      "additionalProperties": true
+    },
+    "langEntry": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "properties": {
+            "title": { "type": "string" },
+            "location": { "type": "string" },
+            "excerpt": { "type": "string" }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "simplifiedOrUnifiedEntry": {
+      "type": "object",
+      "properties": {
+        "tag": { "$ref": "#/$defs/tags" },
+        "tags": { "$ref": "#/$defs/tags" },
+        "date": { "type": ["string", "number"] },
+        "image": { "type": "string" },
+        "thumb": { "type": "string" },
+        "cover": { "type": "string" },
+        "excerpt": { "type": "string" },
+        "default": { "$ref": "#/$defs/langEntry" }
+      },
+      "patternProperties": {
+        "^[A-Za-z]{2}(?:-[A-Za-z0-9]+)?$": { "$ref": "#/$defs/langEntry" },
+        "^(zh|中文|简体中文|日本語|にほんご|english|jp)$": { "$ref": "#/$defs/langEntry" }
+      },
+      "additionalProperties": true,
+      "minProperties": 1
+    },
+    "indexEntry": {
+      "oneOf": [
+        { "$ref": "#/$defs/legacyEntry" },
+        { "$ref": "#/$defs/simplifiedOrUnifiedEntry" }
+      ]
+    }
+  }
+}
+

--- a/assets/schema/site.json
+++ b/assets/schema/site.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://nanosite.schema/site.schema.json",
+  "title": "NanoSite Site Configuration",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "siteTitle": {
+      "$ref": "#/$defs/localizedString"
+    },
+    "siteSubtitle": {
+      "$ref": "#/$defs/localizedString"
+    },
+    "siteDescription": {
+      "$ref": "#/$defs/localizedString"
+    },
+    "siteKeywords": {
+      "$ref": "#/$defs/localizedString"
+    },
+    "resourceURL": {
+      "type": "string"
+    },
+    "avatar": {
+      "type": "string"
+    },
+    "profileLinks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/link"
+      }
+    },
+    "links": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/link"
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "contentOutdatedDays": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "themeMode": {
+      "type": "string",
+      "enum": [
+        "dark",
+        "light",
+        "auto",
+        "user"
+      ]
+    },
+    "themePack": {
+      "type": "string"
+    },
+    "themeOverride": {
+      "type": "boolean"
+    },
+    "cardCoverFallback": {
+      "type": "boolean"
+    },
+    "reportIssueURL": {
+      "type": "string"
+    },
+    "errorOverlay": {
+      "type": "boolean"
+    },
+    "assetWarnings": {
+      "type": "object",
+      "properties": {
+        "largeImage": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "thresholdKB": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "link": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string"
+        },
+        "href": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "label",
+        "href"
+      ],
+      "additionalProperties": false
+    },
+    "localizedString": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "default": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/assets/schema/site.json
+++ b/assets/schema/site.json
@@ -73,6 +73,17 @@
     "errorOverlay": {
       "type": "boolean"
     },
+    "pageSize": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "postsPerPage": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "defaultLanguage": {
+      "type": "string"
+    },
     "assetWarnings": {
       "type": "object",
       "properties": {

--- a/assets/schema/tabs.json
+++ b/assets/schema/tabs.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://nanosite.schema/tabs.schema.json",
+  "title": "NanoSite Tabs Configuration",
+  "type": "object",
+  "additionalProperties": { "$ref": "#/$defs/tabsEntry" },
+  "$defs": {
+    "legacyTabEntry": {
+      "type": "object",
+      "properties": {
+        "location": { "type": "string" },
+        "title": { "type": "string" }
+      },
+      "required": ["location"],
+      "additionalProperties": true
+    },
+    "tabLangEntry": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "object",
+          "properties": {
+            "title": { "type": "string" },
+            "location": { "type": "string" }
+          },
+          "required": ["location"],
+          "additionalProperties": true
+        }
+      ]
+    },
+    "unifiedTabsEntry": {
+      "type": "object",
+      "patternProperties": {
+        "^[A-Za-z]{2}(?:-[A-Za-z0-9]+)?$": { "$ref": "#/$defs/tabLangEntry" },
+        "^(zh|中文|简体中文|日本語|にほんご|english|jp)$": { "$ref": "#/$defs/tabLangEntry" }
+      },
+      "additionalProperties": true,
+      "minProperties": 1
+    },
+    "tabsEntry": {
+      "oneOf": [
+        { "$ref": "#/$defs/legacyTabEntry" },
+        { "$ref": "#/$defs/unifiedTabsEntry" }
+      ]
+    }
+  }
+}
+

--- a/site.yaml
+++ b/site.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=./assets/schema/site.json
+
 siteTitle:
   default: NanoSite
   zh: 微站
@@ -29,4 +31,3 @@ assetWarnings:
   largeImage:
     enabled: true
     thresholdKB: 500
-

--- a/site.yaml
+++ b/site.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=./assets/schema/site.json
 
+# Site identity configurations
 siteTitle:
   default: NanoSite
   zh: 微站
@@ -8,25 +9,35 @@ siteSubtitle:
   default: Just Markdown. Just a website.
   zh: 写下 Markdown，就是你的网站。
   ja: 書くだけ、Markdown。それがサイトになる。
-siteDescription:
-  default: NanoSite - Just Markdown. Just a website.
-  zh: 微站 - 写下 Markdown，就是你的网站。
-  ja: ナノサイト - 書くだけ、Markdown。それがサイトになる。
-resourceURL: https://nano.dee.moe/wwwroot/
-siteKeywords:
-  default: static blog, markdown, github pages, blog
 avatar: assets/avatar.jpeg
+
+# Social media links
 profileLinks:
   - label: GitHub
     href: https://github.com/deemoe404/NanoSite
   - label: Demo
     href: https://nano.dee.moe/
-contentOutdatedDays: 180
+
+# SEO optimization configurations
+resourceURL: https://nano.dee.moe/wwwroot/
+siteDescription:
+  default: NanoSite - Just Markdown. Just a website.
+  zh: 微站 - 写下 Markdown，就是你的网站。
+  ja: ナノサイト - 書くだけ、Markdown。それがサイトになる。
+siteKeywords:
+  default: static blog, markdown, github pages, blog
+
+# Miscellaneous configurations
+contentOutdatedDays: 180  # Days before content is considered outdated
+cardCoverFallback: false  # Use a generated fallback cover image if none provided
+errorOverlay: true        # Show error overlay on the page if an error occurs
+
+# Theme override configurations
 themeMode: user
 themePack: minimalism
 themeOverride: true
-cardCoverFallback: false
-errorOverlay: true
+
+# Asset warnings configurations
 assetWarnings:
   largeImage:
     enabled: true

--- a/site.yaml
+++ b/site.yaml
@@ -31,6 +31,8 @@ siteKeywords:
 contentOutdatedDays: 180  # Days before content is considered outdated
 cardCoverFallback: false  # Use a generated fallback cover image if none provided
 errorOverlay: true        # Show error overlay on the page if an error occurs
+pageSize: 2               # Number of posts per page on the index list
+defaultLanguage: en       # Default UI/content language (e.g., en, zh, ja)
 
 # Theme override configurations
 themeMode: user

--- a/wwwroot/index.yaml
+++ b/wwwroot/index.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../assets/schema/index.json
+
 nanoSite:
   en: post/main/main_en.md
   zh: post/main/main_zh.md
@@ -16,4 +18,3 @@ seo:
   ja: post/seo/seo_ja.md
 test:
   en: post/test/main.md
-

--- a/wwwroot/tabs.yaml
+++ b/wwwroot/tabs.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=../assets/schema/tabs.json
+
 About:
   en:
     title: About
@@ -8,4 +10,3 @@ About:
   ja:
     title: 概要
     location: tab/ja.md
-


### PR DESCRIPTION
This pull request introduces significant improvements to NanoSite's language and configuration handling, enhances user experience with a language reset feature, and adds JSON schema validation for core data files. The main changes are grouped into three themes: language reset and i18n improvements, configuration and site defaults handling, and schema validation for configuration files.

**Language reset and i18n improvements:**

* Added a "Reset Language" button to the UI, allowing users to revert to the site's default language. This includes translations for English, Chinese, and Japanese, and a handler that clears the saved language, updates the URL, and soft-resets the UI without a full reload when possible (`assets/js/i18n.js`, `assets/js/theme.js`) [[1]](diffhunk://#diff-208716f66b472a927f09ee8c661dc4e8b0f123024cba13922bb76172e0846d5eR82) [[2]](diffhunk://#diff-208716f66b472a927f09ee8c661dc4e8b0f123024cba13922bb76172e0846d5eR150) [[3]](diffhunk://#diff-208716f66b472a927f09ee8c661dc4e8b0f123024cba13922bb76172e0846d5eR218) [[4]](diffhunk://#diff-36830fc3e89a6b330e00c7ef30e3001764fa9803c67a9c9fabcacc40578c8df4R142-R144) [[5]](diffhunk://#diff-36830fc3e89a6b330e00c7ef30e3001764fa9803c67a9c9fabcacc40578c8df4R204-R218).
* The i18n initialization now supports a `persist` option, letting the site bootstrap the language non-persistently before the full configuration loads. This prevents premature language persistence and allows site defaults to override on first load (`assets/js/i18n.js`, `assets/main.js`) [[1]](diffhunk://#diff-208716f66b472a927f09ee8c661dc4e8b0f123024cba13922bb76172e0846d5eR256-R261) [[2]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1805-R1808).

**Configuration and site defaults handling:**

* The main script now loads the site configuration before fetching localized content, ensuring that pagination and language defaults from `site.yaml` are honored. The logic for applying the default language is improved to avoid overriding user or URL choices (`assets/main.js`, `site.yaml`) [[1]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1825-R2002) [[2]](diffhunk://#diff-59d3d08d47ffe70f7ca89be20bf627aab6fe16f2180cb193536722702acacec2R1-R3) [[3]](diffhunk://#diff-59d3d08d47ffe70f7ca89be20bf627aab6fe16f2180cb193536722702acacec2L9-L32).
* The `PAGE_SIZE` constant is now a variable, allowing it to be overridden by site configuration (`assets/main.js`).

**Schema validation for configuration files:**

* Added JSON schema files for validating `site.yaml`, `index.yaml`, and `tabs.yaml`, improving reliability and editor support for configuration files (`assets/schema/site.json`, `assets/schema/index.json`, `assets/schema/tabs.json`, `site.yaml`, `wwwroot/index.yaml`) [[1]](diffhunk://#diff-8ce517626c0cbb02cf11f6492503455bfe02e40d910abb6f6dcb0a552fd14c04R1-R143) [[2]](diffhunk://#diff-d9aa8ea2eb2a144c3b3052d0ef2a27c002d747dfae9ed281d3d18eb5aef6f40fR1-R71) [[3]](diffhunk://#diff-b8d16de1eef48506afa4be00b6f99a98a481e07807214bfd1aec760d2bea2000R1-R48) [[4]](diffhunk://#diff-59d3d08d47ffe70f7ca89be20bf627aab6fe16f2180cb193536722702acacec2R1-R3) [[5]](diffhunk://#diff-5cb67abf0aec0945e87ef652e2400b59a98ee548ed10682c8aae291600c23096R1-R2).

These changes collectively make the site more robust, user-friendly, and maintainable by improving language handling, configuration flexibility, and validation of key data files.