### PR TITLE
Add GitHub commit flow to editor bubble

### DIFF
--- a/index_editor.html
+++ b/index_editor.html
@@ -477,6 +477,18 @@
       background: color-mix(in srgb, var(--card) 92%, transparent);
       border:1px solid color-mix(in srgb, var(--border) 70%, transparent);
       box-shadow:0 6px 18px rgba(15, 23, 42, 0.08);
+      cursor: pointer;
+      user-select: none;
+      transition: background-color .18s ease, color .18s ease, border-color .18s ease, box-shadow .18s ease;
+    }
+    .global-status .gs-arrow-bubble:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--primary) 62%, transparent);
+      outline-offset: 2px;
+    }
+    .global-status .gs-arrow-bubble.is-busy {
+      cursor: progress;
+      opacity: .75;
+      box-shadow:0 4px 14px rgba(15, 23, 42, 0.12);
     }
     .global-status[data-dirty="1"] .gs-node-local::after { box-shadow:0 0 0 2px color-mix(in srgb, #f97316 26%, transparent); border-color:color-mix(in srgb, #f97316 44%, transparent); }
     .global-status[data-state="warn"] .gs-node-remote::after { box-shadow:0 0 0 2px color-mix(in srgb, #f59e0b 24%, transparent); border-color:color-mix(in srgb, #f59e0b 42%, transparent); }


### PR DESCRIPTION
## Summary
- make the global status bubble interactive and show busy styling
- prompt for a cached fine-grained PAT and commit unsynced content via GitHub's GraphQL API
- reuse the sync overlay to wait for remote files to update after committing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2cf8a1864832887466b046e8b7981