### PR TITLE
feat: Update pageSize to 8 for improved post visibility on index list

### DIFF
--- a/site.yaml
+++ b/site.yaml
@@ -31,7 +31,7 @@ siteKeywords:
 contentOutdatedDays: 180  # Days before content is considered outdated
 cardCoverFallback: false  # Use a generated fallback cover image if none provided
 errorOverlay: true        # Show error overlay on the page if an error occurs
-pageSize: 2               # Number of posts per page on the index list
+pageSize: 8               # Number of posts per page on the index list
 defaultLanguage: en       # Default UI/content language (e.g., en, zh, ja)
 
 # Theme override configurations


### PR DESCRIPTION
This pull request makes a small configuration change to the site settings, increasing the number of posts displayed per page on the index list from 2 to 8.