### PR TITLE
feat: Add repository configuration to site schema for dynamic report URL generation

### DIFF
--- a/assets/main.js
+++ b/assets/main.js
@@ -2368,8 +2368,19 @@ loadSiteConfig()
         const v = (lang && val[lang]) || val.default || '';
         return typeof v === 'string' ? v : '';
       };
+      const resolveReportUrl = (cfg) => {
+        try {
+          if (!cfg || typeof cfg !== 'object') return null;
+          // Derive from repo fields when available
+          const repo = cfg.repo || {};
+          const owner = repo && typeof repo.owner === 'string' ? repo.owner.trim() : '';
+          const name = repo && typeof repo.name === 'string' ? repo.name.trim() : '';
+          if (owner && name) return `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/issues/new`;
+          return null;
+        } catch (_) { return null; }
+      };
       initErrorReporter({
-        reportUrl: siteConfig && siteConfig.reportIssueURL,
+        reportUrl: resolveReportUrl(siteConfig),
         siteTitle: pick(siteConfig && siteConfig.siteTitle) || 'NanoSite',
         enableOverlay: !!(siteConfig && siteConfig.errorOverlay === true)
       });

--- a/assets/schema/site.json
+++ b/assets/schema/site.json
@@ -94,9 +94,24 @@
       "type": "boolean",
       "description": "Use card cover image as fallback when missing."
     },
-    "reportIssueURL": {
-      "type": "string",
-      "description": "URL for reporting site issues."
+    "repo": {
+      "type": "object",
+      "description": "Repository info used to construct helper URLs (e.g., report issue).",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "description": "Repository owner or organization (e.g., octocat)."
+        },
+        "name": {
+          "type": "string",
+          "description": "Repository name (e.g., hello-world)."
+        },
+        "branch": {
+          "type": "string",
+          "description": "Default branch name (e.g., main or gh-pages)."
+        }
+      },
+      "additionalProperties": true
     },
     "errorOverlay": {
       "type": "boolean",


### PR DESCRIPTION
This pull request updates how the site configuration handles repository information and the construction of the "report issue" URL. Instead of specifying a direct URL, the configuration now accepts structured repository details, which are used to dynamically generate the issue reporting link.

**Configuration schema changes:**

* Replaced the `reportIssueURL` field in `site.json` with a new `repo` object containing `owner`, `name`, and optional `branch` properties for repository information.

**Error reporting logic improvements:**

* Updated `loadSiteConfig()` in `assets/main.js` to use the new `repo` object to construct the GitHub "new issue" URL dynamically, improving maintainability and reducing manual errors.