### PR TITLE
Add local draft persistence for markdown editors

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -33,7 +33,7 @@ const MARKDOWN_PUSH_LABELS = {
   update: 'Synchronize'
 };
 
-const MARKDOWN_DISCARD_LABEL = 'Discard Local Changes';
+const MARKDOWN_DISCARD_LABEL = 'Discard';
 
 let markdownPushButton = null;
 let markdownDiscardButton = null;

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -791,6 +791,20 @@ function getDraftIndicatorMessage(state) {
   }
 }
 
+function updateComposerDraftContainerState(container) {
+  if (!container) return;
+  let childState = '';
+  if (container.querySelector('.ct-lang[data-draft-state="conflict"], .ci-ver-item[data-draft-state="conflict"]')) {
+    childState = 'conflict';
+  } else if (container.querySelector('.ct-lang[data-draft-state="dirty"], .ci-ver-item[data-draft-state="dirty"]')) {
+    childState = 'dirty';
+  } else {
+    childState = '';
+  }
+  if (childState) container.setAttribute('data-child-draft', childState);
+  else container.removeAttribute('data-child-draft');
+}
+
 function applyComposerDraftIndicatorState(el, state) {
   if (!el) return;
   const indicator = el.querySelector('.ct-draft-indicator, .ci-draft-indicator');
@@ -818,6 +832,7 @@ function applyComposerDraftIndicatorState(el, state) {
     indicator.removeAttribute('aria-label');
     indicator.removeAttribute('role');
   }
+  updateComposerDraftContainerState(el.closest('.ct-item, .ci-item'));
 }
 
 function updateComposerMarkdownDraftIndicators(options = {}) {
@@ -3992,14 +4007,15 @@ function buildIndexUI(root, state) {
               arr.splice(i, 1);
               verIds.splice(i, 1);
               entry[lang] = arr.slice();
-              renderVers(prev);
-              markDirty();
-            });
-            verList.appendChild(row);
-          });
-          animateFrom(prevRects);
-        };
-        renderVers();
+        renderVers(prev);
+        markDirty();
+      });
+      verList.appendChild(row);
+    });
+    animateFrom(prevRects);
+    updateComposerDraftContainerState(verList.closest('.ci-item'));
+  };
+  renderVers();
         $('.ci-lang-addver', block).addEventListener('click', () => {
           const prev = snapRects();
           arr.push('');
@@ -4078,6 +4094,7 @@ function buildIndexUI(root, state) {
         });
         bodyInner.appendChild(addLangWrap);
       }
+      updateComposerDraftContainerState(row);
     };
     renderBody();
 
@@ -4275,6 +4292,7 @@ function buildTabsUI(root, state) {
         });
         bodyInner.appendChild(addLangWrap);
       }
+      updateComposerDraftContainerState(row);
     };
     renderBody();
 
@@ -5718,6 +5736,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   .ci-head,.ct-head{display:flex;align-items:center;gap:.5rem;padding:.5rem .6rem;border-bottom:1px solid var(--border);}
   .ci-head,.ct-head{border-bottom:none;}
   .ci-item.is-open .ci-head,.ct-item.is-open .ct-head{border-bottom:1px solid var(--border);}
+  .ci-key,.ct-key{transition:color .18s ease;}
   .ci-body,.ct-body{display:none;padding:.5rem .6rem;}
   .ci-body-inner,.ct-body-inner{overflow:visible;}
   .ci-grip,.ct-grip{cursor:grab;user-select:none;opacity:.7}
@@ -5732,6 +5751,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   .ct-lang-label{display:flex;align-items:center;justify-content:center;gap:.3rem;padding:.35rem .6rem;background:color-mix(in srgb, var(--text) 14%, var(--card));color:var(--text);min-width:78px;white-space:nowrap;font-weight:700;border-radius:6px 0 0 6px;}
   .ct-lang-label .ct-lang-flag{font-size:1.25rem;line-height:1;transform:translateY(-1px);}
   .ct-lang-label .ct-lang-code{font-size:.9rem;font-weight:700;letter-spacing:.045em;}
+  .ci-item[data-child-draft="dirty"] .ci-key,.ct-item[data-child-draft="dirty"] .ct-key{color:#f97316;}
+  .ci-item[data-child-draft="conflict"] .ci-key,.ct-item[data-child-draft="conflict"] .ct-key{color:#ef4444;}
   .ct-draft-indicator,.ci-draft-indicator{display:inline-flex;width:.55rem;height:.55rem;border-radius:999px;background:color-mix(in srgb,var(--muted) 48%, transparent);box-shadow:0 0 0 3px color-mix(in srgb,var(--muted) 14%, transparent);flex:0 0 auto;opacity:0;transform:scale(.6);transition:opacity .18s ease, transform .18s ease, background-color .18s ease, box-shadow .18s ease;}
   .ct-draft-indicator[hidden],.ci-draft-indicator[hidden]{display:none;}
   .ct-lang[data-draft-state] .ct-draft-indicator,.ci-ver-item[data-draft-state] .ci-draft-indicator{opacity:1;transform:scale(.95);}

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -368,6 +368,10 @@ document.addEventListener('DOMContentLoaded', () => {
       if (Number.isFinite(status.code)) detail.push(`HTTP ${status.code}`);
       return detail.length ? `${base} (${detail.join(' · ')})` : base;
     }
+    if (status.message) {
+      const msg = String(status.message);
+      return msg ? `${base} — ${msg}` : base;
+    }
     return base;
   };
 

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -287,7 +287,7 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const STATUS_STATES = new Set(['checking', 'existing', 'missing', 'error']);
-  let currentFileInfo = { path: '', status: null };
+  let currentFileInfo = { path: '', status: null, dirty: false, draft: null };
   let currentFileElRef = null;
 
   const ensureCurrentFileElement = () => {
@@ -295,6 +295,13 @@ document.addEventListener('DOMContentLoaded', () => {
     currentFileElRef = document.getElementById('currentFile');
     return currentFileElRef;
   };
+
+  const escapeHtml = (value) => String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 
   const formatStatusTimestamp = (ms) => {
     if (!Number.isFinite(ms)) return '';
@@ -347,16 +354,45 @@ document.addEventListener('DOMContentLoaded', () => {
     return Object.keys(normalized).length ? normalized : (state ? { state } : null);
   };
 
+  const normalizeDraftPayload = (value) => {
+    if (!value || typeof value !== 'object') return null;
+    let savedAt = value.savedAt;
+    if (savedAt instanceof Date) savedAt = savedAt.getTime();
+    else if (typeof savedAt === 'string') {
+      const trimmed = savedAt.trim();
+      if (trimmed) {
+        const asNumber = Number(trimmed);
+        if (Number.isFinite(asNumber)) savedAt = asNumber;
+        else {
+          const parsed = Date.parse(trimmed);
+          savedAt = Number.isFinite(parsed) ? parsed : null;
+        }
+      } else {
+        savedAt = null;
+      }
+    }
+    if (Number.isFinite(savedAt)) savedAt = Math.floor(savedAt);
+    else savedAt = null;
+
+    const normalized = {};
+    if (savedAt != null) normalized.savedAt = savedAt;
+    if (value.conflict) normalized.conflict = true;
+
+    return Object.keys(normalized).length ? normalized : null;
+  };
+
   const normalizeCurrentFilePayload = (input) => {
     if (typeof input === 'string') {
-      return { path: String(input || '').trim(), status: null };
+      return { path: String(input || '').trim(), status: null, dirty: false, draft: null };
     }
     if (input && typeof input === 'object') {
       const path = input.path != null ? String(input.path || '').trim() : '';
       const status = normalizeStatusPayload(input.status);
-      return { path, status };
+      const dirty = !!input.dirty;
+      const draft = normalizeDraftPayload(input.draft);
+      return { path, status, dirty, draft };
     }
-    return { path: '', status: null };
+    return { path: '', status: null, dirty: false, draft: null };
   };
 
   const describeStatusLabel = (status) => {
@@ -391,6 +427,32 @@ document.addEventListener('DOMContentLoaded', () => {
     return '';
   };
 
+  const formatDraftRelative = (ms) => {
+    if (!Number.isFinite(ms)) return '';
+    try {
+      if (typeof Intl === 'object' && typeof Intl.RelativeTimeFormat === 'function') {
+        const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+        let duration = (ms - Date.now()) / 1000;
+        const divisions = [
+          { amount: 60, unit: 'second' },
+          { amount: 60, unit: 'minute' },
+          { amount: 24, unit: 'hour' },
+          { amount: 7, unit: 'day' },
+          { amount: 4.34524, unit: 'week' },
+          { amount: 12, unit: 'month' },
+          { amount: Infinity, unit: 'year' }
+        ];
+        for (const division of divisions) {
+          if (Math.abs(duration) < division.amount) {
+            return rtf.format(Math.round(duration), division.unit);
+          }
+          duration /= division.amount;
+        }
+      }
+    } catch (_) { /* fall back below */ }
+    return '';
+  };
+
   const renderCurrentFileIndicator = () => {
     const el = ensureCurrentFileElement();
     if (!el) return;
@@ -400,22 +462,57 @@ document.addEventListener('DOMContentLoaded', () => {
       el.removeAttribute('data-file-state');
       el.removeAttribute('data-last-checked');
       el.removeAttribute('title');
+      el.removeAttribute('data-dirty');
+      el.removeAttribute('data-draft-conflict');
+      el.removeAttribute('data-draft-saved');
       return;
     }
 
     const status = currentFileInfo.status || null;
+    const dirty = !!currentFileInfo.dirty;
+    const draft = currentFileInfo.draft || null;
+
     const segments = [`${path}`];
     const statusLabel = describeStatusLabel(status);
     const meta = formatStatusMeta(status);
     if (statusLabel) segments.push(`— ${statusLabel}`);
     if (meta) segments.push(statusLabel ? `· ${meta}` : `— ${meta}`);
-    const text = segments.join(' ');
-    el.textContent = text;
-    el.setAttribute('title', text);
+    const primaryText = segments.join(' ');
+
+    let draftText = '';
+    if (draft) {
+      const pieces = [];
+      if (draft.savedAt != null) {
+        const stamp = formatStatusTimestamp(draft.savedAt);
+        if (stamp) pieces.push(stamp);
+        const relative = formatDraftRelative(draft.savedAt);
+        if (relative && relative !== stamp) pieces.push(relative);
+      }
+      const base = draft.conflict ? 'Local draft (remote updated)' : 'Local draft';
+      draftText = pieces.length ? `${base} — ${pieces.join(' · ')}` : base;
+    } else if (dirty) {
+      draftText = 'Unsaved edits — local draft pending…';
+    }
+
+    const tooltipParts = [primaryText];
+    let html = `<span class="cf-line cf-primary">${escapeHtml(primaryText)}</span>`;
+    if (draftText) {
+      html += `<span class="cf-line cf-draft">${escapeHtml(draftText)}</span>`;
+      tooltipParts.push(draftText);
+    }
+    el.innerHTML = html;
+    el.setAttribute('title', tooltipParts.join('\n'));
+
     if (status && status.state) el.setAttribute('data-file-state', status.state);
     else el.removeAttribute('data-file-state');
     if (status && Number.isFinite(status.checkedAt)) el.setAttribute('data-last-checked', String(status.checkedAt));
     else el.removeAttribute('data-last-checked');
+    if (dirty) el.setAttribute('data-dirty', '1');
+    else el.removeAttribute('data-dirty');
+    if (draft && draft.conflict) el.setAttribute('data-draft-conflict', '1');
+    else el.removeAttribute('data-draft-conflict');
+    if (draft && Number.isFinite(draft.savedAt)) el.setAttribute('data-draft-saved', String(draft.savedAt));
+    else el.removeAttribute('data-draft-saved');
   };
 
   const bindCurrentFileElement = (el) => {

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -171,7 +171,8 @@ function renderPreview(mdText) {
 document.addEventListener('DOMContentLoaded', () => {
   const ta = document.getElementById('mdInput');
   const editor = createHiEditor(ta, 'markdown', false);
-  const wrapToggle = document.getElementById('editorWrapToggle');
+  const wrapToggle = document.getElementById('wrapToggle');
+  const wrapToggleButtons = wrapToggle ? Array.from(wrapToggle.querySelectorAll('[data-wrap]')) : [];
   let wrapEnabled = false;
 
   const readWrapState = () => {
@@ -192,10 +193,16 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const syncWrapToggle = (on) => {
-    if (!wrapToggle) return;
-    const checked = !!on;
-    wrapToggle.checked = checked;
-    wrapToggle.setAttribute('aria-checked', checked ? 'true' : 'false');
+    const enabled = !!on;
+    if (wrapToggle) {
+      wrapToggle.setAttribute('data-state', enabled ? 'on' : 'off');
+    }
+    wrapToggleButtons.forEach((btn) => {
+      const isOn = (btn.dataset.wrap || '').toLowerCase() === 'on';
+      const active = isOn === enabled;
+      btn.classList.toggle('active', active);
+      btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+    });
   };
 
   const applyWrapState = (value, opts = {}) => {
@@ -213,20 +220,23 @@ document.addEventListener('DOMContentLoaded', () => {
     if (opts.persist !== false) persistWrapState(on);
   };
 
-  const handleWrapToggle = () => {
-    const next = wrapToggle ? wrapToggle.checked : !wrapEnabled;
+  const handleWrapSelection = (state) => {
+    const next = String(state || '').toLowerCase() === 'on';
     applyWrapState(next);
   };
 
-  if (wrapToggle) {
-    wrapToggle.addEventListener('change', handleWrapToggle);
-    wrapToggle.addEventListener('input', handleWrapToggle);
-    wrapToggle.addEventListener('click', () => {
-      if (!wrapToggle.matches(':focus-visible')) {
-        try { wrapToggle.blur(); } catch (_) {}
+  wrapToggleButtons.forEach((btn) => {
+    btn.addEventListener('click', (event) => {
+      event.preventDefault();
+      handleWrapSelection(btn.dataset.wrap);
+    });
+    btn.addEventListener('keydown', (event) => {
+      if (event.key === ' ') {
+        event.preventDefault();
+        handleWrapSelection(btn.dataset.wrap);
       }
     });
-  }
+  });
 
   applyWrapState(readWrapState(), { persist: false });
 

--- a/index_editor.html
+++ b/index_editor.html
@@ -172,7 +172,7 @@
       color: color-mix(in srgb, #991b1b 82%, #ef4444 45%);
       box-shadow: 0 16px 34px rgba(239, 68, 68, 0.32);
     }
-    .mode-tab.dynamic-mode[data-dirty="1"] .mode-tab-chip::after {
+    .mode-tab.dynamic-mode[data-dirty="1"] .mode-tab-chip::before {
       content: '';
       flex: 0 0 auto;
       width: .5rem;
@@ -180,8 +180,9 @@
       border-radius: 999px;
       background: color-mix(in srgb, #f97316 82%, var(--card));
       box-shadow: 0 0 0 2px color-mix(in srgb, #f97316 26%, transparent);
+      margin-right: .38rem;
     }
-    .mode-tab.dynamic-mode[data-draft-conflict="1"] .mode-tab-chip::after {
+    .mode-tab.dynamic-mode[data-draft-conflict="1"] .mode-tab-chip::before {
       background: color-mix(in srgb, #ef4444 82%, var(--card));
       box-shadow: 0 0 0 2px color-mix(in srgb, #ef4444 28%, transparent);
     }
@@ -189,6 +190,9 @@
       pointer-events: none;
     }
     .mode-tab-chip { display: inline-flex; align-items: center; gap: .45rem; }
+    .mode-tab-chip::before { display: none; }
+    .mode-tab.dynamic-mode[data-dirty="1"] .mode-tab-chip::before,
+    .mode-tab.dynamic-mode[data-draft-conflict="1"] .mode-tab-chip::before { display: inline-flex; }
     .mode-tab-label { overflow: hidden; text-overflow: ellipsis; }
     .mode-tab-close {
       appearance: none;
@@ -237,11 +241,52 @@
     .editor-sidebar .search input:focus { outline: none; box-shadow: 0 0 0 .12rem color-mix(in srgb, var(--primary) 35%, transparent); border-color: color-mix(in srgb, var(--primary) 45%, var(--border)); }
     .editor-sidebar .status { margin-top: .4rem; font-size: .78rem; color: var(--muted); }
     .editor-sidebar .lists { display: block; }
-    .current-file { color: var(--muted); font-size: .85rem; margin-left: .5rem; }
-    .current-file[data-file-state="checking"] { color: color-mix(in srgb, #2563eb 70%, var(--text)); }
-    .current-file[data-file-state="existing"] { color: color-mix(in srgb, #15803d 70%, var(--text)); }
-    .current-file[data-file-state="missing"] { color: color-mix(in srgb, #d97706 75%, var(--text)); }
-    .current-file[data-file-state="error"] { color: color-mix(in srgb, #dc2626 80%, var(--text)); }
+    .current-file {
+      color: var(--muted);
+      font-size: .85rem;
+      margin-left: .5rem;
+      display: inline-flex;
+      flex-direction: column;
+      gap: .15rem;
+      min-width: 0;
+      max-width: min(340px, 55vw);
+      white-space: normal;
+    }
+    .current-file .cf-line {
+      display: block;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .current-file .cf-primary {
+      font-weight: 600;
+      color: inherit;
+      line-height: 1.2;
+    }
+    .current-file .cf-draft {
+      font-size: .78rem;
+      color: color-mix(in srgb, var(--muted) 86%, var(--text) 14%);
+      line-height: 1.25;
+    }
+    .current-file[data-dirty="1"] .cf-primary {
+      color: color-mix(in srgb, var(--text) 88%, var(--primary) 18%);
+    }
+    .current-file[data-draft-conflict="1"] .cf-draft {
+      color: color-mix(in srgb, #dc2626 72%, var(--text));
+    }
+    .current-file[data-file-state="checking"] .cf-primary { color: color-mix(in srgb, #2563eb 70%, var(--text)); }
+    .current-file[data-file-state="existing"] .cf-primary { color: color-mix(in srgb, #15803d 70%, var(--text)); }
+    .current-file[data-file-state="missing"] .cf-primary { color: color-mix(in srgb, #d97706 75%, var(--text)); }
+    .current-file[data-file-state="error"] .cf-primary { color: color-mix(in srgb, #dc2626 80%, var(--text)); }
+    #btnPushMarkdown { white-space: nowrap; }
+    #btnPushMarkdown[data-dirty="1"] {
+      border-color: color-mix(in srgb, #f97316 42%, var(--border));
+      color: color-mix(in srgb, var(--text) 82%, #f97316 30%);
+    }
+    #btnPushMarkdown[data-conflict="1"] {
+      border-color: color-mix(in srgb, #ef4444 55%, var(--border));
+      color: color-mix(in srgb, var(--text) 82%, #ef4444 35%);
+    }
     /* Grouped list styles */
     .editor-sidebar .file-group { border-bottom: 1px solid var(--border); }
     .editor-sidebar .file-group:last-child { border-bottom: 0; }
@@ -473,6 +518,7 @@
             <span class="current-file" id="currentFile" aria-live="polite"></span>
           </div>
           <div class="right-actions">
+            <button class="btn-secondary" id="btnPushMarkdown" type="button" title="Copy Markdown and open the GitHub editor" aria-label="Push local draft to GitHub">Push to GitHub</button>
             <div class="view-toggle" aria-label="View switch">
               <span class="vt-label">View:</span>
               <a href="#" class="vt-btn active" data-view="edit">Editor</a>

--- a/index_editor.html
+++ b/index_editor.html
@@ -101,6 +101,14 @@
       font-weight: 600;
       cursor: pointer;
     }
+    .mode-tab.dynamic-mode[data-dirty="1"] {
+      border-color: color-mix(in srgb, #f97316 45%, var(--border));
+      box-shadow: 0 8px 24px rgba(249, 115, 22, 0.22);
+    }
+    .mode-tab.dynamic-mode[data-draft-conflict="1"] {
+      border-color: color-mix(in srgb, #ef4444 52%, var(--border));
+      box-shadow: 0 10px 26px rgba(239, 68, 68, 0.24);
+    }
     .mode-tab.is-busy {
       opacity: .6;
       cursor: progress;
@@ -163,6 +171,19 @@
       background: linear-gradient(135deg, color-mix(in srgb, #ef4444 28%, var(--card)), color-mix(in srgb, var(--card) 90%, transparent));
       color: color-mix(in srgb, #991b1b 82%, #ef4444 45%);
       box-shadow: 0 16px 34px rgba(239, 68, 68, 0.32);
+    }
+    .mode-tab.dynamic-mode[data-dirty="1"] .mode-tab-chip::after {
+      content: '';
+      flex: 0 0 auto;
+      width: .5rem;
+      height: .5rem;
+      border-radius: 999px;
+      background: color-mix(in srgb, #f97316 82%, var(--card));
+      box-shadow: 0 0 0 2px color-mix(in srgb, #f97316 26%, transparent);
+    }
+    .mode-tab.dynamic-mode[data-draft-conflict="1"] .mode-tab-chip::after {
+      background: color-mix(in srgb, #ef4444 82%, var(--card));
+      box-shadow: 0 0 0 2px color-mix(in srgb, #ef4444 28%, transparent);
     }
     .mode-tab.dynamic-mode.is-busy {
       pointer-events: none;

--- a/index_editor.html
+++ b/index_editor.html
@@ -376,6 +376,29 @@
     button#btnVerify.btn-secondary:hover { background:#3d7741 !important; }
     button#btnVerify.btn-secondary:active { background:#298e46 !important; }
     button#btnVerify.btn-secondary:focus-visible { outline:2px solid #2ea44f66; outline-offset:2px; }
+    button#btnPushMarkdown.btn-secondary {
+      background:#428646 !important;
+      color:#ffffff !important;
+      border:1px solid #3d7741 !important;
+      border-radius:8px !important;
+    }
+    button#btnPushMarkdown.btn-secondary:hover { background:#3d7741 !important; }
+    button#btnPushMarkdown.btn-secondary:active { background:#298e46 !important; }
+    button#btnPushMarkdown.btn-secondary:focus-visible { outline:2px solid #2ea44f66; outline-offset:2px; }
+    button#btnPushMarkdown.btn-secondary:disabled {
+      opacity:.6;
+      cursor:not-allowed;
+      color:rgba(255,255,255,.85) !important;
+    }
+    button#btnPushMarkdown.btn-secondary svg {
+      width:16px;
+      height:16px;
+      flex:0 0 auto;
+    }
+    button#btnPushMarkdown.btn-secondary .btn-label {
+      font-weight:600;
+      white-space:nowrap;
+    }
     button#btnDiscard.btn-secondary {
       background:#e15b5b !important;
       color:#3f1010 !important;
@@ -384,6 +407,18 @@
     button#btnDiscard.btn-secondary:hover { background:#d14b4b !important; }
     button#btnDiscard.btn-secondary:active { background:#b73d3d !important; }
     button#btnDiscard.btn-secondary:focus-visible { outline:2px solid #f59f9f66; outline-offset:2px; }
+    button#btnDiscardMarkdown.btn-secondary {
+      background:#e15b5b !important;
+      color:#3f1010 !important;
+      border:1px solid #c94848 !important;
+    }
+    button#btnDiscardMarkdown.btn-secondary:hover { background:#d14b4b !important; }
+    button#btnDiscardMarkdown.btn-secondary:active { background:#b73d3d !important; }
+    button#btnDiscardMarkdown.btn-secondary:focus-visible { outline:2px solid #f59f9f66; outline-offset:2px; }
+    button#btnDiscardMarkdown.btn-secondary:disabled {
+      opacity:.55;
+      cursor:not-allowed;
+    }
     button#btnReview.btn-secondary {
       background:#f3c766 !important;
       color:#4a3510 !important;
@@ -498,7 +533,15 @@
               <span class="dim" aria-hidden="true">/</span>
               <a href="#" class="vt-btn" data-view="preview">Preview</a>
             </div>
-            <button type="button" class="btn-secondary" id="btnPushMarkdown" disabled>Push to GitHub</button>
+            <button type="button" class="btn-secondary" id="btnPushMarkdown" disabled>
+              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg">
+                <path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="currentColor"/>
+              </svg>
+              <span class="btn-label">Synchronize</span>
+            </button>
+            <button type="button" class="btn-secondary" id="btnDiscardMarkdown" disabled>
+              <span class="btn-label">Discard Local Changes</span>
+            </button>
             <label class="wrap-toggle" for="editorWrapToggle">
               <input type="checkbox" id="editorWrapToggle" role="switch" aria-checked="false">
               <span class="wrap-track" aria-hidden="true"><span class="wrap-thumb"></span></span>

--- a/index_editor.html
+++ b/index_editor.html
@@ -101,14 +101,6 @@
       font-weight: 600;
       cursor: pointer;
     }
-    .mode-tab.dynamic-mode[data-dirty="1"] {
-      border-color: color-mix(in srgb, #f97316 45%, var(--border));
-      box-shadow: 0 8px 24px rgba(249, 115, 22, 0.22);
-    }
-    .mode-tab.dynamic-mode[data-draft-conflict="1"] {
-      border-color: color-mix(in srgb, #ef4444 52%, var(--border));
-      box-shadow: 0 10px 26px rgba(239, 68, 68, 0.24);
-    }
     .mode-tab.is-busy {
       opacity: .6;
       cursor: progress;
@@ -172,27 +164,10 @@
       color: color-mix(in srgb, #991b1b 82%, #ef4444 45%);
       box-shadow: 0 16px 34px rgba(239, 68, 68, 0.32);
     }
-    .mode-tab.dynamic-mode[data-dirty="1"] .mode-tab-chip::before {
-      content: '';
-      flex: 0 0 auto;
-      width: .5rem;
-      height: .5rem;
-      border-radius: 999px;
-      background: color-mix(in srgb, #f97316 82%, var(--card));
-      box-shadow: 0 0 0 2px color-mix(in srgb, #f97316 26%, transparent);
-      margin-right: .38rem;
-    }
-    .mode-tab.dynamic-mode[data-draft-conflict="1"] .mode-tab-chip::before {
-      background: color-mix(in srgb, #ef4444 82%, var(--card));
-      box-shadow: 0 0 0 2px color-mix(in srgb, #ef4444 28%, transparent);
-    }
     .mode-tab.dynamic-mode.is-busy {
       pointer-events: none;
     }
     .mode-tab-chip { display: inline-flex; align-items: center; gap: .45rem; }
-    .mode-tab-chip::before { display: none; }
-    .mode-tab.dynamic-mode[data-dirty="1"] .mode-tab-chip::before,
-    .mode-tab.dynamic-mode[data-draft-conflict="1"] .mode-tab-chip::before { display: inline-flex; }
     .mode-tab-label { overflow: hidden; text-overflow: ellipsis; }
     .mode-tab-close {
       appearance: none;
@@ -241,52 +216,11 @@
     .editor-sidebar .search input:focus { outline: none; box-shadow: 0 0 0 .12rem color-mix(in srgb, var(--primary) 35%, transparent); border-color: color-mix(in srgb, var(--primary) 45%, var(--border)); }
     .editor-sidebar .status { margin-top: .4rem; font-size: .78rem; color: var(--muted); }
     .editor-sidebar .lists { display: block; }
-    .current-file {
-      color: var(--muted);
-      font-size: .85rem;
-      margin-left: .5rem;
-      display: inline-flex;
-      flex-direction: column;
-      gap: .15rem;
-      min-width: 0;
-      max-width: min(340px, 55vw);
-      white-space: normal;
-    }
-    .current-file .cf-line {
-      display: block;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-    .current-file .cf-primary {
-      font-weight: 600;
-      color: inherit;
-      line-height: 1.2;
-    }
-    .current-file .cf-draft {
-      font-size: .78rem;
-      color: color-mix(in srgb, var(--muted) 86%, var(--text) 14%);
-      line-height: 1.25;
-    }
-    .current-file[data-dirty="1"] .cf-primary {
-      color: color-mix(in srgb, var(--text) 88%, var(--primary) 18%);
-    }
-    .current-file[data-draft-conflict="1"] .cf-draft {
-      color: color-mix(in srgb, #dc2626 72%, var(--text));
-    }
-    .current-file[data-file-state="checking"] .cf-primary { color: color-mix(in srgb, #2563eb 70%, var(--text)); }
-    .current-file[data-file-state="existing"] .cf-primary { color: color-mix(in srgb, #15803d 70%, var(--text)); }
-    .current-file[data-file-state="missing"] .cf-primary { color: color-mix(in srgb, #d97706 75%, var(--text)); }
-    .current-file[data-file-state="error"] .cf-primary { color: color-mix(in srgb, #dc2626 80%, var(--text)); }
-    #btnPushMarkdown { white-space: nowrap; }
-    #btnPushMarkdown[data-dirty="1"] {
-      border-color: color-mix(in srgb, #f97316 42%, var(--border));
-      color: color-mix(in srgb, var(--text) 82%, #f97316 30%);
-    }
-    #btnPushMarkdown[data-conflict="1"] {
-      border-color: color-mix(in srgb, #ef4444 55%, var(--border));
-      color: color-mix(in srgb, var(--text) 82%, #ef4444 35%);
-    }
+    .current-file { color: var(--muted); font-size: .85rem; margin-left: .5rem; }
+    .current-file[data-file-state="checking"] { color: color-mix(in srgb, #2563eb 70%, var(--text)); }
+    .current-file[data-file-state="existing"] { color: color-mix(in srgb, #15803d 70%, var(--text)); }
+    .current-file[data-file-state="missing"] { color: color-mix(in srgb, #d97706 75%, var(--text)); }
+    .current-file[data-file-state="error"] { color: color-mix(in srgb, #dc2626 80%, var(--text)); }
     /* Grouped list styles */
     .editor-sidebar .file-group { border-bottom: 1px solid var(--border); }
     .editor-sidebar .file-group:last-child { border-bottom: 0; }
@@ -518,13 +452,13 @@
             <span class="current-file" id="currentFile" aria-live="polite"></span>
           </div>
           <div class="right-actions">
-            <button class="btn-secondary" id="btnPushMarkdown" type="button" title="Copy Markdown and open the GitHub editor" aria-label="Push local draft to GitHub">Push to GitHub</button>
             <div class="view-toggle" aria-label="View switch">
               <span class="vt-label">View:</span>
               <a href="#" class="vt-btn active" data-view="edit">Editor</a>
               <span class="dim" aria-hidden="true">/</span>
               <a href="#" class="vt-btn" data-view="preview">Preview</a>
             </div>
+            <button type="button" class="btn-secondary" id="btnPushMarkdown" disabled>Push to GitHub</button>
             <label class="wrap-toggle" for="editorWrapToggle">
               <input type="checkbox" id="editorWrapToggle" role="switch" aria-checked="false">
               <span class="wrap-track" aria-hidden="true"><span class="wrap-thumb"></span></span>

--- a/index_editor.html
+++ b/index_editor.html
@@ -427,21 +427,20 @@
     button#btnReview.btn-secondary:hover { background:#e6b541 !important; }
     button#btnReview.btn-secondary:active { background:#cf9830 !important; }
     button#btnReview.btn-secondary:focus-visible { outline:2px solid #f7d98f66; outline-offset:2px; }
-    .view-toggle { display:inline-flex; align-items:center; gap:.35rem; font-size:.92rem; color:#57606a; }
-    .view-toggle .vt-label { color:#6e7781; font-weight:500; margin-right:.25rem; }
-    .view-toggle .vt-btn { color:#0969da; text-decoration:none; padding:.1rem .25rem; border-radius:6px; position:relative; }
-    .view-toggle .vt-btn:hover { text-decoration:underline; }
-    .view-toggle .vt-btn.active { background:#eaeef2; color:#24292f; text-decoration:none; cursor:default; }
+    .view-toggle,
+    .wrap-toggle { display:inline-flex; align-items:center; gap:.35rem; font-size:.92rem; color:#57606a; }
+    .view-toggle .vt-label,
+    .wrap-toggle .vt-label { color:#6e7781; font-weight:500; margin-right:.25rem; }
+    .view-toggle .vt-btn,
+    .wrap-toggle .vt-btn { color:#0969da; text-decoration:none; padding:.1rem .25rem; border-radius:6px; position:relative; }
+    .view-toggle .vt-btn:hover,
+    .wrap-toggle .vt-btn:hover { text-decoration:underline; }
+    .view-toggle .vt-btn.active,
+    .wrap-toggle .vt-btn.active { background:#eaeef2; color:#24292f; text-decoration:none; cursor:default; }
     .view-toggle .vt-btn.has-draft::before { content:'●'; display:inline-block; font-size:.65rem; color:#f97316; margin-right:.35rem; line-height:1; }
     .view-toggle .vt-btn.has-draft { padding-left:.5rem; }
-    .wrap-toggle { position:relative; display:inline-flex; align-items:center; gap:.4rem; font-size:.92rem; color:#57606a; cursor:pointer; user-select:none; }
-    .wrap-toggle input { position:absolute; opacity:0; pointer-events:none; }
-    .wrap-toggle .wrap-track { width:36px; height:20px; border-radius:999px; background:color-mix(in srgb, var(--muted) 28%, var(--card)); border:1px solid color-mix(in srgb, var(--muted) 30%, var(--border)); position:relative; transition:background-color .18s ease, border-color .18s ease; }
-    .wrap-toggle .wrap-thumb { position:absolute; top:1px; left:1px; width:16px; height:16px; border-radius:50%; background:#ffffff; box-shadow:0 2px 6px rgba(15,23,42,0.25); transition:transform .18s ease; }
-    .wrap-toggle input:checked + .wrap-track { background:color-mix(in srgb, var(--primary) 55%, var(--card)); border-color:color-mix(in srgb, var(--primary) 55%, var(--border)); }
-    .wrap-toggle input:checked + .wrap-track .wrap-thumb { transform:translateX(16px); }
-    .wrap-toggle input:focus-visible + .wrap-track { outline:2px solid color-mix(in srgb, var(--primary) 40%, transparent); outline-offset:2px; }
-    .wrap-toggle .wrap-label { font-weight:500; }
+    .view-toggle .dim,
+    .wrap-toggle .dim { color:#8c959f; }
     /* Editor: reuse SEO hi-editor rules for perfect alignment */
     .hi-editor pre.hi-pre { background-color: transparent; color: var(--code-text); padding: 1rem 1rem 1rem 0.5rem; overflow: hidden; border: 0; border-radius: 8px; line-height: 20px; font-size: 12px; tab-size: 4; position: relative; margin: 0; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Ubuntu Mono", monospace; font-weight: 400; font-variant-ligatures: none; letter-spacing: 0; }
     .hi-editor .code-scroll { display: flex; align-items: stretch; border: 1px solid var(--border); border-radius: 8px; background: var(--code-bg); overflow-x: auto; overflow-y: hidden; position: relative; }
@@ -527,26 +526,27 @@
             <span class="current-file" id="currentFile" aria-live="polite"></span>
           </div>
           <div class="right-actions">
+            <div class="wrap-toggle view-toggle" id="wrapToggle" aria-label="Wrap setting">
+              <span class="vt-label">Wrap:</span>
+              <a href="#" class="vt-btn" data-wrap="on" role="button">on</a>
+              <span class="dim" aria-hidden="true">/</span>
+              <a href="#" class="vt-btn active" data-wrap="off" role="button">off</a>
+            </div>
             <div class="view-toggle" aria-label="View switch">
               <span class="vt-label">View:</span>
               <a href="#" class="vt-btn active" data-view="edit">Editor</a>
               <span class="dim" aria-hidden="true">/</span>
               <a href="#" class="vt-btn" data-view="preview">Preview</a>
             </div>
+            <button type="button" class="btn-secondary" id="btnDiscardMarkdown" disabled>
+              <span class="btn-label">Discard</span>
+            </button>
             <button type="button" class="btn-secondary" id="btnPushMarkdown" disabled>
               <svg aria-hidden="true" width="16" height="16" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg">
                 <path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="currentColor"/>
               </svg>
               <span class="btn-label">Synchronize</span>
             </button>
-            <button type="button" class="btn-secondary" id="btnDiscardMarkdown" disabled>
-              <span class="btn-label">Discard Local Changes</span>
-            </button>
-            <label class="wrap-toggle" for="editorWrapToggle">
-              <input type="checkbox" id="editorWrapToggle" role="switch" aria-checked="false">
-              <span class="wrap-track" aria-hidden="true"><span class="wrap-thumb"></span></span>
-              <span class="wrap-label">Wrap</span>
-            </label>
           </div>
         </div>
 

--- a/index_editor.html
+++ b/index_editor.html
@@ -85,7 +85,7 @@
       position: relative;
       display: inline-flex;
       align-items: center;
-      gap: .5rem;
+      gap: .55rem;
       border-radius: 999px;
       border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
       padding: .35rem .65rem .35rem .85rem;
@@ -164,6 +164,36 @@
       color: color-mix(in srgb, #991b1b 82%, #ef4444 45%);
       box-shadow: 0 16px 34px rgba(239, 68, 68, 0.32);
     }
+    .mode-tab.dynamic-mode::before {
+      content: '';
+      width: .55rem;
+      height: .55rem;
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--muted) 45%, transparent);
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--muted) 12%, transparent);
+      opacity: 0;
+      transform: scale(.6);
+      transition: opacity .18s ease, transform .18s ease, box-shadow .18s ease, background-color .18s ease;
+      flex: 0 0 auto;
+    }
+    .mode-tab.dynamic-mode[data-dirty="1"]::before {
+      opacity: 1;
+      transform: scale(1);
+      background: #f97316;
+      box-shadow: 0 0 0 3px color-mix(in srgb, #f97316 22%, transparent);
+    }
+    .mode-tab.dynamic-mode[data-draft-state="saved"]:not([data-dirty])::before {
+      opacity: .95;
+      transform: scale(.95);
+      background: #22c55e;
+      box-shadow: 0 0 0 3px color-mix(in srgb, #22c55e 20%, transparent);
+    }
+    .mode-tab.dynamic-mode[data-draft-state="conflict"]::before {
+      opacity: 1;
+      transform: scale(1);
+      background: #ef4444;
+      box-shadow: 0 0 0 3px color-mix(in srgb, #ef4444 25%, transparent);
+    }
     .mode-tab.dynamic-mode.is-busy {
       pointer-events: none;
     }
@@ -216,11 +246,20 @@
     .editor-sidebar .search input:focus { outline: none; box-shadow: 0 0 0 .12rem color-mix(in srgb, var(--primary) 35%, transparent); border-color: color-mix(in srgb, var(--primary) 45%, var(--border)); }
     .editor-sidebar .status { margin-top: .4rem; font-size: .78rem; color: var(--muted); }
     .editor-sidebar .lists { display: block; }
-    .current-file { color: var(--muted); font-size: .85rem; margin-left: .5rem; }
-    .current-file[data-file-state="checking"] { color: color-mix(in srgb, #2563eb 70%, var(--text)); }
-    .current-file[data-file-state="existing"] { color: color-mix(in srgb, #15803d 70%, var(--text)); }
-    .current-file[data-file-state="missing"] { color: color-mix(in srgb, #d97706 75%, var(--text)); }
-    .current-file[data-file-state="error"] { color: color-mix(in srgb, #dc2626 80%, var(--text)); }
+    .current-file { color: var(--muted); font-size: .85rem; margin-left: .5rem; display: flex; flex-direction: column; gap: .18rem; min-width: 0; }
+    .current-file .cf-line-main { font-weight: 600; color: color-mix(in srgb, var(--text) 65%, transparent); font-size: .9rem; display: inline-flex; align-items: center; gap: .4rem; min-width: 0; }
+    .current-file .cf-line-main .cf-path { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .current-file .cf-line-meta { font-size: .78rem; color: color-mix(in srgb, var(--muted) 88%, transparent); display: inline-flex; gap: .35rem; flex-wrap: wrap; }
+    .current-file .cf-draft { display: inline-flex; align-items: center; gap: .35rem; font-weight: 500; color: color-mix(in srgb, #2563eb 70%, var(--text)); }
+    .current-file .cf-draft::before { content: ''; width: .45rem; height: .45rem; border-radius: 999px; background: #22c55e; box-shadow: 0 0 0 3px color-mix(in srgb, #22c55e 18%, transparent); }
+    .current-file[data-draft-state="conflict"] .cf-draft { color: color-mix(in srgb, #ef4444 75%, var(--text)); }
+    .current-file[data-draft-state="conflict"] .cf-draft::before { background: #ef4444; box-shadow: 0 0 0 3px color-mix(in srgb, #ef4444 26%, transparent); }
+    .current-file[data-dirty="1"] .cf-draft::before { background: #f97316; box-shadow: 0 0 0 3px color-mix(in srgb, #f97316 26%, transparent); }
+    .current-file[data-file-state="checking"] .cf-line-main { color: color-mix(in srgb, #2563eb 70%, var(--text)); }
+    .current-file[data-file-state="existing"] .cf-line-main { color: color-mix(in srgb, #15803d 70%, var(--text)); }
+    .current-file[data-file-state="missing"] .cf-line-main { color: color-mix(in srgb, #d97706 75%, var(--text)); }
+    .current-file[data-file-state="error"] .cf-line-main { color: color-mix(in srgb, #dc2626 80%, var(--text)); }
+    .current-file[data-dirty="1"] .cf-line-main { color: color-mix(in srgb, #f97316 78%, var(--text)); }
     /* Grouped list styles */
     .editor-sidebar .file-group { border-bottom: 1px solid var(--border); }
     .editor-sidebar .file-group:last-child { border-bottom: 0; }
@@ -358,7 +397,8 @@
     .view-toggle .vt-btn { color:#0969da; text-decoration:none; padding:.1rem .25rem; border-radius:6px; position:relative; }
     .view-toggle .vt-btn:hover { text-decoration:underline; }
     .view-toggle .vt-btn.active { background:#eaeef2; color:#24292f; text-decoration:none; cursor:default; }
-    .view-toggle .vt-btn.has-draft::after { content:'●'; display:inline-block; font-size:.65rem; color:#f97316; margin-left:.3rem; line-height:1; }
+    .view-toggle .vt-btn.has-draft::before { content:'●'; display:inline-block; font-size:.65rem; color:#f97316; margin-right:.35rem; line-height:1; }
+    .view-toggle .vt-btn.has-draft { padding-left:.5rem; }
     .wrap-toggle { position:relative; display:inline-flex; align-items:center; gap:.4rem; font-size:.92rem; color:#57606a; cursor:pointer; user-select:none; }
     .wrap-toggle input { position:absolute; opacity:0; pointer-events:none; }
     .wrap-toggle .wrap-track { width:36px; height:20px; border-radius:999px; background:color-mix(in srgb, var(--muted) 28%, var(--card)); border:1px solid color-mix(in srgb, var(--muted) 30%, var(--border)); position:relative; transition:background-color .18s ease, border-color .18s ease; }


### PR DESCRIPTION
## Summary
- persist markdown editor tabs to local storage and restore drafts, including conflict awareness
- display unsaved state and potential conflicts directly on markdown tab buttons and prompt before closing
- expose draft status details in the current file indicator for better context

## Testing
- not run (not specified)


------
https://chatgpt.com/codex/tasks/task_e_68cf8ae87bfc83288c76e234d35150b4