### PR TITLE
Hide discard button when no local changes

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -726,6 +726,8 @@ function updateDiscardButtonVisibility(hasLocalChanges) {
   const btn = document.getElementById('btnDiscard');
   if (!btn) return;
   btn.hidden = !hasLocalChanges;
+  btn.setAttribute('aria-hidden', hasLocalChanges ? 'false' : 'true');
+  btn.style.display = hasLocalChanges ? '' : 'none';
 }
 
 function updateUnsyncedSummary() {

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -722,9 +722,18 @@ function computeUnsyncedSummary() {
   return entries;
 }
 
+function updateDiscardButtonVisibility(hasLocalChanges) {
+  const btn = document.getElementById('btnDiscard');
+  if (!btn) return;
+  btn.hidden = !hasLocalChanges;
+}
+
 function updateUnsyncedSummary() {
   const el = document.getElementById('composerStatus');
-  if (!el) return;
+  if (!el) {
+    updateDiscardButtonVisibility(false);
+    return;
+  }
   const summaryEntries = computeUnsyncedSummary();
   if (summaryEntries.length) {
     el.innerHTML = '';
@@ -746,10 +755,12 @@ function updateUnsyncedSummary() {
     });
     el.dataset.summary = '1';
     el.dataset.state = 'dirty';
+    updateDiscardButtonVisibility(true);
   } else {
     el.textContent = CLEAN_STATUS_MESSAGE;
     el.dataset.summary = '0';
     el.dataset.state = 'clean';
+    updateDiscardButtonVisibility(false);
   }
 }
 
@@ -1717,8 +1728,6 @@ async function handleComposerDiscard(btn) {
   const hasChanges = !!(diff && diff.hasChanges);
   const hasDraft = !!meta;
   if (!hasChanges && !hasDraft) {
-    showStatus(`No local changes to discard for ${label}`);
-    setTimeout(() => { showStatus(''); }, 1400);
     return;
   }
 

--- a/index_editor.html
+++ b/index_editor.html
@@ -255,6 +255,7 @@
     .toolbar { display:flex; align-items:center; justify-content:space-between; gap:.75rem; flex-wrap:wrap; margin-bottom:.75rem; padding-bottom:.5rem; border-bottom:1px solid #d0d7de; }
     .left-actions, .right-actions { display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; }
     .btn-secondary { display:inline-flex; align-items:center; justify-content:center; gap:.35rem; background: var(--card); color: var(--text); border:1px solid var(--border); padding:.45rem .8rem; border-radius:8px; cursor:pointer; font-size:.93rem; height:2.25rem; line-height:1; text-decoration:none; }
+    .btn-secondary[hidden] { display:none !important; }
     .btn-secondary:hover { background: color-mix(in srgb, var(--text) 5%, var(--card)); }
     a.btn-secondary:visited { color: var(--text); }
     .btn-secondary.is-busy { opacity:.6; cursor:progress; pointer-events:none; }

--- a/index_editor.html
+++ b/index_editor.html
@@ -413,7 +413,7 @@
             <button class="btn-secondary" id="btnAddItem">New Post Wizard</button>
             <button class="btn-secondary" id="btnRefresh" title="Fetch latest remote snapshot">Refresh</button>
             
-            <button class="btn-secondary" id="btnDiscard" title="Discard local draft and reload remote file">Discard</button>
+            <button class="btn-secondary" id="btnDiscard" title="Discard local draft and reload remote file" hidden>Discard</button>
             <button class="btn-secondary" id="btnVerify">
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg">
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="currentColor"/>


### PR DESCRIPTION
## Summary
- hide the composer discard button by default and only reveal it when unsynced changes exist
- remove the redundant status message when no local changes are available to discard and adjust status updates accordingly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ced75fbeec8328aa2f3b4ea57b4f28