### PR TITLE
feat: Add version 2.1.0 multilingual documentation for NanoSite in English, Japanese, and Chinese

### DIFF
--- a/wwwroot/index.yaml
+++ b/wwwroot/index.yaml
@@ -14,12 +14,15 @@ nanodoc:
   en:
     - post/doc/v1.0.0/doc_en.md
     - post/doc/v2.0.0/doc_en.md
+    - post/doc/v2.1.0/doc_en.md
   zh:
     - post/doc/v1.0.0/doc_zh.md
     - post/doc/v2.0.0/doc_zh.md
+    - post/doc/v2.1.0/doc_zh.md
   ja:
     - post/doc/v1.0.0/doc_ja.md
     - post/doc/v2.0.0/doc_ja.md
+    - post/doc/v2.1.0/doc_ja.md
 githubpages:
   en: post/page/githubpages_en.md
   zh: post/page/githubpages_zh.md

--- a/wwwroot/post/doc/v2.1.0/doc_en.md
+++ b/wwwroot/post/doc/v2.1.0/doc_en.md
@@ -1,0 +1,257 @@
+---
+title: Documentation for NanoSite
+date: 2025-08-23
+version: v2.1.0
+tags:
+  - NanoSite
+  - Documentation
+excerpt: Build a content site directly from Markdown with no build steps — drop files into wwwroot/, list them in YAML, and publish (compatible with GitHub Pages). This guide covers project structure, configuration, content loading, themes, search, tags, SEO, media, and deployment.
+author: deemoe
+ai: true
+---
+
+## File Overview
+Before using NanoSite, it helps to understand the core files/folders:
+
+- `site.yaml` — Configure basic site info, such as the site title or your profile links.
+- `wwwroot/` — Holds all content and data:
+  - `wwwroot/index.yaml` — Index of all posts (e.g., “Travel Log — Maldives”, “Reading Notes: The Little Prince”).
+  - `wwwroot/tabs.yaml` — Index of static pages (e.g., “About”, “Legal”).
+
+> You can always fetch the v2.1.0 default settings from v2.1.0/site.yaml.
+
+
+## Site Basics
+Set the following in `site.yaml`:
+
+- `siteTitle` and `siteSubtitle` — Site title and subtitle.
+- `avatar` — Site logo.
+
+Example:
+
+```yaml
+# Basic site info
+siteTitle:
+  default: NanoSite
+  zh: 微站
+  ja: ナノサイト
+siteSubtitle:
+  default: Just Markdown. Just a website.
+  zh: 写下 Markdown，就是你的网站。
+  ja: 書くだけ、Markdown。それがサイトになる。
+avatar: assets/avatar.jpeg
+```
+
+
+## Profile & Social Links
+NanoSite can display your contacts or social links on the site card. Add `profileLinks` in `site.yaml`:
+
+```yaml
+# Social/profile links
+profileLinks:
+  - label: GitHub
+    href: https://github.com/deemoe404/NanoSite
+  - label: Demo
+    href: https://nano.dee.moe/
+```
+
+> The `label` is just display text — it can be any string, not a fixed platform name.
+
+
+## Writing Posts
+By default, NanoSite uses the `wwwroot/` folder as its working directory and reads `wwwroot/index.yaml` for the posts list. For example, the article Configure GitHub Pages for NanoSite corresponds to this entry in `wwwroot/index.yaml`:
+
+```yaml
+githubpages:
+  en: post/page/githubpages_en.md
+  zh: post/page/githubpages_zh.md # Chinese version stored at wwwroot/post/page/githubpages_zh.md
+  ja: post/page/githubpages_ja.md
+```
+
+In addition to listing post paths in `wwwroot/index.yaml`, include front matter at the top of each Markdown file to supply metadata. Here’s an excerpt from `wwwroot/post/page/githubpages_en.md`:
+
+```markdown
+---
+title: Configure GitHub Pages for NanoSite
+date: 2025-08-21
+tags:
+  - NanoSite
+  - Tech
+  - GitHub Pages
+image: page.jpeg
+excerpt: You can host NanoSite on GitHub Pages for free. This article is a self-contained reference, but always consult GitHub’s official docs for the most accurate details.
+author: deemoe
+ai: true
+---
+
+... content omitted
+```
+
+Field meanings:
+
+- `title` — Post title.
+- `date` — Publish date.
+- `tags` — Tags for the post; multiple allowed.
+- `excerpt` — Summary for cards and meta.
+- `image` — Cover image path (relative to the Markdown file).
+- `author` — Author name.
+- `ai` — Whether generative AI (specifically LLMs) participated in authoring.
+
+> All front matter fields are optional. Leave any out if you don’t need them.
+
+## Writing Pages
+Similar to Writing Posts, NanoSite reads `wwwroot/tabs.yaml` for static pages. For example, the About page entry in `wwwroot/tabs.yaml` looks like:
+
+```yaml
+About:
+  en:
+    title: About
+    location: tab/about/en.md
+  zh:
+    title: 关于
+    location: tab/about/zh.md # Chinese version stored at wwwroot/tab/about/zh.md
+  ja:
+    title: 概要
+    location: tab/about/ja.md
+```
+
+Unlike posts, page Markdown files may omit front matter.
+
+
+## Images and Videos
+NanoSite supports images and videos in Markdown. Paths resolve relative to the current Markdown file. In Configure GitHub Pages for NanoSite, the content begins with an image:
+
+```markdown
+![page](page.jpeg)
+```
+
+Because the article lives at `wwwroot/post/page/githubpages_en.md`, the image should be placed at `wwwroot/post/page/page.jpeg`. Videos work the same way; just ensure the path is correct — NanoSite detects video files and renders them accordingly.
+
+## Internal Link Cards (Previews)
+
+If a paragraph contains only a link to a post (`?id=...`), the link is upgraded to a card with cover image, excerpt, date, and read time (like the cards on the home page).
+
+```markdown
+... content above omitted
+
+[Configure GitHub Pages for NanoSite](?id=post%2Fpage%2Fgithubpages_en.md)
+
+... content below omitted
+```
+
+To force a card inline, include `card` in the link title or add `data-card`:
+
+```markdown
+... content above omitted
+
+This is an inline card for [Configure GitHub Pages for NanoSite](?id=post%2Fpage%2Fgithubpages_en.md "card").
+
+... content below omitted
+```
+
+## FAQ
+
+- Q: The site is blank when opened.
+  - A: Validate your YAML (indentation, colons, list/map structure).
+  - A: Paths in `index.yaml`/`tabs.yaml` must be relative to `wwwroot/` by default. Double-check paths.
+  - A: Preview via a local or real web server (not by double‑clicking `index.html`). Some browsers block local resource loading for security reasons.
+- Q: I wrote a post but it doesn’t show up.
+  - A: Ensure its `location` is listed in `wwwroot/index.yaml` and the path is correct.
+  - A: Hard refresh your browser cache (e.g., Shift + click the reload button).
+
+## Advanced
+Advanced options if you want to go further.
+
+### Other Settings
+Additional options in `site.yaml`:
+
+#### Theme Override
+By default, the site respects user theme choices (stored in the browser). You can force a theme (and its variant):
+- `themeMode` — Theme mode (e.g., `user`, `dark`, `light`, `default`).
+- `themePack` — Theme pack (e.g., `minimalism`, `github`).
+- `themeOverride` — Force a specific theme for all users (default `false`).
+
+Example:
+```yaml
+themeMode: user
+themePack: minimalism
+themeOverride: true
+```
+
+#### Error Reporting
+- `reportIssueURL` — Enable a prefilled issue link (e.g., GitHub New Issue).
+- `errorOverlay` — Show an error overlay on the page if something goes wrong (default `false`).
+- `assetWarnings` — Asset-related warnings.
+  - `largeImage` — Large image warnings.
+    - `enabled` — Enable large image warnings (default `false`).
+    - `thresholdKB` — Size threshold in KB (default `500KB`).
+
+Example:
+```yaml
+reportIssueURL: https://github.com/deemoe404/NanoSite/issues/new
+errorOverlay: true
+assetWarnings:
+  largeImage:
+    enabled: true
+    thresholdKB: 500
+```
+
+#### Misc
+- `contentOutdatedDays` — Days after which content is considered outdated (default 180).
+- `cardCoverFallback` — Generate a fallback cover when a post has no image (default `true`).
+- `pageSize` — Number of posts per page in index views (default `8`).
+- `defaultLanguage` — Default UI/content language (e.g., `en`, `zh`, `ja`; default `en`).
+
+Example:
+```yaml
+contentOutdatedDays: 180
+cardCoverFallback: false
+pageSize: 8
+defaultLanguage: en
+```
+
+### How Routing Works
+
+The client router reads URL query parameters:
+
+- `?tab=posts` — All posts (default). Supports `&page=N` pagination.
+- `?tab=search&q=term` — Search by title or tag. You can also filter by `&tag=TagName`.
+- `?id=path/to/post.md` — Open a specific post (the path must exist in `index.yaml`).
+- `?lang=zh` — UI/content language. Stored in localStorage, falls back to browser settings and `<html lang>`.
+
+Markdown examples: `[See this](?id=post/frogy/main.md)` and `[About](?tab=about)`.
+
+### SEO (Built‑in)
+
+At runtime, NanoSite updates meta tags per page (title, description, Open Graph, Twitter Card) and injects structured data (JSON‑LD). Source order:
+
+1) Markdown front matter (`title`, `excerpt`, `tags`, `date`, `image`)
+2) `index.yaml` metadata
+3) Auto‑fallbacks (H1/first paragraph) and a generated fallback social image
+
+Example `index.yaml` SEO fields:
+```yaml
+resourceURL: https://nano.dee.moe/wwwroot/
+siteDescription:
+  default: NanoSite - Just Markdown. Just a website.
+  zh: 微站 - 写下 Markdown，就是你的网站。
+  ja: ナノサイト - 書くだけ、Markdown。それがサイトになる。
+siteKeywords:
+  default: static blog, markdown, github pages, blog
+```
+
+Where:
+- `resourceURL` — Base URL for assets to ensure images/videos resolve correctly. Point it to your site’s actual `wwwroot/`.
+- `siteDescription` — Site description for SEO and social sharing.
+- `siteKeywords` — Keywords for SEO.
+
+You should also open `index_seo.html` to generate `sitemap.xml` and `robots.txt` into the site root (same level as `index.html`), and to generate starter `<head>` tags for `index.html` based on `site.yaml`.
+
+### Multi‑language
+
+- UI strings live in `assets/js/i18n.js` (English/中文/日本語 included). Extend `translations` and `languageNames` to add more.
+- Content support:
+  - Simplified (as in this repo): provide Markdown paths per language
+  - Unified: `{title, location}` per language
+  - Legacy: `index.en.yaml`/`index.en.json`, `index.zh.yaml`/`index.zh.json`... (fallback)
+- When switching languages, the router keeps you on the same article if a variant exists.

--- a/wwwroot/post/doc/v2.1.0/doc_ja.md
+++ b/wwwroot/post/doc/v2.1.0/doc_ja.md
@@ -1,0 +1,257 @@
+---
+title: NanoSite ドキュメント
+date: 2025-08-23
+version: v2.1.0
+tags:
+	- NanoSite
+	- ドキュメント
+excerpt: Markdown ファイルだけでコンテンツサイトを構築できます。ビルド工程は不要で、wwwroot/ に置いて YAML に列挙して公開するだけ（GitHub Pages に対応）。本ガイドは、プロジェクト構造、設定ファイル、コンテンツの読み込み、テーマ、検索、タグ、SEO、メディア、デプロイ方法を解説します。
+author: deemoe
+ai: true
+---
+
+## ファイル概要
+NanoSite を使い始める前に、サイト構成の中核となるファイル/フォルダを把握しておくと便利です。
+
+- `site.yaml` — サイトの基本情報（サイトタイトルやプロフィールリンクなど）を設定します。
+- `wwwroot/` — すべてのコンテンツとデータを格納します：
+  - `wwwroot/index.yaml` — 記事のインデックス（例：「旅行記 — モルディブ」「読書ノート：星の王子さま」など）。
+  - `wwwroot/tabs.yaml` — 固定ページのインデックス（例：「About」「法的表示」など）。
+
+> v2.1.0 のデフォルト設定ファイルは v2.1.0/site.yaml から取得できます。
+
+
+## サイト基本情報
+`site.yaml` で以下を設定します：
+
+- `siteTitle` / `siteSubtitle` — サイトのタイトルとサブタイトル。
+- `avatar` — サイトのロゴ。
+
+例：
+
+```yaml
+# サイト基本情報
+siteTitle:
+  default: NanoSite
+  zh: 微站
+  ja: ナノサイト
+siteSubtitle:
+  default: Just Markdown. Just a website.
+  zh: 写下 Markdown，就是你的网站。
+  ja: 書くだけ、Markdown。それがサイトになる。
+avatar: assets/avatar.jpeg
+```
+
+
+## プロフィール／ソーシャルリンク
+サイトカードに連絡先やソーシャルリンクを表示できます。`site.yaml` に `profileLinks` を追加します：
+
+```yaml
+# ソーシャルリンク
+profileLinks:
+  - label: GitHub
+    href: https://github.com/deemoe404/NanoSite
+  - label: Demo
+    href: https://nano.dee.moe/
+```
+
+> `label` は表示用テキストです。任意の文字列を使えます（固定のサービス名に限定されません）。
+
+
+## 記事の作成
+NanoSite は既定で `wwwroot/` をワークディレクトリとして使用し、`wwwroot/index.yaml` を読んで記事一覧を取得します。例として「NanoSite を GitHub Pages で公開する設定」は `wwwroot/index.yaml` に以下のように登録します：
+
+```yaml
+githubpages:
+  en: post/page/githubpages_en.md
+  zh: post/page/githubpages_zh.md # 中国語版は wwwroot/post/page/githubpages_zh.md にあります
+  ja: post/page/githubpages_ja.md
+```
+
+`wwwroot/index.yaml` に記事パスを記載するほか、各 Markdown の先頭に Front Matter を入れてメタデータを提供します。`wwwroot/post/page/githubpages_ja.md` の例：
+
+```markdown
+---
+title: NanoSite を GitHub Pages で公開する設定
+date: 2025-08-21
+tags:
+  - NanoSite
+  - 技術
+  - GitHub Pages
+image: page.jpeg
+excerpt: NanoSite は GitHub Pages に無料でホスティングできます。本稿は自足的なリファレンスですが、最新かつ正確な情報は GitHub 公式ドキュメントを参照してください。
+author: deemoe
+ai: true
+---
+
+... 以下省略
+```
+
+主な項目：
+
+- `title` — 記事タイトル。
+- `date` — 公開日。
+- `tags` — タグ（複数可）。
+- `excerpt` — カードや meta 用の要約。
+- `image` — カバー画像のパス（Markdown ファイルからの相対）。
+- `author` — 著者名。
+- `ai` — 生成系 AI（特に LLM）の関与有無。
+
+> Front Matter の全項目は任意です。不要なら省略して構いません。
+
+## ページの作成
+記事の作成と同様に、固定ページは `wwwroot/tabs.yaml` で管理します。例えば About ページは次のように設定します：
+
+```yaml
+About:
+  en:
+    title: About
+    location: tab/about/en.md
+  zh:
+    title: 关于
+    location: tab/about/zh.md # 中国語版は wwwroot/tab/about/zh.md にあります
+  ja:
+    title: 概要
+    location: tab/about/ja.md
+```
+
+ページの Markdown は Front Matter を省略しても構いません。
+
+
+## 画像と動画
+Markdown 中の画像・動画をサポートします。パスはその Markdown ファイルからの相対で解決されます。前述の GitHub Pages 設定記事では、本文冒頭に次の画像を挿入しています：
+
+```markdown
+![page](page.jpeg)
+```
+
+記事のパスが `wwwroot/post/page/githubpages_ja.md` の場合、画像は `wwwroot/post/page/page.jpeg` に置きます。動画も同様で、パスが正しければ NanoSite が動画として扱います。
+
+## サイト内リンクカード（プレビュー）
+
+段落全体が記事へのリンク（`?id=...`）だけで構成される場合、そのリンクはカバー画像・抜粋・日付・読了時間を含むカードに自動的に拡張されます。
+
+```markdown
+... ここまでの内容は省略
+
+[NanoSite を GitHub Pages で公開する設定](?id=post%2Fpage%2Fgithubpages_ja.md)
+
+... ここから先の内容は省略
+```
+
+行内でも強制的にカード表示したい場合は、リンクの `title` に `card` を含めるか、`data-card` を追加します：
+
+```markdown
+... ここまでの内容は省略
+
+これは行内カードです → [NanoSite を GitHub Pages で公開する設定](?id=post%2Fpage%2Fgithubpages_ja.md "card")
+
+... ここから先の内容は省略
+```
+
+## よくある質問
+
+- Q：サイトを開いたら真っ白です。
+  - A：YAML（インデント、コロン、配列/マップ構造）を検証してください。
+  - A：既定では `index.yaml`/`tabs.yaml` のパスは `wwwroot/` からの相対です。パスを確認してください。
+  - A：`index.html` をダブルクリックではなく、ローカル/実サーバー経由でプレビューしてください。セキュリティ上の理由でローカルリソースの読み込みを禁止するブラウザがあります。
+- Q：記事を書いたのに一覧に出ません。
+  - A：`wwwroot/index.yaml` に該当記事の `location` が登録され、パスが正しいか確認してください。
+  - A：ブラウザのキャッシュを強制更新してください（例：Shift を押しながら再読み込み）。
+
+## 上級
+さらに細かく調整したい場合のオプションです。
+
+### その他の設定
+`site.yaml` の追加オプション：
+
+#### テーマ強制
+既定では、テーマはユーザーの選択（ブラウザに保存）を尊重します。特定のテーマ（およびバリアント）を強制することもできます。
+- `themeMode` — `user`、`dark`、`light`、`default` など。
+- `themePack` — `minimalism`、`github` など。
+- `themeOverride` — テーマを強制するか（既定 `false`）。
+
+例：
+```yaml
+themeMode: user
+themePack: minimalism
+themeOverride: true
+```
+
+#### エラーレポート設定
+- `reportIssueURL` — 事前入力された Issue へのリンクを有効化（例：GitHub の新規 Issue）。
+- `errorOverlay` — エラー発生時にページ上へオーバーレイ表示（既定 `false`）。
+- `assetWarnings` — アセットに関する警告。
+  - `largeImage` — 大きな画像に関する警告。
+    - `enabled` — 警告を有効化（既定 `false`）。
+    - `thresholdKB` — KB 単位の閾値（既定 `500KB`）。
+
+例：
+```yaml
+reportIssueURL: https://github.com/deemoe404/NanoSite/issues/new
+errorOverlay: true
+assetWarnings:
+  largeImage:
+    enabled: true
+    thresholdKB: 500
+```
+
+#### そのほか
+- `contentOutdatedDays` — この記事が古いとみなす日数（既定 180）。
+- `cardCoverFallback` — カバー画像が無い場合に自動生成のプレースホルダーを使用（既定 `true`）。
+- `pageSize` — 一覧の 1 ページあたり件数（既定 `8`）。
+- `defaultLanguage` — 既定の UI/コンテンツ言語（例：`en`、`zh`、`ja`。既定は `en`）。
+
+例：
+```yaml
+contentOutdatedDays: 180
+cardCoverFallback: false
+pageSize: 8
+defaultLanguage: en
+```
+
+### ルーティングの仕組み
+
+フロントエンドのルーターは URL のクエリを読み取ります：
+
+- `?tab=posts` — すべての記事（既定）。`&page=N` でページング。
+- `?tab=search&q=語句` — タイトル/タグで検索。`&tag=タグ名` でさらに絞り込み。
+- `?id=path/to/post.md` — 個別記事を開く（パスは `index.yaml` に存在している必要があります）。
+- `?lang=zh` — UI/コンテンツの言語。localStorage に保存し、ブラウザ設定と `<html lang>` にフォールバックします。
+
+Markdown の例：`[この記事](?id=post/frogy/main.md)`、`[概要](?tab=about)`。
+
+### SEO（内蔵）
+
+ページごとに meta（タイトル、説明、Open Graph、Twitter Card）を動的に更新し、構造化データ（JSON-LD）を挿入します。参照順：
+
+1) Markdown の Front Matter（`title`、`excerpt`、`tags`、`date`、`image`）
+2) `index.yaml` のメタデータ
+3) 自動フォールバック（H1/最初の段落）と自動生成のプレースホルダー画像
+
+`index.yaml` の SEO 例：
+```yaml
+resourceURL: https://nano.dee.moe/wwwroot/
+siteDescription:
+  default: NanoSite - Just Markdown. Just a website.
+  zh: 微站 - 写下 Markdown，就是你的网站。
+  ja: ナノサイト - 書くだけ、Markdown。それがサイトになる。
+siteKeywords:
+  default: static blog, markdown, github pages, blog
+```
+
+補足：
+- `resourceURL` — 画像/動画などのリソースが正しく解決されるようにするためのベース URL。実サイトの `wwwroot/` に合わせて設定します。
+- `siteDescription` — SEO やソーシャル共有用のサイト説明。
+- `siteKeywords` — SEO 用のキーワード。
+
+あわせて `index_seo.html` を開き、`sitemap.xml` と `robots.txt` をサイトルート（`index.html` と同じ階層）に生成し、`site.yaml` に基づく初期の `<head>` タグを `index.html` に反映してください。
+
+### 多言語
+
+- UI 文言は `assets/js/i18n.js` にあります（英語/中国語/日本語を同梱）。`translations` と `languageNames` を拡張して追加可能です。
+- コンテンツの多言語：
+  - 簡易（本リポジトリの形）：言語ごとに Markdown のパスを指定
+  - 統合：言語ごとに `{title, location}`
+  - 旧来：`index.en.yaml`/`index.en.json`、`index.zh.yaml`/`index.zh.json` ...（フォールバック）
+- 言語切替時、対象記事の言語版があれば同じ記事に留まるようにルーターが調整します。

--- a/wwwroot/post/doc/v2.1.0/doc_zh.md
+++ b/wwwroot/post/doc/v2.1.0/doc_zh.md
@@ -1,0 +1,257 @@
+---
+title: NanoSite 使用文档
+date: 2025-08-23
+version: v2.1.0
+tags:
+	- NanoSite
+	- 文档
+excerpt: 无需构建步骤即可直接用 Markdown 文件创建内容网站，只需将文件放入 wwwroot/，在 YAML 中列出并发布，即可兼容 GitHub Pages。本指南涵盖项目结构、配置文件、内容加载、主题、搜索、标签、SEO、媒体以及部署方法。
+author: deemoe
+ai: false
+---
+
+## 文件概览
+在开始使用 **NanoSite** 之前，理解网站结构中的核心文件十分重要：
+
+- `site.yaml` — 您将在这里设置网站的基本信息，例如**站点标题**或您的**个人资料链接**。
+- `wwwroot/` — 包含所有内容和数据的文件夹：
+  - `wwwroot/index.yaml` — 所有**文章**的索引，例如“旅行日志 - 马尔代夫”、“读书笔记：小王子”等。
+  - `wwwroot/tabs.yaml` — 所有**页面**的索引，例如“关于本站”、“法律声明”等。
+
+> 您始终可以从 [v2.1.0/site.yaml](https://github.com/deemoe404/NanoSite/blob/2.1.0/site.yaml) 获取到 v2.1.0 版本的**默认**设置文件。
+
+
+## 网站基本信息设置
+在 `site.yaml` 中，您可以设置以下基本信息：
+
+- `siteTitle` 与 `siteSubtitle` — 网站的标题与副标题。
+- `avatar` — 网站的 LOGO。
+
+例如，本站的 `site.yaml` 配置如下：
+
+```yaml
+# 网站基本信息设置
+siteTitle:
+  default: NanoSite
+  zh: 微站
+  ja: ナノサイト
+siteSubtitle:
+  default: Just Markdown. Just a website.
+  zh: 写下 Markdown，就是你的网站。
+  ja: 書くだけ、Markdown。それがサイトになる。
+avatar: assets/avatar.jpeg
+```
+
+
+## 联系方式与社交媒体展示
+NanoSite 允许您在站点卡片上展示您的联系方式或者社交媒体链接。您可以在 `site.yaml` 中添加 `profileLinks` 字段来实现这一点，例如：
+
+```yaml
+# 社交媒体链接
+profileLinks:
+  - label: GitHub
+    href: https://github.com/deemoe404/NanoSite
+  - label: Demo
+    href: https://nano.dee.moe/
+```
+
+> `label` 选项仅用于显示文本，因此可以是任意值——而非固定的社交媒体名称。
+
+
+## 文章写作
+NanoSite 默认将 `wwwroot/` 文件夹作为工作路径。它通过读取这个文件夹下的 `index.yaml` 文件来获取文章列表。例如 [为 NanoSite 配置 GitHub Pages](?id=post%2Fpage%2Fgithubpages_zh.md&lang=zh) 这篇文章对应的 `wwwroot/index.yaml` 内容如下：
+
+```yaml
+githubpages:
+  en: post/page/githubpages_en.md
+  zh: post/page/githubpages_zh.md # 文章的中文版本位于 wwwroot/post/page/githubpages_zh.md
+  ja: post/page/githubpages_ja.md
+```
+
+除了在 `wwwroot/index.yaml` 中指定文章的 Markdown 文件路径外，您还需要在每篇 Markdown 文件的开头添加前言区（Front Matter）来提供文章的元数据。以下是 `wwwroot/post/page/githubpages_zh.md` 的文件节选：
+
+```markdown
+---
+title: 为 NanoSite 配置 GitHub Pages
+date: 2025-08-21
+tags:
+  - 微站
+  - 技术
+  - GitHub Pages
+image: page.jpeg
+excerpt: 你可以将 NanoSite 免费托管在 GitHub Pages 上。本文作为一份自包含的参考，但仍请以 GitHub 官方文档为准以获取最准确的信息。
+author: deemoe
+ai: true
+---
+
+... 此后内容省略
+```
+
+其中的关键词含义如下：
+
+- `title` — 文章标题。
+- `date` — 文章发布日期。
+- `tags` — 文章标签，可多选（参见上文示例）。
+- `excerpt` — 文章摘要。
+- `image` — 文章封面图片路径（相对于该 Markdown 文件本身）。
+- `author` — 文章作者。
+- `ai` — 声明该文章的创作过程是否有生成式 AI（此处特指 LLMs）的参与。
+
+> 前言区的所有参数都是可选的；若您不愿意提供某个参数，可直接将其留空或删除该行。
+
+## 页面写作
+与 [文章写作](#45) 类似，NanoSite 通过读取 `wwwroot/` 文件夹内的 `tabs.yaml` 文件来获取页面列表。例如 [关于](?tab=about&lang=zh) 页面的对应的 `wwwroot/tabs.yaml` 内容如下：
+
+```yaml
+About:
+  en:
+    title: About
+    location: tab/about/en.md
+  zh:
+    title: 关于
+    location: tab/about/zh.md # 页面的中文版本位于 wwwroot/tab/about/zh.md
+  ja:
+    title: 概要
+    location: tab/about/ja.md
+```
+
+与文章不同，页面对应的 Markdown 文件可以不包含前言区。
+
+
+## 图片与视频
+NanoSite 支持在 Markdown 中插入图片和视频。所有 Markdown 文件中的图片和视频都会以该文件的相对路径进行引用。例如在 [为 NanoSite 配置 GitHub Pages](?id=post%2Fpage%2Fgithubpages_zh.md&lang=zh) 这篇文章中，其于内容开头处插入了一张图片：
+
+```markdown
+![page](page.jpeg)
+```
+
+且其文章路径为 `wwwroot/post/page/githubpages_zh.md`，那么 `page.jpeg` 的存放位置则应为 `wwwroot/post/page/page.jpeg`。视频文件与图片文件的引用方式相同，只需确保路径正确即可，NanoSite 会自动识别出视频文件并进行处理。
+
+## 站内链接卡片（预览）
+
+当某段落只包含一个指向文章的链接（如 `?id=...`）时，该链接会被升级为带封面、摘要、日期、阅读时长的卡片（就像您在文章列表中看到的那样）。
+
+```markdown
+... 此前内容省略
+
+[为 NanoSite 配置 GitHub Pages](?id=post%2Fpage%2Fgithubpages_zh.md)
+
+... 此后内容省略
+```
+
+若要在行内强制显示为卡片，可在 `title` 中包含 `card` 或添加 `data-card`：
+
+```markdown
+... 此前内容省略
+
+这是一张 [为 NanoSite 配置 GitHub Pages](?id=post%2Fpage%2Fgithubpages_zh.md "card") 行内卡片。
+
+... 此后内容省略
+```
+
+## 常见问题
+
+- Q：网站打开后完全空白？
+  - A：请校验 YAML（缩进、冒号、列表/键值结构）。
+  - A：默认情况下，`index.yaml`/`tabs.yaml` 中的路径需相对 `wwwroot/`。请检查路径。
+  - A：请确认您通过一个模拟服务器或真实服务器进行网站预览（而非直接双击 `index.html` 打开），因为某些浏览器出于安全考虑默认禁止本地网页加载资源。
+- Q：文章已编写但未在网站中列出
+  - A：请确认文章的 `location` 已写入 `wwwroot/index.yaml`，并且路径正确。
+  - A：请尝试按住键盘上的 `Shift` 按键点击刷新按钮，强制刷新浏览器缓存。
+
+## 进阶内容
+此处记录 NanoSite 的一些高级选项，若您有兴趣可以进一步探索。
+
+### 其他设置
+`site.yaml` 还有一些其他设置选项。
+
+#### 主题覆写
+默认情况下，网站的主题尊重用户的选择，并储存在浏览器中。但您可以通过设置强制用户加载某一主题（及其变体）。
+- `themeMode` — 主题模式（例如，`user`、`dark`、`light`、`default`）。
+- `themePack` — 主题包（例如，`minimalism`、`github`）。
+- `themeOverride` — 强制用户加载特定主题（缺省为 `false`）。
+
+例如：
+```yaml
+themeMode: user
+themePack: minimalism
+themeOverride: true
+```
+
+#### 错误报告设置
+- `reportIssueURL` — 启用预填充的 GitHub 问题链接。
+- `errorOverlay` — 如果发生错误，则在页面上显示错误弹窗（缺省为 `false`）。
+- `assetWarnings` — 资源相关警告设置。
+  - `largeImage` — 大图警告设置。
+    - `enabled` — 是否启用大图警告（缺省为 `false`）。
+    - `thresholdKB` — 大图阈值（缺省为 `500KB`）。
+
+例如：
+```yaml
+reportIssueURL: https://github.com/deemoe404/NanoSite/issues/new
+errorOverlay: true
+assetWarnings:
+  largeImage:
+    enabled: true
+    thresholdKB: 500
+```
+
+#### 杂项设置
+- `contentOutdatedDays` — 内容被视为过时的天数（默认为 180 天）。
+- `cardCoverFallback` — 如果未提供封面图像，则使用生成的占位封面图像（缺省为 `true`）。
+- `pageSize` — 索引列表中每页的帖子数量（缺省为 `8`）。
+- `defaultLanguage` — 默认 UI/内容语言（例如，`en`、`zh`、`ja`；缺省为 `en`）。
+
+例如：
+```yaml
+contentOutdatedDays: 180
+cardCoverFallback: false
+pageSize: 8
+defaultLanguage: en
+```
+
+### 路由工作方式
+
+前端路由读取 URL 查询参数：
+
+- `?tab=posts` — 全部文章（默认）。支持 `&page=N` 分页。
+- `?tab=search&q=关键词` — 按标题或标签搜索。也可用 `&tag=标签名` 过滤。
+- `?id=路径/到/文章.md` — 直接打开某篇文章（路径必须存在于 `index.yaml`）。
+- `?lang=zh` — UI/内容语言。存储在 localStorage，并回退到浏览器与 `<html lang>`。
+
+Markdown 中的站内跳转链接示例：`[看看这篇](?id=post/frogy/main.md)`，标签页：`[关于](?tab=about)`。
+
+### SEO（内置）
+
+运行时按页面动态更新 meta（标题、描述、Open Graph、Twitter Card），并注入结构化数据（JSON-LD）。数据来源优先级：
+
+1) Markdown 前言区（`title`、`excerpt`、`tags`、`date`、`image`）
+2) `index.yaml` 元数据
+3) 自动回退（H1/首段）与生成的占位社交图
+
+`index.yaml` 的 SEO 部分示例配置如下：
+```yaml
+resourceURL: https://nano.dee.moe/wwwroot/
+siteDescription:
+  default: NanoSite - Just Markdown. Just a website.
+  zh: 微站 - 写下 Markdown，就是你的网站。
+  ja: ナノサイト - 書くだけ、Markdown。それがサイトになる。
+siteKeywords:
+  default: static blog, markdown, github pages, blog
+```
+
+其中：
+- `resourceURL` — 资源的基础 URL，确保所有资源（如图片、视频）都能正确加载。默认情况下设置为您实际网站的 `wwwroot/` 目录即可。
+- `siteDescription` — 网站的描述信息，用于 SEO 和社交分享。
+- `siteKeywords` — 网站的关键词，用于 SEO。
+
+您同时应该打开 `index_seo.html`，生成 `sitemap.xml`、`robots.txt` 并放入网站根目录（与 `index.html` 同级）；以及根据 `site.yaml` 生成初始 `<head>` 标签并填入 `index.html` 的对应位置。
+
+### 多语言
+
+- UI 文案在 `assets/js/i18n.js`（已含 English/中文/日本語）。可扩展 `translations` 和 `languageNames` 添加更多语言。
+- 内容支持：
+	- 简化版（本仓库示例）：按语言直接给出 Markdown 路径
+	- 统一版：每种语言的 `{title, location}`
+	- 旧版：`index.en.yaml`/`index.en.json`、`index.zh.yaml`/`index.zh.json`…（回退）
+- 切换语言时，若当前文章存在相应变体，路由会尽量保持在“同一篇”。


### PR DESCRIPTION
This pull request adds comprehensive documentation for NanoSite version 2.1.0 in English, Chinese, and Japanese. It updates the documentation index to include the new version for all three supported languages, and provides detailed guides covering project structure, configuration, content management, theming, SEO, multi-language support, and deployment.

**Documentation updates:**

* Added new documentation files for NanoSite v2.1.0 in English (`doc_en.md`), Chinese (`doc_zh.md`), and Japanese (`doc_ja.md`), each providing a full-featured usage guide for the platform. [[1]](diffhunk://#diff-60d529c3c29682f7f2cb79cef7f2c7376a2a2a0ead3365460bbcc7ee5247bea7R1-R257) [[2]](diffhunk://#diff-2fd241b1dc813d13413a4999889022fa6f21e0a5986de08717f691c1132d45d7R1-R257) [[3]](diffhunk://#diff-3b31ed10752fb9c2102e9337a29a4226aa12600f99932e2dbecab59e7ef7e739R1-R257)
* Updated `wwwroot/index.yaml` to register the v2.1.0 documentation files for all three languages, ensuring they are discoverable in the site's documentation index.