### PR TITLE
feat: Add versioning support for posts; enhance UI with version selector and metadata handling

### DIFF
--- a/assets/js/templates.js
+++ b/assets/js/templates.js
@@ -18,12 +18,29 @@ export function renderPostMetaCard(title, meta, markdown) {
     if (dateHtml) parts.push(dateHtml);
     if (readHtml) parts.push(readHtml);
     const metaLine = parts.length ? `<div class="post-meta-line">${parts.join('<span class="card-sep">•</span>')}</div>` : '';
+    // Optional version selector (only when multiple versions available)
+    let versionHtml = '';
+    try {
+      const versions = Array.isArray(meta && meta.versions) ? meta.versions : [];
+      if (versions.length > 1 && meta && meta.location) {
+        const current = String(meta.location);
+        const opts = versions
+          .map(v => {
+            const label = String(v.versionLabel || v.date || v.location || '').trim() || '—';
+            const sel = (v.location === current) ? ' selected' : '';
+            return `<option value="${escapeHtml(String(v.location))}"${sel}>${escapeHtml(label)}</option>`;
+          })
+          .join('');
+        versionHtml = `<div class="post-meta-line"><label style="opacity:.8; margin-right:.35rem;">${t('ui.versionLabel')}</label><select class="post-version-select" aria-label="${t('ui.versionLabel')}">${opts}</select></div>`;
+      }
+    } catch (_) {}
     const excerptHtml = (meta && meta.excerpt) ? `<div class="post-meta-excerpt">${escapeHtml(String(meta.excerpt))}</div>` : '';
     const tags = meta ? renderTags(meta.tag) : '';
     return `<section class="post-meta-card" aria-label="Post meta">
       <div class="post-meta-title">${safeTitle}</div>
       <button type="button" class="post-meta-copy" aria-label="${t('ui.copyLink')}" title="${t('ui.copyLink')}">${t('ui.copyLink')}</button>
       ${metaLine}
+      ${versionHtml}
       ${excerptHtml}
       ${tags || ''}
     </section>`;

--- a/assets/schema/index.json
+++ b/assets/schema/index.json
@@ -30,6 +30,7 @@
     "langEntry": {
       "oneOf": [
         { "type": "string" },
+        { "type": "array", "items": { "type": "string" } },
         {
           "type": "object",
           "properties": {
@@ -68,4 +69,3 @@
     }
   }
 }
-


### PR DESCRIPTION
This pull request introduces support for blog posts with multiple language-specific versions, enabling version selection in the UI and improving how versioned content is loaded, displayed, and navigated. The changes include enhancements to metadata loading, updates to UI components to show and switch between versions, and improvements to language and version aliasing logic.

**Support for Multi-Version Blog Posts**

* The content loader in `i18n.js` now supports per-language arrays of post versions, loads all versions' metadata, and selects the latest by date as the primary version. Metadata now includes a `versions` array for UI use. [[1]](diffhunk://#diff-208716f66b472a927f09ee8c661dc4e8b0f123024cba13922bb76172e0846d5eR373) [[2]](diffhunk://#diff-208716f66b472a927f09ee8c661dc4e8b0f123024cba13922bb76172e0846d5eL386-R461) [[3]](diffhunk://#diff-208716f66b472a927f09ee8c661dc4e8b0f123024cba13922bb76172e0846d5eL460-R491)
* The UI translations for "Version" and "versions count" were added in English, Chinese, and Japanese. [[1]](diffhunk://#diff-208716f66b472a927f09ee8c661dc4e8b0f123024cba13922bb76172e0846d5eR40-R41) [[2]](diffhunk://#diff-208716f66b472a927f09ee8c661dc4e8b0f123024cba13922bb76172e0846d5eR110-R111) [[3]](diffhunk://#diff-208716f66b472a927f09ee8c661dc4e8b0f123024cba13922bb76172e0846d5eR180-R181)

**UI Enhancements for Versioned Posts**

* The post meta card (`renderPostMetaCard` in `templates.js`) now displays a version selector dropdown when multiple versions are available, allowing users to switch between versions.
* The index and search result cards display a version count badge when multiple versions exist, and the meta line layout is updated to include this information. [[1]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1319-R1353) [[2]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1377-R1417) [[3]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1442-R1480) [[4]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1504-R1548)

**Navigation and Version Selector Handling**

* A global event handler is added to handle version selector changes, updating the URL and reloading the correct version.
* The logic for resolving post metadata and titles is updated to correctly handle versioned entries.
* Version selector wiring is improved to ensure it works after language switches and soft resets.

**Language and Version Aliasing Improvements**

* The aliasing system is updated to ensure that language switching and navigation always resolve to the correct primary version for the selected language, considering all available versions. [[1]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295R1652) [[2]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295R1965-R1991)

These changes collectively enable robust support for multi-version, multi-language blog posts, with clear UI affordances and seamless navigation between versions and languages.