### PR TITLE
configurable content root directory for site assets; minor bug fixes

### DIFF
--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -9,6 +9,7 @@
 // - To show a friendly name in the language dropdown, add an entry to `languageNames`.
 
 import { parseFrontMatter } from './content.js';
+import { getContentRoot } from './utils.js';
 import { fetchConfigWithYamlFallback } from './yaml.js';
 
 // Default language fallback when no user/browser preference is available.
@@ -414,7 +415,7 @@ async function loadContentFromFrontMatter(obj, lang) {
     const variants = [];
     for (const p of paths) {
       try {
-        const response = await fetch(`wwwroot/${p}`);
+        const response = await fetch(`${getContentRoot()}/${p}`);
         if (!response || !response.ok) { continue; }
         const content = await response.text();
         const { frontMatter } = parseFrontMatter(content);

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -1,4 +1,13 @@
 // General utilities and safe helpers
+// Content root helper: default to 'wwwroot' but allow runtime override via window.__ns_content_root
+export function getContentRoot() {
+  try {
+    const raw = (typeof window !== 'undefined' && window.__ns_content_root) ? String(window.__ns_content_root) : 'wwwroot';
+    return raw.replace(/^\/+|\/+$/g, '');
+  } catch (_) {
+    return 'wwwroot';
+  }
+}
 export function escapeHtml(text) {
   return typeof text === 'string'
     ? text
@@ -85,7 +94,7 @@ export function cardImageSrc(p) {
   const s = String(p || '').trim();
   if (!s) return '';
   if (/^https?:\/\//i.test(s)) return s;
-  return 'wwwroot/' + s.replace(/^\/+/, '');
+  return getContentRoot() + '/' + s.replace(/^\/+/, '');
 }
 
 export function fallbackCover(title) {

--- a/assets/main.js
+++ b/assets/main.js
@@ -3,7 +3,7 @@ import { setupAnchors, setupTOC } from './js/toc.js';
 import { applySavedTheme, bindThemeToggle, bindSeoGenerator, bindThemePackPicker, mountThemeControls, refreshLanguageSelector, applyThemeConfig } from './js/theme.js';
 import { setupSearch } from './js/search.js';
 import { extractExcerpt, computeReadTime } from './js/content.js';
-import { getQueryVariable, setDocTitle, setBaseSiteTitle, cardImageSrc, fallbackCover, renderTags, slugifyTab, escapeHtml, formatDisplayDate, formatBytes, renderSkeletonArticle, isModifiedClick } from './js/utils.js';
+import { getQueryVariable, setDocTitle, setBaseSiteTitle, cardImageSrc, fallbackCover, renderTags, slugifyTab, escapeHtml, formatDisplayDate, formatBytes, renderSkeletonArticle, isModifiedClick, getContentRoot } from './js/utils.js';
 import { initI18n, t, withLangParam, loadLangJson, loadContentJson, loadTabsJson, getCurrentLang, normalizeLangKey } from './js/i18n.js';
 import { updateSEO, extractSEOFromMarkdown } from './js/seo.js';
 import { initErrorReporter, setReporterContext, showErrorOverlay } from './js/errors.js';
@@ -766,7 +766,7 @@ function hydrateInternalLinkCards(container) {
 
       // Fetch markdown to compute excerpt + read time
       const ensureMd = (l) => {
-        if (!mdCache.has(l)) mdCache.set(l, getFile('wwwroot/' + l).catch(() => ''));
+        if (!mdCache.has(l)) mdCache.set(l, getFile(`${getContentRoot()}/${l}`).catch(() => ''));
         return mdCache.get(l);
       };
       ensureMd(loc).then(md => {
@@ -1197,7 +1197,7 @@ function displayPost(postname) {
   const main = document.getElementById('mainview');
   if (main) main.innerHTML = renderSkeletonArticle();
 
-  return getFile('wwwroot/' + postname).then(markdown => {
+  return getFile(`${getContentRoot()}/${postname}`).then(markdown => {
     // Ignore stale responses if a newer navigation started
     if (reqId !== __activePostRequestId) return;
     // Remove loading-state classes
@@ -1205,7 +1205,7 @@ function displayPost(postname) {
     if (sidebarEl) sidebarEl.classList.remove('loading');
     
     const dir = (postname.lastIndexOf('/') >= 0) ? postname.slice(0, postname.lastIndexOf('/') + 1) : '';
-    const baseDir = `wwwroot/${dir}`;
+    const baseDir = `${getContentRoot()}/${dir}`;
   const output = mdParse(markdown, baseDir);
   // Compute fallback title using index cache before rendering
   const fallback = postsByLocationTitle[postname] || postname;
@@ -1327,8 +1327,8 @@ function displayPost(postname) {
       showErrorOverlay(err, {
         message: err.message,
         origin: 'view.post.notfound',
-        filename: 'wwwroot/' + postname,
-        assetUrl: 'wwwroot/' + postname,
+        filename: `${getContentRoot()}/${postname}`,
+        assetUrl: `${getContentRoot()}/${postname}`,
         id: postname
       });
     } catch (_) {}
@@ -1426,7 +1426,7 @@ function displayIndex(parsed) {
     if (exEl && meta && meta.excerpt) {
       try { exEl.textContent = String(meta.excerpt); } catch (_) {}
     }
-    getFile('wwwroot/' + loc).then(md => {
+    getFile(`${getContentRoot()}/${loc}`).then(md => {
       const ex = extractExcerpt(md, 50);
       // Only set excerpt from markdown if no explicit excerpt in metadata
       if (exEl && !(meta && meta.excerpt)) exEl.textContent = ex;
@@ -1558,7 +1558,7 @@ function displaySearch(query) {
     if (exEl && meta && meta.excerpt) {
       try { exEl.textContent = String(meta.excerpt); } catch (_) {}
     }
-    getFile('wwwroot/' + loc).then(md => {
+    getFile(`${getContentRoot()}/${loc}`).then(md => {
       const ex = extractExcerpt(md, 50);
       // Only set excerpt from markdown if no explicit excerpt in metadata
       if (exEl && !(meta && meta.excerpt)) exEl.textContent = ex;
@@ -1617,14 +1617,14 @@ function displayStaticTab(slug) {
   const tagBox = document.getElementById('tagview');
   if (tagBox) smoothHide(tagBox);
   renderTabs(slug);
-  getFile('wwwroot/' + tab.location)
+  getFile(`${getContentRoot()}/${tab.location}`)
     .then(md => {
       // 移除加载状态类
       if (contentEl) contentEl.classList.remove('loading');
       if (sidebarEl) sidebarEl.classList.remove('loading');
       
       const dir = (tab.location.lastIndexOf('/') >= 0) ? tab.location.slice(0, tab.location.lastIndexOf('/') + 1) : '';
-      const baseDir = `wwwroot/${dir}`;
+      const baseDir = `${getContentRoot()}/${dir}`;
       const output = mdParse(md, baseDir);
   const mv = document.getElementById('mainview');
   if (mv) mv.innerHTML = output.post;
@@ -1662,7 +1662,7 @@ function displayStaticTab(slug) {
       
       // Surface an overlay for missing static tab page
       try {
-        const url = 'wwwroot/' + tab.location;
+        const url = `${getContentRoot()}/${tab.location}`;
         const msg = (t('errors.pageUnavailableBody') || 'Could not load this tab.') + (e && e.message ? ` (${e.message})` : '');
         const err = new Error(msg);
         try { err.name = 'Warning'; } catch(_) {}
@@ -1919,9 +1919,9 @@ async function softResetToSiteDefaultLanguage() {
   // Reload localized content and tabs for the new language, then rerender
   try {
     const results = await Promise.allSettled([
-      loadContentJson('wwwroot', 'index'),
-      loadTabsJson('wwwroot', 'tabs'),
-      (async () => { try { const obj = await fetchConfigWithYamlFallback(['wwwroot/index.yaml','wwwroot/index.yml']); return (obj && typeof obj === 'object') ? obj : null; } catch (_) { return null; } })()
+      loadContentJson(getContentRoot(), 'index'),
+      loadTabsJson(getContentRoot(), 'tabs'),
+      (async () => { try { const cr = getContentRoot(); const obj = await fetchConfigWithYamlFallback([`${cr}/index.yaml`,`${cr}/index.yml`]); return (obj && typeof obj === 'object') ? obj : null; } catch (_) { return null; } })()
     ]);
     const posts = results[0].status === 'fulfilled' ? (results[0].value || {}) : {};
     const tabs = results[1].status === 'fulfilled' ? (results[1].value || {}) : {};
@@ -2081,6 +2081,11 @@ try { window.__ns_softResetLang = () => softResetToSiteDefaultLanguage(); } catc
 loadSiteConfig()
   .then(cfg => {
     siteConfig = cfg || {};
+    // Apply content root override early so subsequent loads honor it
+    try {
+      const rawRoot = (siteConfig && (siteConfig.contentRoot || siteConfig.contentBase || siteConfig.contentPath)) || 'wwwroot';
+      if (typeof window !== 'undefined') window.__ns_content_root = String(rawRoot).replace(/^\/+|\/+$/g, '');
+    } catch (_) {}
     // Apply site-configured defaults early
     try {
       // 1) Page size (pagination)
@@ -2109,11 +2114,12 @@ loadSiteConfig()
 
     // Now fetch localized content and tabs for the (possibly updated) language
     return Promise.allSettled([
-      loadContentJson('wwwroot', 'index'),
-      loadTabsJson('wwwroot', 'tabs'),
+      loadContentJson(getContentRoot(), 'index'),
+      loadTabsJson(getContentRoot(), 'tabs'),
       (async () => {
         try {
-          const obj = await fetchConfigWithYamlFallback(['wwwroot/index.yaml','wwwroot/index.yml']);
+          const cr = getContentRoot();
+          const obj = await fetchConfigWithYamlFallback([`${cr}/index.yaml`,`${cr}/index.yml`]);
           return (obj && typeof obj === 'object') ? obj : null;
         } catch (_) { return null; }
       })()

--- a/assets/main.js
+++ b/assets/main.js
@@ -173,7 +173,17 @@ try {
         url.searchParams.set('id', loc);
         const lang = (getCurrentLang && getCurrentLang()) || 'en';
         url.searchParams.set('lang', lang);
-        window.location.assign(url.toString());
+        // Use SPA navigation so back/forward keeps the selector in sync
+        try {
+          history.pushState({}, '', url.toString());
+          // Some parts of the app listen to popstate; dispatch to keep behavior consistent
+          try { window.dispatchEvent(new PopStateEvent('popstate')); } catch (_) { /* fallback to direct render */ }
+          if (typeof routeAndRender === 'function') routeAndRender();
+          try { window.scrollTo(0, 0); } catch (_) {}
+        } catch (_) {
+          // Fallback to full navigation if History API fails
+          window.location.assign(url.toString());
+        }
       } catch (_) {}
     };
     document.addEventListener('change', handler, true);

--- a/assets/schema/site.json
+++ b/assets/schema/site.json
@@ -20,6 +20,12 @@
     "resourceURL": {
       "type": "string"
     },
+    "contentRoot": {
+      "type": "string",
+      "description": "Relative folder that contains site content (index.yaml, tabs.yaml, markdown posts). Defaults to 'wwwroot'.",
+      "default": "wwwroot",
+      "examples": ["wwwroot", "content", "docs"]
+    },
     "avatar": {
       "type": "string"
     },

--- a/index_seo.html
+++ b/index_seo.html
@@ -265,6 +265,11 @@
             return await fetchConfigWithYamlFallback(['site.yaml', 'site.yml']);
         }
 
+        function getContentRootFrom(cfg) {
+            const raw = (cfg && (cfg.contentRoot || cfg.contentBase || cfg.contentPath)) || 'wwwroot';
+            return String(raw).replace(/^\/+|\/+$/g, '');
+        }
+
         async function loadSiteYamlRaw() {
             const attempts = ['site.yaml', 'site.yml'];
             for (const p of attempts) {
@@ -323,9 +328,12 @@
                 statusEl.innerHTML = '<p>Loading data...</p>';
                 
                 // Load all required data
+                // Load site config to determine content root (default: wwwroot)
+                currentSiteConfig = await loadSiteConfigFlex();
+                const cr = getContentRootFrom(currentSiteConfig);
                 const [postsObj, tabsObj] = await Promise.all([
-                    fetchConfigWithYamlFallback(['wwwroot/index.yaml','wwwroot/index.yml']),
-                    fetchConfigWithYamlFallback(['wwwroot/tabs.yaml','wwwroot/tabs.yml'])
+                    fetchConfigWithYamlFallback([`${cr}/index.yaml`,`${cr}/index.yml`]),
+                    fetchConfigWithYamlFallback([`${cr}/tabs.yaml`,`${cr}/tabs.yml`])
                 ]);
                 
                 currentPostsData = postsObj || {};
@@ -470,6 +478,7 @@
         function generateRobotsTxt(siteConfig) {
             // Use site's base URL (remove current file path)
             const baseUrl = window.location.origin + '/';
+            const cr = getContentRootFrom(siteConfig);
             
             let robots = `User-agent: *\n`;
             robots += `Allow: /\n\n`;
@@ -478,7 +487,7 @@
             robots += `Sitemap: ${baseUrl}sitemap.xml\n\n`;
             
             robots += `# Allow crawling of main content\n`;
-            robots += `Allow: /wwwroot/\n`;
+            robots += `Allow: /${cr}/\n`;
             robots += `Allow: /assets/\n\n`;
             
             robots += `# Disallow admin or internal directories\n`;

--- a/site.yaml
+++ b/site.yaml
@@ -31,8 +31,9 @@ siteKeywords:
 contentOutdatedDays: 180  # Days before content is considered outdated
 cardCoverFallback: false  # Use a generated fallback cover image if none provided
 errorOverlay: true        # Show error overlay on the page if an error occurs
-pageSize: 2               # Number of posts per page on the index list
+pageSize: 8               # Number of posts per page on the index list
 defaultLanguage: en       # Default UI/content language (e.g., en, zh, ja)
+contentRoot: wwwroot      # Root directory for content files
 
 # Theme override configurations
 themeMode: user


### PR DESCRIPTION
This pull request introduces a configurable content root directory for site assets, replacing hardcoded references to `wwwroot` throughout the codebase. This allows site owners to specify a different folder for their content files (such as markdown posts and YAML configs) via the `contentRoot` property in `site.yaml` or site config. The change is fully backwards compatible, defaulting to `wwwroot` if no override is provided. Additionally, the PR includes improvements to navigation behavior, error handling, and scroll normalization.

**Content Root Configuration and Usage:**

- Added support for a `contentRoot` property in `site.yaml` and the site config schema, allowing the content directory to be set (defaults to `wwwroot`). All content and asset fetches now use this configurable root via the new `getContentRoot()` utility. [[1]](diffhunk://#diff-8ce517626c0cbb02cf11f6492503455bfe02e40d910abb6f6dcb0a552fd14c04R23-R28) [[2]](diffhunk://#diff-59d3d08d47ffe70f7ca89be20bf627aab6fe16f2180cb193536722702acacec2L34-R36) [[3]](diffhunk://#diff-01798669f003fe54b83c25f63adf170e0c6b8177a607846ca4255875fbb897bcR2-R10) [[4]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295R2084-R2088) [[5]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L2073-R2122) [[6]](diffhunk://#diff-208716f66b472a927f09ee8c661dc4e8b0f123024cba13922bb76172e0846d5eR12) [[7]](diffhunk://#diff-208716f66b472a927f09ee8c661dc4e8b0f123024cba13922bb76172e0846d5eL417-R418) [[8]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L755-R769) [[9]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295R1172-R1173) [[10]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1184-R1208) [[11]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1401-R1429) [[12]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1533-R1561) [[13]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1592-R1627) [[14]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1302-R1331) [[15]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1637-R1665) [[16]](diffhunk://#diff-01798669f003fe54b83c25f63adf170e0c6b8177a607846ca4255875fbb897bcL88-R97)

**Navigation and SPA Improvements:**

- Improved SPA navigation by updating the History API usage for version switching and normalizing scroll position when navigating between posts. Also, added a mechanism to ignore stale content loads if a newer navigation has started. [[1]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295R32-R35) [[2]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295R180-R190) [[3]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295R1172-R1173) [[4]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295R1856-R1868) [[5]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1282-R1318)

**Error Handling and Robustness:**

- Enhanced error handling to ensure overlays and loading states are correctly managed, even when navigation is interrupted or assets are missing. [[1]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1302-R1331) [[2]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1592-R1627) [[3]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1637-R1665)

**SEO and Tooling Updates:**

- Updated the SEO tooling and robots.txt generation in `index_seo.html` to respect the new `contentRoot` setting, ensuring correct paths are used for content discovery and crawling. [[1]](diffhunk://#diff-4c76d1ce50091c842876d7e4cf3f926acf32f7e89b3e9e012758d3db00ab8075R268-R272) [[2]](diffhunk://#diff-4c76d1ce50091c842876d7e4cf3f926acf32f7e89b3e9e012758d3db00ab8075R331-R336) [[3]](diffhunk://#diff-4c76d1ce50091c842876d7e4cf3f926acf32f7e89b3e9e012758d3db00ab8075R481) [[4]](diffhunk://#diff-4c76d1ce50091c842876d7e4cf3f926acf32f7e89b3e9e012758d3db00ab8075L481-R490)

**Miscellaneous:**

- Increased the default `pageSize` in `site.yaml` from 2 to 8 for a more typical index list experience.