### PR TITLE
Hide composer discard button when clean

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -1562,6 +1562,29 @@ function updateDraftButtonState(forceTarget) {
   if (stale) {
     btn.title = btn.title ? `${btn.title} -- Remote snapshot changed` : 'Remote snapshot changed';
   }
+  try { updateDiscardButtonState(target); } catch (_) {}
+}
+
+function updateDiscardButtonState(forceTarget) {
+  const btn = document.getElementById('btnDiscard');
+  if (!btn) return;
+  const target = forceTarget || getActiveComposerFile();
+  const diff = composerDiffCache[target];
+  const meta = composerDraftMeta[target];
+  const hasChanges = !!(diff && diff.hasChanges);
+  const hasDraft = !!meta;
+  const shouldShow = hasChanges || hasDraft;
+  if (shouldShow) {
+    btn.hidden = false;
+    btn.removeAttribute('aria-hidden');
+  } else {
+    btn.hidden = true;
+    btn.setAttribute('aria-hidden', 'true');
+    btn.classList.remove('is-busy');
+    btn.removeAttribute('aria-busy');
+    btn.disabled = false;
+    try { btn.textContent = 'Discard'; } catch (_) {}
+  }
 }
 
 function scheduleAutoDraft(kind) {

--- a/index_editor.html
+++ b/index_editor.html
@@ -413,7 +413,7 @@
             <button class="btn-secondary" id="btnAddItem">New Post Wizard</button>
             <button class="btn-secondary" id="btnRefresh" title="Fetch latest remote snapshot">Refresh</button>
             <button class="btn-secondary" id="btnDraft" title="Save a local draft of current changes">暂存 Draft</button>
-            <button class="btn-secondary" id="btnDiscard" title="Discard local draft and reload remote file">Discard</button>
+            <button class="btn-secondary" id="btnDiscard" title="Discard local draft and reload remote file" hidden>Discard</button>
             <button class="btn-secondary" id="btnVerify">
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg">
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="currentColor"/>


### PR DESCRIPTION
## Summary
- hide the composer discard button until there is a local draft or diff to discard
- keep the discard button state in sync with composer diff and draft metadata

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ced3972f74832889eba6da659f3d04