### PR TITLE
doc: Update documentation titles and links to use '微站指南' instead of 'NanoSite 使用文档'

### DIFF
--- a/wwwroot/post/doc/v1.0.0/doc_zh.md
+++ b/wwwroot/post/doc/v1.0.0/doc_zh.md
@@ -1,9 +1,9 @@
 ---
-title: NanoSite 使用文档
+title: 微站指南
 date: 2025-08-17
 version: v1.0.0
 tags:
-	- NanoSite
+	- 微站
 	- 文档
 excerpt: 无需构建步骤即可直接用 Markdown 文件创建内容网站，只需将文件放入 wwwroot/，在 JSON 中列出并发布，即可兼容 GitHub Pages。本指南涵盖项目结构、配置文件、内容加载、主题、搜索、标签、SEO、媒体以及部署方法。
 author: deemoe

--- a/wwwroot/post/doc/v2.0.0/doc_zh.md
+++ b/wwwroot/post/doc/v2.0.0/doc_zh.md
@@ -1,10 +1,10 @@
 ---
-title: NanoSite 使用文档
+title: 微站指南
 date: 2025-08-22
 version: v2.0.0
 tags:
-	- NanoSite
-	- 文档
+  - 微站
+  - 文档
 excerpt: 无需构建步骤即可直接用 Markdown 文件创建内容网站，只需将文件放入 wwwroot/，在 YAML 中列出并发布，即可兼容 GitHub Pages。本指南涵盖项目结构、配置文件、内容加载、主题、搜索、标签、SEO、媒体以及部署方法。
 author: deemoe
 ai: true

--- a/wwwroot/post/doc/v2.1.0/doc_zh.md
+++ b/wwwroot/post/doc/v2.1.0/doc_zh.md
@@ -1,13 +1,13 @@
 ---
-title: NanoSite 使用文档
+title: 微站指南
 date: 2025-08-23
 version: v2.1.0
 tags:
-	- NanoSite
+	- 微站
 	- 文档
 excerpt: 无需构建步骤即可直接用 Markdown 文件创建内容网站，只需将文件放入 wwwroot/，在 YAML 中列出并发布，即可兼容 GitHub Pages。本指南涵盖项目结构、配置文件、内容加载、主题、搜索、标签、SEO、媒体以及部署方法。
 author: deemoe
-ai: false
+ai: true
 ---
 
 ## 文件概览

--- a/wwwroot/tab/about/zh.md
+++ b/wwwroot/tab/about/zh.md
@@ -7,4 +7,4 @@
 
 让我们开始吧：➡️ [初识微站](?id=post/main/v2.0.0/main_zh.md)。
 
-> 要是你对文档不过敏，这是一份更好的启动资料：➡️ [NanoSite 使用文档](?id=post/doc/v2.1.0/doc_zh.md)。😊
+> 要是你对文档不过敏，这是一份更好的启动资料：➡️ [微站指南](?id=post/doc/v2.1.0/doc_zh.md)。😊


### PR DESCRIPTION
This pull request updates documentation and references across multiple files to rebrand "NanoSite" as "微站" and to update the documentation title accordingly. It also enables the `ai` feature in the latest documentation version.

Documentation rebranding and updates:

* Updated the title in the documentation files for versions 1.0.0, 2.0.0, and 2.1.0 from "NanoSite 使用文档" to "微站指南" and replaced the "NanoSite" tag with "微站" for consistent branding. [[1]](diffhunk://#diff-844004ba9fe80a41fc1e5a0c82d57c5cd42761933c9f76603e6fc4bbee566dbeL2-R6) [[2]](diffhunk://#diff-e9f553d280964f90628edb9312f94a62716297fa317853434250381399e609f9L2-R6) [[3]](diffhunk://#diff-2fd241b1dc813d13413a4999889022fa6f21e0a5986de08717f691c1132d45d7L2-R10)
* Updated a reference in the about page from "NanoSite 使用文档" to "微站指南" to match the new documentation title.

Feature flag update:

* Enabled the `ai` feature in the metadata of the v2.1.0 documentation file.