### PR TITLE
Fix markdown editor status after canceled GitHub create

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -593,6 +593,10 @@ function startMarkdownSyncWatcher(tab, options = {}) {
     ? `Waiting for GitHub to create ${label}`
     : `Waiting for GitHub to update ${label}`;
 
+  const previousStatus = tab.fileStatus && typeof tab.fileStatus === 'object'
+    ? { ...tab.fileStatus }
+    : null;
+
   setDynamicTabStatus(tab, {
     state: 'checking',
     checkedAt: Date.now(),
@@ -651,8 +655,11 @@ function startMarkdownSyncWatcher(tab, options = {}) {
       updateMarkdownDiscardButton(tab);
     },
     onCancel: () => {
+      const fallbackStatus = (previousStatus && previousStatus.state)
+        ? previousStatus
+        : { state: isCreate ? 'missing' : 'existing' };
       setDynamicTabStatus(tab, {
-        state: 'existing',
+        ...fallbackStatus,
         checkedAt: Date.now(),
         message: 'Remote check canceled'
       });


### PR DESCRIPTION
## Summary
- preserve the previous remote status before starting the GitHub sync watcher
- restore the saved status when the watcher is canceled instead of forcing "existing"
- keep the button label aligned with the restored status so missing files stay marked as new

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d170648ea08328b73a8751d692635c