### PR TITLE
feat: Add draft notice and badge to post metadata and update styles for visibility

### DIFF
--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -60,7 +60,9 @@ const translations = {
       warning: 'Warning',
       error: 'Error',
       aiFlagLabel: 'AI-assisted',
-      aiFlagTooltip: 'AI-assisted: generated or edited with an LLM'
+      aiFlagTooltip: 'AI-assisted: generated or edited with an LLM',
+      draftBadge: 'Draft',
+      draftNotice: 'This post is a draft and may change.'
     },
     code: {
       copy: 'Copy',
@@ -134,7 +136,9 @@ const translations = {
       warning: '警告',
       error: '错误',
       aiFlagLabel: 'AI 参与',
-      aiFlagTooltip: 'AI 参与：本文由生成式 LLM 生成或修改'
+      aiFlagTooltip: 'AI 参与：本文由生成式 LLM 生成或修改',
+      draftBadge: '草稿',
+      draftNotice: '本文仍在撰写/修改中，内容可能随时变更。'
     },
     code: {
       copy: '复制',
@@ -208,7 +212,9 @@ const translations = {
       warning: '警告',
       error: 'エラー',
       aiFlagLabel: 'AI 参加',
-      aiFlagTooltip: 'AI 参加：本記事は生成系LLMで生成・編集されています'
+      aiFlagTooltip: 'AI 参加：本記事は生成系LLMで生成・編集されています',
+      draftBadge: '下書き',
+      draftNotice: 'この記事は執筆中・編集中です。内容は変更される場合があります。'
     },
     code: {
       copy: 'コピー',
@@ -452,6 +458,7 @@ async function loadContentFromFrontMatter(obj, lang) {
           excerpt: frontMatter.excerpt || undefined,
           versionLabel: frontMatter.version || undefined,
           ai: truthy(frontMatter.ai || frontMatter.aiGenerated || frontMatter.llm) || undefined,
+          draft: truthy(frontMatter.draft || frontMatter.wip || frontMatter.unfinished || frontMatter.inprogress) || undefined,
           __title: frontMatter.title || undefined
         });
       } catch (error) {

--- a/assets/js/templates.js
+++ b/assets/js/templates.js
@@ -8,6 +8,7 @@ export function renderPostMetaCard(title, meta, markdown) {
   try {
     const safeTitle = escapeHtml(String(title || ''));
     const aiFlag = !!(meta && (meta.ai || meta.aiGenerated || meta.llm));
+    const isDraft = !!(meta && meta.draft);
     const aiIcon = aiFlag
       ? `<span class="ai-flag" role="img" tabindex="0" aria-label="${t('ui.aiFlagLabel')}">
           <svg viewBox=\"0 0 32 32\" width=\"1em\" height=\"1em\" aria-hidden=\"true\" focusable=\"false\"><path fill=\"currentColor\" d=\"M10.52 7.052a1.17 1.17 0 0 1-.639-.636L8.93 4.257c-.178-.343-.69-.343-.858 0l-.952 2.16a1.28 1.28 0 0 1-.638.635l-1.214.524a.462.462 0 0 0 0 .838l1.214.524c.293.121.523.353.638.636l.952 2.169c.178.343.69.343.858 0l.952-2.17c.126-.282.356-.504.638-.635l1.214-.524a.462.462 0 0 0 0-.838zM25.574 13.555a3.73 3.73 0 0 1-1.922-1.977L20.79 4.81a1.432 1.432 0 0 0-2.58 0l-2.863 6.768a3.8 3.8 0 0 1-1.921 1.977l-3.622 1.64c-1.072.53-1.072 2.08 0 2.61l3.622 1.64c.87.388 1.557 1.101 1.922 1.977l2.862 6.768a1.432 1.432 0 0 0 2.58 0l2.863-6.768a3.8 3.8 0 0 1 1.921-1.977l3.622-1.64c1.072-.53 1.072-2.08 0-2.61zM8.281 20.33c.16.392.454.696.822.872l1.55.725a.646.646 0 0 1 0 1.146l-1.55.725c-.368.176-.661.49-.822.872l-1.228 2.977a.61.61 0 0 1-1.106 0L4.72 24.67a1.66 1.66 0 0 0-.822-.872l-1.55-.725a.646.646 0 0 1 0-1.146l1.55-.725c.368-.176.661-.49.822-.872l1.228-2.977a.61.61 0 0 1 1.106 0z\"/><\/svg>
@@ -24,6 +25,7 @@ export function renderPostMetaCard(title, meta, markdown) {
     if (dateHtml) parts.push(dateHtml);
     if (readHtml) parts.push(readHtml);
     const metaLine = parts.length ? `<div class="post-meta-line">${parts.join('<span class="card-sep">•</span>')}</div>` : '';
+    const draftNotice = isDraft ? `<div class="post-draft-notice" role="note">${t('ui.draftNotice')}</div>` : '';
     // Optional version selector (only when multiple versions available)
     let versionHtml = '';
     try {
@@ -56,6 +58,7 @@ export function renderPostMetaCard(title, meta, markdown) {
     return `<section class="post-meta-card" aria-label="Post meta">
       <div class="post-meta-title">${aiIcon}${safeTitle}</div>
       <button type="button" class="post-meta-copy" aria-label="${t('ui.copyLink')}" title="${t('ui.copyLink')}">${t('ui.copyLink')}</button>
+      ${draftNotice}
       ${metaLine}
       ${versionHtml}
       ${excerptHtml}

--- a/assets/main.js
+++ b/assets/main.js
@@ -761,6 +761,7 @@ function hydrateInternalLinkCards(container) {
   const href = withLangParam(`?id=${encodeURIComponent(loc)}`);
       const tagsHtml = meta ? renderTags(meta.tag) : '';
       const dateHtml = meta && meta.date ? `<span class="card-date">${escapeHtml(formatDisplayDate(meta.date))}</span>` : '';
+      const draftHtml = meta && meta.draft ? `<span class="card-draft">${t('ui.draftBadge')}</span>` : '';
       // Allow relative frontmatter image (e.g., 'cover.jpg'); resolve against the post's folder
       const rawCover = meta && (meta.thumb || meta.cover || meta.image);
       let coverSrc = rawCover;
@@ -777,7 +778,8 @@ function hydrateInternalLinkCards(container) {
 
       const wrapper = document.createElement('div');
       wrapper.className = 'link-card-wrap';
-      wrapper.innerHTML = `<a class="link-card" href="${href}">${cover}<div class="card-title">${escapeHtml(title)}</div><div class="card-excerpt">${t('ui.loading')}</div><div class="card-meta">${dateHtml}</div>${tagsHtml}</a>`;
+      const initialMeta = [dateHtml, draftHtml].filter(Boolean).join('<span class="card-sep">•</span>');
+      wrapper.innerHTML = `<a class="link-card" href="${href}">${cover}<div class="card-title">${escapeHtml(title)}</div><div class="card-excerpt">${t('ui.loading')}</div><div class="card-meta">${initialMeta}</div>${tagsHtml}</a>`;
 
       // If index metadata provides an explicit excerpt, prefer it immediately
       try {
@@ -831,12 +833,12 @@ function hydrateInternalLinkCards(container) {
         const metaEl = card.querySelector('.card-meta');
         if (metaEl) {
           const readHtml = `<span class="card-read">${minutes} ${t('ui.minRead')}</span>`;
-          if (metaEl.querySelector('.card-date')) {
-            const dEl = metaEl.querySelector('.card-date');
-            metaEl.innerHTML = `${dEl.outerHTML}<span class="card-sep">•</span>${readHtml}`;
-          } else {
-            metaEl.innerHTML = readHtml;
-          }
+          const dEl = metaEl.querySelector('.card-date');
+          const parts = [];
+          if (dEl && dEl.textContent.trim()) parts.push(dEl.outerHTML);
+          parts.push(readHtml);
+          if (meta && meta.draft) parts.push(`<span class="card-draft">${t('ui.draftBadge')}</span>`);
+          metaEl.innerHTML = parts.join('<span class="card-sep">•</span>');
         }
       }).catch(() => {});
     });
@@ -1461,7 +1463,12 @@ function displayIndex(parsed) {
     const dateHtml = hasDate ? `<span class=\"card-date\">${escapeHtml(formatDisplayDate(value.date))}</span>` : '';
     const verCount = (value && Array.isArray(value.versions)) ? value.versions.length : 0;
     const versionsHtml = verCount > 1 ? `<span class=\"card-versions\" title=\"${t('ui.versionLabel')}\">${t('ui.versionsCount', verCount)}</span>` : '';
-    const metaInner = dateHtml + (dateHtml && versionsHtml ? `<span class=\"card-sep\">•</span>` : '') + (versionsHtml || '');
+    const draftHtml = (value && value.draft) ? `<span class=\"card-draft\">${t('ui.draftBadge')}</span>` : '';
+    const parts = [];
+    if (dateHtml) parts.push(dateHtml);
+    if (versionsHtml) parts.push(versionsHtml);
+    if (draftHtml) parts.push(draftHtml);
+    const metaInner = parts.join('<span class=\"card-sep\">•</span>');
     html += `<a href=\"${withLangParam(`?id=${encodeURIComponent(value['location'])}`)}\" data-idx=\"${encodeURIComponent(key)}\">${cover}<div class=\"card-title\">${key}</div><div class=\"card-excerpt\"></div><div class=\"card-meta\">${metaInner}</div>${tag}</a>`;
   }
   html += '</div>';
@@ -1526,6 +1533,7 @@ function displayIndex(parsed) {
         if (dateEl && dateEl.textContent.trim()) parts.push(dateEl.outerHTML);
         parts.push(readHtml);
         if (versionsHtml) parts.push(versionsHtml);
+        if (meta && meta.draft) parts.push(`<span class=\"card-draft\">${t('ui.draftBadge')}</span>`);
         metaEl.innerHTML = parts.join('<span class=\"card-sep\">•</span>');
       }
   // Recompute masonry span for the updated card
@@ -1588,7 +1596,12 @@ function displaySearch(query) {
     const dateHtml = hasDate ? `<span class=\"card-date\">${escapeHtml(formatDisplayDate(value.date))}</span>` : '';
     const verCount = (value && Array.isArray(value.versions)) ? value.versions.length : 0;
     const versionsHtml = verCount > 1 ? `<span class=\"card-versions\" title=\"${t('ui.versionLabel')}\">${t('ui.versionsCount', verCount)}</span>` : '';
-    const metaInner = dateHtml + (dateHtml && versionsHtml ? `<span class=\"card-sep\">•</span>` : '') + (versionsHtml || '');
+    const draftHtml = (value && value.draft) ? `<span class=\"card-draft\">${t('ui.draftBadge')}</span>` : '';
+    const parts = [];
+    if (dateHtml) parts.push(dateHtml);
+    if (versionsHtml) parts.push(versionsHtml);
+    if (draftHtml) parts.push(draftHtml);
+    const metaInner = parts.join('<span class=\"card-sep\">•</span>');
     html += `<a href=\"${withLangParam(`?id=${encodeURIComponent(value['location'])}`)}\" data-idx=\"${encodeURIComponent(key)}\">${cover}<div class=\"card-title\">${key}</div><div class=\"card-excerpt\"></div><div class=\"card-meta\">${metaInner}</div>${tag}</a>`;
   }
   html += '</div>';
@@ -1658,6 +1671,7 @@ function displaySearch(query) {
         if (dateEl && dateEl.textContent.trim()) parts.push(dateEl.outerHTML);
         parts.push(readHtml);
         if (versionsHtml) parts.push(versionsHtml);
+        if (meta && meta.draft) parts.push(`<span class=\"card-draft\">${t('ui.draftBadge')}</span>`);
         metaEl.innerHTML = parts.join('<span class=\"card-sep\">•</span>');
       }
   const container = document.querySelector('.index');

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -477,6 +477,16 @@ table tr:hover { background-color: color-mix(in srgb, var(--primary) 8%, transpa
   #mainview .post-outdated-card { transition: none; }
   #mainview .post-outdated-card .post-outdated-close { transition: none; }
 }
+#mainview .post-meta-card .post-draft-notice {
+  /* Remove the framed box; use accent color for text only */
+  border: none;
+  background: transparent;
+  color: #b45309; /* amber-700 like accent for visibility */
+  border-radius: 0;
+  padding: 0;
+  font-size: 0.92rem;
+  margin: 0.125rem 0 0.35rem;
+}
 #mainview .post-meta-card .tags { display:flex; flex-wrap: wrap; gap:0.375rem; padding: 0; }
 #mainview .post-meta-card .tag { font-size: .8rem; }
 
@@ -529,6 +539,7 @@ table tr:hover { background-color: color-mix(in srgb, var(--primary) 8%, transpa
 .index .card-excerpt { padding: 0 0.875rem 0.625rem; color: var(--muted); font-size: .92rem; line-height: 1.5; max-height: 4.5em; overflow: hidden; display: -webkit-box; -webkit-line-clamp: 3; line-clamp: 3; -webkit-box-orient: vertical; }
 .index .card-meta { padding: 0.375rem 0.875rem 0.625rem; color: var(--muted); font-size: .72rem; display:flex; align-items:center; gap:0.5rem; text-transform: uppercase; letter-spacing: .04em; font-weight: 600; border-top: 0.0625rem solid var(--border); margin-top: 0.25rem; opacity: .9; }
 .index .card-sep { opacity: .6; margin: 0 0.125rem; }
+.index .card-draft, #mainview .link-card .card-draft { display:inline-block; padding: 0.075rem 0.35rem; border-radius: 0.35rem; font-weight: 800; color: #b45309; background: color-mix(in srgb, #f59e0b 18%, var(--card)); border: 0.0625rem solid color-mix(in srgb, #f59e0b 35%, var(--border)); font-size: .72rem; letter-spacing: .04em; }
 .index .tags { display:flex; flex-wrap: wrap; gap:0.375rem; padding: 0 0.875rem 0.875rem; }
 .index .tag, .tags .tag { display:inline-block; margin: 0; font-size:.8rem; color: var(--muted); background: color-mix(in srgb, var(--text) 6%, transparent); padding:.1rem .4rem; border-radius: 999px; }
 


### PR DESCRIPTION
This pull request introduces draft status indicators for posts across the UI, including support for multiple languages, visual badges, and notices. It updates both the frontend logic and styles to ensure draft posts are clearly marked and communicated to users in post cards, internal link cards, and search/index listings.

**Internationalization & UI Text:**
* Added `draftBadge` and `draftNotice` translations for English, Chinese, and Japanese, enabling localized draft indicators and notices in the UI. [[1]](diffhunk://#diff-208716f66b472a927f09ee8c661dc4e8b0f123024cba13922bb76172e0846d5eL63-R65) [[2]](diffhunk://#diff-208716f66b472a927f09ee8c661dc4e8b0f123024cba13922bb76172e0846d5eL137-R141) [[3]](diffhunk://#diff-208716f66b472a927f09ee8c661dc4e8b0f123024cba13922bb76172e0846d5eL211-R217)

**Frontend Logic for Draft Status:**
* Updated frontmatter parsing in `loadContentFromFrontMatter` to recognize draft status from multiple possible fields (`draft`, `wip`, `unfinished`, `inprogress`).
* Modified `renderPostMetaCard` to display a draft notice when a post is marked as draft. [[1]](diffhunk://#diff-01c31cc89a36f7c261a08ad0965690eed7ceea041ff6ea14d98d71a4cd66b865R11) [[2]](diffhunk://#diff-01c31cc89a36f7c261a08ad0965690eed7ceea041ff6ea14d98d71a4cd66b865R28) [[3]](diffhunk://#diff-01c31cc89a36f7c261a08ad0965690eed7ceea041ff6ea14d98d71a4cd66b865R61)

**Draft Badges in Cards and Listings:**
* Internal link cards, index, and search results now display a draft badge if the post is a draft, both in initial rendering and after metadata is loaded. [[1]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295R764) [[2]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L780-R782) [[3]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L834-R841) [[4]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1464-R1471) [[5]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295R1536) [[6]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295L1591-R1604) [[7]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295R1674)

**Styling Enhancements:**
* Added new CSS classes for `.post-draft-notice` and `.card-draft` to visually distinguish draft notices and badges, using an amber accent color for visibility and consistency across the UI. [[1]](diffhunk://#diff-9bce12f93ec0640b44be69b747d96875ab88cd339ff1024423f4e2e64b37b2e1R480-R489) [[2]](diffhunk://#diff-9bce12f93ec0640b44be69b747d96875ab88cd339ff1024423f4e2e64b37b2e1R542)