### PR TITLE
doc: Add landingTab and showAllPosts configurations to site.yaml

### DIFF
--- a/site.yaml
+++ b/site.yaml
@@ -44,3 +44,6 @@ assetWarnings:
   largeImage:
     enabled: true
     thresholdKB: 500
+
+landingTab: About   # Set to a tab slug or title defined in tabs.yaml
+showAllPosts: true      # Set to false to hide the All Posts tab/index


### PR DESCRIPTION
This pull request introduces two new configuration options to the `site.yaml` file, allowing for customization of the landing tab and visibility of the "All Posts" tab.

Configuration enhancements:

* Added `landingTab` option to specify the default landing tab, which can be set to a tab slug or title defined in `tabs.yaml`.
* Added `showAllPosts` option to control whether the "All Posts" tab/index is visible.