### PR TITLE
feat: update visuals

### DIFF
--- a/assets/js/typography.js
+++ b/assets/js/typography.js
@@ -1,0 +1,66 @@
+// Typography utilities
+// - applyLangHints: add lang="en" to long Latin tokens inside CJK pages
+//   to improve hyphenation without touching code blocks or links.
+
+export function applyLangHints(container) {
+  try {
+    const root = typeof container === 'string' ? document.querySelector(container) : (container || document);
+    if (!root) return;
+    // Only apply when page lang is CJK or container/ancestors indicate CJK
+    const docLang = (document.documentElement && (document.documentElement.lang || document.documentElement.getAttribute('lang'))) || '';
+    const isCJK = /^(zh|ja)/i.test(docLang);
+    if (!isCJK) return;
+    // Avoid repeated work
+    if (root.__langHintsApplied) return; root.__langHintsApplied = true;
+    const SKIP_TAGS = new Set(['CODE', 'PRE', 'KBD', 'SAMP', 'VAR', 'SCRIPT', 'STYLE']);
+    const MAX_WRAPS = 200; // safety cap
+    let wraps = 0;
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        try {
+          if (!node || !node.nodeValue) return NodeFilter.FILTER_REJECT;
+          const t = node.nodeValue;
+          if (!/[A-Za-z]/.test(t)) return NodeFilter.FILTER_REJECT; // no Latin letters
+          const p = node.parentElement;
+          if (!p || SKIP_TAGS.has(p.tagName)) return NodeFilter.FILTER_REJECT;
+          if (p.closest('pre, code, kbd, samp, var, .code-scroll, .code-block')) return NodeFilter.FILTER_REJECT;
+          if (p.closest('a')) return NodeFilter.FILTER_SKIP; // avoid altering links
+          return NodeFilter.FILTER_ACCEPT;
+        } catch { return NodeFilter.FILTER_REJECT; }
+      }
+    });
+    const re = /([A-Za-z][A-Za-z\-]{4,})/g; // long-ish Latin tokens (>=5 chars incl. hyphen)
+    const batch = [];
+    let n;
+    while ((n = walker.nextNode())) {
+      const text = n.nodeValue;
+      if (!re.test(text)) continue;
+      batch.push(n);
+      if (batch.length > 2000) break; // hard cap for performance
+    }
+    for (const node of batch) {
+      if (wraps >= MAX_WRAPS) break;
+      const text = node.nodeValue;
+      const parts = text.split(re);
+      if (!parts || parts.length <= 1) continue;
+      const frag = document.createDocumentFragment();
+      for (let i = 0; i < parts.length; i++) {
+        const s = parts[i];
+        if (!s) continue;
+        if (re.test(s)) {
+          const span = document.createElement('span');
+          span.setAttribute('lang', 'en');
+          span.textContent = s;
+          frag.appendChild(span);
+          wraps++;
+          if (wraps >= MAX_WRAPS) break;
+        } else {
+          frag.appendChild(document.createTextNode(s));
+        }
+      }
+      node.parentNode.replaceChild(frag, node);
+      if (wraps >= MAX_WRAPS) break;
+    }
+  } catch (_) { /* noop */ }
+}
+

--- a/assets/main.js
+++ b/assets/main.js
@@ -15,6 +15,7 @@ import { installLightbox } from './js/lightbox.js';
 import { renderPostNav } from './js/post-nav.js';
 import { prefersReducedMotion, getArticleTitleFromMain } from './js/dom-utils.js';
 import { renderPostMetaCard, renderOutdatedCard } from './js/templates.js';
+import { applyLangHints } from './js/typography.js';
 
 // Lightweight fetch helper
 const getFile = (filename) => fetch(filename).then(resp => { if (!resp.ok) throw new Error(`HTTP ${resp.status}`); return resp.text(); });
@@ -1297,6 +1298,7 @@ function displayPost(postname) {
   try { renderPostNav('#mainview', postsIndexCache, postname); } catch (_) {}
   try { hydratePostImages('#mainview'); } catch (_) {}
     try { applyLazyLoadingIn('#mainview'); } catch (_) {}
+    try { applyLangHints('#mainview'); } catch (_) {}
     // After images are in DOM, run large-image watchdog if enabled in site config
     try {
       const cfg = (siteConfig && siteConfig.assetWarnings && siteConfig.assetWarnings.largeImage) || {};

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -487,13 +487,22 @@ table tr:hover { background-color: color-mix(in srgb, var(--primary) 8%, transpa
   margin: 0.125rem 0 0.5rem;
 }
 
-/* Post meta excerpt: match article body font for print-like feel */
+/* Post meta excerpt: journal-like, justified, refined wrapping */
 #mainview .post-meta-card .post-meta-excerpt {
   color: var(--muted);
   font-size: .93rem;
-  line-height: 1.35;
+  line-height: 1.55;              /* more comfortable reading rhythm */
   margin: 0.2rem 0 0.85rem;
-  white-space: pre-line;
+  white-space: normal;            /* avoid forced breaks from source */
+  text-align: justify;            /* full justification like journals */
+  text-align-last: left;          /* keep last line ragged-left */
+  text-justify: inter-ideograph;  /* better for CJK; ignored elsewhere */
+  text-wrap: pretty;              /* reduce runts/tight last words (progressive) */
+  hanging-punctuation: first allow-end; /* nicer edge (progressive) */
+  /* Enable hyphenation where appropriate; relies on :lang hints */
+  hyphens: auto;
+  -webkit-hyphens: auto;
+  -ms-hyphens: auto;
   /* Use the same serif stack as article body */
   font-family: var(--article-serif-stack);
 }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -467,7 +467,14 @@ table tr:hover { background-color: color-mix(in srgb, var(--primary) 8%, transpa
   margin: 0.25rem 0 1rem;
   position: relative;
 }
-.post-meta-title { font-size: 1.5rem; font-weight: 800; line-height: 1.25; margin: 0 0 0.25rem; }
+.post-meta-title {
+  font-size: 1.5rem;
+  font-weight: 800;
+  line-height: 1.25;
+  margin: 0 0 0.25rem;
+  /* Match body serif stack for a print-like look */
+  font-family: var(--article-serif-stack);
+}
 .post-meta-title .ai-flag { display: inline-flex; align-items: center; justify-content: center; width: 1.25em; height: 1.25em; margin-right: 0.4rem; color: var(--primary); vertical-align: -0.15em; cursor: help; }
 .post-meta-title .ai-flag svg { width: 1em; height: 1em; }
 .post-meta-title .ai-flag { position: relative; }
@@ -480,8 +487,16 @@ table tr:hover { background-color: color-mix(in srgb, var(--primary) 8%, transpa
   margin: 0.125rem 0 0.5rem;
 }
 
-/* Post meta excerpt: slightly tighter line-height and a bit more space before tags */
-#mainview .post-meta-card .post-meta-excerpt { color: var(--muted); font-size: .93rem; line-height: 1.35; margin: 0.2rem 0 0.85rem; white-space: pre-line; }
+/* Post meta excerpt: match article body font for print-like feel */
+#mainview .post-meta-card .post-meta-excerpt {
+  color: var(--muted);
+  font-size: .93rem;
+  line-height: 1.35;
+  margin: 0.2rem 0 0.85rem;
+  white-space: pre-line;
+  /* Use the same serif stack as article body */
+  font-family: var(--article-serif-stack);
+}
 
 #mainview .post-outdated-card {
   border: 0.0625rem solid color-mix(in srgb, #f59e0b 35%, var(--border));

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -12,6 +12,8 @@
   --code-text: #e5e7eb;
   --hr: #e5e7eb;
   --shadow: 0 0.0625rem 0.1875rem rgba(0, 0, 0, 0.06), 0 0.0625rem 0.125rem rgba(0, 0, 0, 0.04);
+  /* Serif stack for article-like body text (theme packs may override) */
+  --article-serif-stack: Georgia, "Times New Roman", Times, "Noto Serif CJK SC", "Source Han Serif SC", "Noto Serif", "STSong", serif;
 }
 
 [data-theme="dark"] {
@@ -69,8 +71,20 @@ h1:hover .anchor, h2:hover .anchor, h3:hover .anchor, h4:hover .anchor, h5:hover
 /* duplicate rule cleanup handled above with theme variables */
 
 /* Paragraph style */
-#mainview { font-size: 1.04rem; line-height: 1.85; letter-spacing: .005em; hyphens: auto; text-wrap: pretty; }
-#mainview p { margin: .85rem 0; }
+#mainview {
+  font-size: 1.04rem;
+  line-height: 1.85;
+  letter-spacing: .005em;
+  /* Prefer LaTeX-like hyphenation for Latin scripts */
+  hyphens: auto;
+  -webkit-hyphens: auto;
+  -ms-hyphens: auto;
+  /* Avoid overly aggressive breaking; allow long tokens to wrap when needed */
+  word-break: normal;
+  overflow-wrap: break-word;
+  text-wrap: pretty;
+}
+#mainview p { margin: .85rem 0; text-align: justify; text-justify: inter-ideograph; }
 #mainview p + p { margin-top: 1rem; }
 #mainview h1, #mainview h2, #mainview h3, #mainview h4, #mainview h5, #mainview h6 { scroll-margin-top: 6.25rem; text-wrap: balance; }
 #mainview h2 { margin: 1.6rem 0 .7rem; }
@@ -80,6 +94,38 @@ h1:hover .anchor, h2:hover .anchor, h3:hover .anchor, h4:hover .anchor, h5:hover
 #mainview li { margin: .35rem 0; line-height: 1.75; }
 #mainview img { margin: 1rem auto; border-radius: 0.5rem; box-shadow: var(--shadow); }
 #mainview hr { margin: 1.4rem 0; }
+
+/* Article body: serif stack for a journal feel (theme packs can override) */
+#mainview p,
+#mainview li,
+#mainview blockquote,
+#mainview td,
+#mainview th { font-family: var(--article-serif-stack); }
+
+/* Language-aware refinements */
+/* English: enable automatic hyphenation clearly */
+:lang(en) #mainview,
+#mainview :lang(en) {
+  hyphens: auto;
+  -webkit-hyphens: auto;
+  -ms-hyphens: auto;
+  word-break: normal;
+}
+/* Chinese/Japanese: no hyphen insertion; stricter line breaking; no added tracking */
+:lang(zh) #mainview,
+#mainview :lang(zh),
+:lang(ja) #mainview,
+#mainview :lang(ja) {
+  hyphens: none;
+  -webkit-hyphens: none;
+  -ms-hyphens: none;
+  line-break: strict;
+  /* Allow normal CJK line breaking to avoid excessive justification stretching in Safari */
+  word-break: normal;
+  letter-spacing: 0;
+  /* Prefer character-based justification when supported */
+  text-justify: inter-character;
+}
 
 /* Horizontal rule style */
 hr { border: none; border-top: 0.0625rem solid var(--hr); margin: 1.25rem 0; }
@@ -1280,9 +1326,12 @@ ul.collapsed, li > ul.collapsed { display: none; }
     min-height: 15.625rem; /* Reduce min-height */
     width: 100%;
     max-width: 100%;
-    overflow-wrap: break-word; /* Force long-word wrap */
-    word-break: break-word; /* Compatibility */
+    /* Allow long tokens to wrap, but prefer hyphenation over arbitrary breaks */
+    overflow-wrap: break-word; /* Allow long-word wrap when necessary */
+    word-break: normal; /* Do not force arbitrary breaks */
     hyphens: auto; /* Enable hyphenation */
+    -webkit-hyphens: auto;
+    -ms-hyphens: auto;
     box-sizing: border-box;
   }
   


### PR DESCRIPTION
This pull request introduces significant improvements to typography and code block handling, especially for multilingual (CJK and Latin) content. The main changes include enhanced language-aware hyphenation and justification, a new utility for adding language hints to long Latin words in CJK pages, and refinements to code block highlighting and labeling. These updates aim to provide a more polished, journal-like reading experience and better code block usability.

**Typography and Language-aware Styling:**

* Added a new CSS variable (`--article-serif-stack`) and applied it to article text, post titles, and excerpts for a print-like, serif appearance. Enhanced justification, hyphenation, and line breaking rules for both Latin and CJK scripts, with language-specific refinements for better readability. [[1]](diffhunk://#diff-9bce12f93ec0640b44be69b747d96875ab88cd339ff1024423f4e2e64b37b2e1R15-R16) [[2]](diffhunk://#diff-9bce12f93ec0640b44be69b747d96875ab88cd339ff1024423f4e2e64b37b2e1L72-R87) [[3]](diffhunk://#diff-9bce12f93ec0640b44be69b747d96875ab88cd339ff1024423f4e2e64b37b2e1R98-R129) [[4]](diffhunk://#diff-9bce12f93ec0640b44be69b747d96875ab88cd339ff1024423f4e2e64b37b2e1L424-R477) [[5]](diffhunk://#diff-9bce12f93ec0640b44be69b747d96875ab88cd339ff1024423f4e2e64b37b2e1L437-R508) [[6]](diffhunk://#diff-9bce12f93ec0640b44be69b747d96875ab88cd339ff1024423f4e2e64b37b2e1L1283-R1358)

* Introduced the `applyLangHints` JavaScript utility, which automatically adds `lang="en"` to long Latin words in CJK pages (excluding code blocks and links). This improves hyphenation and line breaking for mixed-language content. Integrated this utility into post rendering. [[1]](diffhunk://#diff-d9e9d14a14d15fb909423ac7dfe04d3aa63911deb2744d216a38462598f51618R1-R66) [[2]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295R18) [[3]](diffhunk://#diff-cf14fafae7faac4339b75c791c2a78e1ac69c4dd3f640126bff30f88de513295R1301)

**Code Block Highlighting and Labeling:**

* Improved code block handling in `initSyntaxHighlighting`: now honors flags like `nohighlight`, `plain`, `text`, and `data-nohighlight` to disable syntax highlighting and copy enhancements. When highlighting is disabled, the language label always displays as "PLAIN", and copy features remain available. [[1]](diffhunk://#diff-4ddf6e867e816ef5b8959dbb125fe614fb19fa7f0466ab87ecbc9e57299b44cbR238-R267) [[2]](diffhunk://#diff-4ddf6e867e816ef5b8959dbb125fe614fb19fa7f0466ab87ecbc9e57299b44cbL316-R335) [[3]](diffhunk://#diff-4ddf6e867e816ef5b8959dbb125fe614fb19fa7f0466ab87ecbc9e57299b44cbL334-R358) [[4]](diffhunk://#diff-4ddf6e867e816ef5b8959dbb125fe614fb19fa7f0466ab87ecbc9e57299b44cbL363-R382) [[5]](diffhunk://#diff-4ddf6e867e816ef5b8959dbb125fe614fb19fa7f0466ab87ecbc9e57299b44cbL378-R397)