### PR TITLE
Remove unload warning from editor

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -1426,12 +1426,11 @@ function handleBeforeUnload(event) {
   try {
     dynamicEditorTabs.forEach(tab => { flushMarkdownDraft(tab); });
   } catch (_) {}
-  if (hasUnsavedComposerChanges() || hasUnsavedMarkdownDrafts()) {
-    try {
-      event.preventDefault();
-    } catch (_) {}
-    event.returnValue = '';
-  }
+  // Previously we attempted to warn users about unsaved changes. The editor now
+  // performs automatic saving, so the confirmation dialog is no longer needed.
+  // Keep flushing drafts but avoid setting `event.returnValue`, which would
+  // trigger the browser prompt.
+  void event;
 }
 
 try {


### PR DESCRIPTION
## Summary
- stop setting the beforeunload return value in the editor script so the browser does not show a confirmation dialog
- retain draft flushing logic while leaving the automatic saves intact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d28f4419648328bb1e3fe609a14ac7