### PR TITLE
Keep remote status node height independent

### DIFF
--- a/index_editor.html
+++ b/index_editor.html
@@ -313,6 +313,12 @@
       min-width:0;
       position:relative;
     }
+    @media (min-width: 521px) {
+      .global-status .gs-node-remote,
+      .global-status .gs-arrow {
+        align-self:center;
+      }
+    }
     .global-status .gs-node::after { content:''; position:absolute; inset:0; border-radius:inherit; pointer-events:none; transition: box-shadow .18s ease, border-color .18s ease; border:2px solid transparent; }
     .global-status .gs-node-header { display:flex; align-items:center; gap:.55rem; width:100%; }
     .global-status .gs-node-icon { width:24px; height:24px; flex:0 0 auto; color: color-mix(in srgb, var(--muted) 70%, transparent); }


### PR DESCRIPTION
## Summary
- ensure the remote global status node is vertically centered without stretching with the local node
- center the connecting arrow when the wide layout is active so the pointer continues to align with the remote node

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d247683b608328bb010413e965a160