### PR TITLE
Add inline composer order preview sidebar

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -4201,6 +4201,8 @@ function ensureComposerOrderPreview(kind) {
   const root = host.querySelector('.composer-order-inline');
   if (!root) return null;
 
+  const meta = host.querySelector('.composer-order-meta');
+
   let svg = host.querySelector('svg.composer-order-inline-lines');
   if (!svg) {
     svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
@@ -4209,12 +4211,12 @@ function ensureComposerOrderPreview(kind) {
     host.appendChild(svg);
   }
 
-  const statsWrap = root.querySelector('.composer-order-inline-stats');
+  const statsWrap = host.querySelector('.composer-order-inline-stats');
   const list = root.querySelector('.composer-order-inline-list');
   const emptyNotice = root.querySelector('.composer-order-inline-empty');
-  const kindLabel = root.querySelector('.composer-order-inline-kind');
-  const title = root.querySelector('.composer-order-inline-title');
-  const openBtn = root.querySelector('.composer-order-inline-open');
+  const kindLabel = host.querySelector('.composer-order-inline-kind');
+  const title = host.querySelector('.composer-order-inline-title');
+  const openBtn = host.querySelector('.composer-order-inline-open');
 
   if (openBtn && !openBtn.__nsBound) {
     openBtn.__nsBound = true;
@@ -4246,7 +4248,7 @@ function ensureComposerOrderPreview(kind) {
     try { window.addEventListener('resize', composerOrderPreviewResizeHandler); } catch (_) {}
   }
 
-  const preview = { host, root, list, statsWrap, emptyNotice, svg, kindLabel, openBtn, title };
+  const preview = { host, root, meta, list, statsWrap, emptyNotice, svg, kindLabel, openBtn, title };
   composerOrderPreviewElements[normalized] = preview;
   return preview;
 }
@@ -4257,7 +4259,7 @@ function updateComposerOrderPreview(kind, options = {}) {
   if (!preview) return;
   composerOrderPreviewActiveKind = normalized;
 
-  const { host, root, list, statsWrap, emptyNotice, svg, kindLabel, openBtn, title } = preview;
+  const { host, root, meta, list, statsWrap, emptyNotice, svg, kindLabel, openBtn, title } = preview;
   const label = normalized === 'tabs' ? 'tabs.yaml' : 'index.yaml';
 
   if (title) title.textContent = 'Old order';
@@ -4332,6 +4334,10 @@ function updateComposerOrderPreview(kind, options = {}) {
       root.setAttribute('aria-hidden', 'true');
       root.dataset.state = 'clean';
     }
+    if (meta) {
+      meta.hidden = true;
+      meta.setAttribute('aria-hidden', 'true');
+    }
     if (host) host.dataset.state = 'clean';
     if (svg) svg.style.display = 'none';
     composerOrderPreviewState[normalized] = null;
@@ -4342,6 +4348,10 @@ function updateComposerOrderPreview(kind, options = {}) {
     if (options.reveal !== false) root.hidden = false;
     root.setAttribute('aria-hidden', root.hidden ? 'true' : 'false');
     root.dataset.state = hasChanges ? 'changed' : 'clean';
+  }
+  if (meta) {
+    if (options.reveal !== false) meta.hidden = false;
+    meta.setAttribute('aria-hidden', meta.hidden ? 'true' : 'false');
   }
   if (host) host.dataset.state = hasChanges ? 'changed' : 'clean';
 

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -3486,7 +3486,9 @@ function buildOrderDiffItem(entry, side) {
 
   const keyEl = document.createElement('span');
   keyEl.className = 'composer-order-key';
-  keyEl.textContent = entry.key || '(empty)';
+  const keyText = entry.key || '(empty)';
+  keyEl.textContent = keyText;
+  keyEl.title = keyText;
   item.appendChild(keyEl);
 
   const badgeEl = document.createElement('span');

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -4227,8 +4227,6 @@ function ensureComposerOrderPreview(kind) {
   const root = host.querySelector('.composer-order-inline');
   if (!root) return null;
 
-  const footer = root.querySelector('.composer-order-inline-footer');
-
   let svg = host.querySelector('svg.composer-order-inline-lines');
   if (!svg) {
     svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
@@ -4237,12 +4235,13 @@ function ensureComposerOrderPreview(kind) {
     host.appendChild(svg);
   }
 
-  const statsWrap = root.querySelector('.composer-order-inline-stats');
+  const meta = document.getElementById('composerOrderInlineMeta');
+  const statsWrap = meta ? meta.querySelector('.composer-order-inline-stats') : null;
   const list = root.querySelector('.composer-order-inline-list');
   const emptyNotice = root.querySelector('.composer-order-inline-empty');
-  const kindLabel = root.querySelector('.composer-order-inline-kind');
-  const title = root.querySelector('.composer-order-inline-title');
-  const openBtn = root.querySelector('.composer-order-inline-open');
+  const kindLabel = meta ? meta.querySelector('.composer-order-inline-kind') : null;
+  const title = meta ? meta.querySelector('.composer-order-inline-title') : null;
+  const openBtn = meta ? meta.querySelector('.composer-order-inline-open') : null;
 
   if (openBtn && !openBtn.__nsBound) {
     openBtn.__nsBound = true;
@@ -4274,7 +4273,7 @@ function ensureComposerOrderPreview(kind) {
     try { window.addEventListener('resize', composerOrderPreviewResizeHandler); } catch (_) {}
   }
 
-  const preview = { host, root, footer, list, statsWrap, emptyNotice, svg, kindLabel, openBtn, title };
+  const preview = { host, root, list, statsWrap, emptyNotice, svg, kindLabel, openBtn, title, meta };
   composerOrderPreviewElements[normalized] = preview;
   return preview;
 }
@@ -4285,11 +4284,12 @@ function updateComposerOrderPreview(kind, options = {}) {
   if (!preview) return;
   composerOrderPreviewActiveKind = normalized;
 
-  const { host, root, footer, list, statsWrap, emptyNotice, svg, kindLabel, openBtn, title } = preview;
+  const { host, root, list, statsWrap, emptyNotice, svg, kindLabel, openBtn, title, meta } = preview;
   const label = normalized === 'tabs' ? 'tabs.yaml' : 'index.yaml';
 
   if (title) title.textContent = 'Old order';
   if (kindLabel) kindLabel.textContent = label;
+  if (meta) meta.dataset.kind = normalized;
   if (root) {
     root.dataset.kind = normalized;
     root.setAttribute('aria-label', `Old order for ${label}`);
@@ -4360,9 +4360,9 @@ function updateComposerOrderPreview(kind, options = {}) {
       root.setAttribute('aria-hidden', 'true');
       root.dataset.state = 'clean';
     }
-    if (footer) {
-      footer.hidden = true;
-      footer.setAttribute('aria-hidden', 'true');
+    if (meta) {
+      meta.hidden = true;
+      meta.setAttribute('aria-hidden', 'true');
     }
     if (host) host.dataset.state = 'clean';
     if (svg) svg.style.display = 'none';
@@ -4375,9 +4375,9 @@ function updateComposerOrderPreview(kind, options = {}) {
     root.setAttribute('aria-hidden', root.hidden ? 'true' : 'false');
     root.dataset.state = hasChanges ? 'changed' : 'clean';
   }
-  if (footer) {
-    if (options.reveal !== false) footer.hidden = false;
-    footer.setAttribute('aria-hidden', footer.hidden ? 'true' : 'false');
+  if (meta) {
+    if (options.reveal !== false) meta.hidden = false;
+    meta.setAttribute('aria-hidden', meta.hidden ? 'true' : 'false');
   }
   if (host) host.dataset.state = hasChanges ? 'changed' : 'clean';
 

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -4147,6 +4147,16 @@ function drawOrderDiffLines(state) {
   if (!ctx) return;
   const { container, svg, connectors, leftMap, rightMap } = ctx;
   if (!container || !svg) return;
+
+  if (leftMap && typeof leftMap.forEach === 'function') {
+    leftMap.forEach(el => {
+      if (!el || !el.style) return;
+      el.style.removeProperty('min-height');
+      el.style.removeProperty('margin-top');
+      el.style.removeProperty('margin-bottom');
+    });
+  }
+
   const rect = container.getBoundingClientRect();
   const width = container.clientWidth;
   const height = Math.max(container.scrollHeight, rect.height);
@@ -4159,13 +4169,27 @@ function drawOrderDiffLines(state) {
   const offsetY = rect.top;
   const scrollTop = container.scrollTop || 0;
 
+  const segments = Array.isArray(connectors) ? connectors : [];
   let movedIdx = 0;
-  connectors.forEach(info => {
+  segments.forEach(info => {
     const leftEl = leftMap.get(info.key);
     const rightEl = rightMap.get(info.key);
     if (!leftEl || !rightEl) return;
+    const rightRect = rightEl.getBoundingClientRect();
+    const cs = (typeof window !== 'undefined' && window.getComputedStyle)
+      ? window.getComputedStyle(rightEl)
+      : null;
+    if (leftEl.style) {
+      if (rightRect && rightRect.height) {
+        leftEl.style.minHeight = Math.max(rightRect.height, 0) + 'px';
+      }
+      if (cs) {
+        leftEl.style.marginTop = cs.marginTop;
+        leftEl.style.marginBottom = cs.marginBottom;
+      }
+    }
     const lRect = leftEl.getBoundingClientRect();
-    const rRect = rightEl.getBoundingClientRect();
+    const rRect = rightRect;
     let startX = (lRect.right - offsetX);
     const startY = (lRect.top - offsetY) + (lRect.height / 2) + scrollTop;
     let endX = (rRect.left - offsetX);

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -4227,7 +4227,7 @@ function ensureComposerOrderPreview(kind) {
   const root = host.querySelector('.composer-order-inline');
   if (!root) return null;
 
-  const meta = host.querySelector('.composer-order-meta');
+  const footer = root.querySelector('.composer-order-inline-footer');
 
   let svg = host.querySelector('svg.composer-order-inline-lines');
   if (!svg) {
@@ -4237,12 +4237,12 @@ function ensureComposerOrderPreview(kind) {
     host.appendChild(svg);
   }
 
-  const statsWrap = host.querySelector('.composer-order-inline-stats');
+  const statsWrap = root.querySelector('.composer-order-inline-stats');
   const list = root.querySelector('.composer-order-inline-list');
   const emptyNotice = root.querySelector('.composer-order-inline-empty');
-  const kindLabel = host.querySelector('.composer-order-inline-kind');
-  const title = host.querySelector('.composer-order-inline-title');
-  const openBtn = host.querySelector('.composer-order-inline-open');
+  const kindLabel = root.querySelector('.composer-order-inline-kind');
+  const title = root.querySelector('.composer-order-inline-title');
+  const openBtn = root.querySelector('.composer-order-inline-open');
 
   if (openBtn && !openBtn.__nsBound) {
     openBtn.__nsBound = true;
@@ -4274,7 +4274,7 @@ function ensureComposerOrderPreview(kind) {
     try { window.addEventListener('resize', composerOrderPreviewResizeHandler); } catch (_) {}
   }
 
-  const preview = { host, root, meta, list, statsWrap, emptyNotice, svg, kindLabel, openBtn, title };
+  const preview = { host, root, footer, list, statsWrap, emptyNotice, svg, kindLabel, openBtn, title };
   composerOrderPreviewElements[normalized] = preview;
   return preview;
 }
@@ -4285,7 +4285,7 @@ function updateComposerOrderPreview(kind, options = {}) {
   if (!preview) return;
   composerOrderPreviewActiveKind = normalized;
 
-  const { host, root, meta, list, statsWrap, emptyNotice, svg, kindLabel, openBtn, title } = preview;
+  const { host, root, footer, list, statsWrap, emptyNotice, svg, kindLabel, openBtn, title } = preview;
   const label = normalized === 'tabs' ? 'tabs.yaml' : 'index.yaml';
 
   if (title) title.textContent = 'Old order';
@@ -4360,9 +4360,9 @@ function updateComposerOrderPreview(kind, options = {}) {
       root.setAttribute('aria-hidden', 'true');
       root.dataset.state = 'clean';
     }
-    if (meta) {
-      meta.hidden = true;
-      meta.setAttribute('aria-hidden', 'true');
+    if (footer) {
+      footer.hidden = true;
+      footer.setAttribute('aria-hidden', 'true');
     }
     if (host) host.dataset.state = 'clean';
     if (svg) svg.style.display = 'none';
@@ -4375,9 +4375,9 @@ function updateComposerOrderPreview(kind, options = {}) {
     root.setAttribute('aria-hidden', root.hidden ? 'true' : 'false');
     root.dataset.state = hasChanges ? 'changed' : 'clean';
   }
-  if (meta) {
-    if (options.reveal !== false) meta.hidden = false;
-    meta.setAttribute('aria-hidden', meta.hidden ? 'true' : 'false');
+  if (footer) {
+    if (options.reveal !== false) footer.hidden = false;
+    footer.setAttribute('aria-hidden', footer.hidden ? 'true' : 'false');
   }
   if (host) host.dataset.state = hasChanges ? 'changed' : 'clean';
 

--- a/index_editor.html
+++ b/index_editor.html
@@ -920,14 +920,14 @@
     .composer-order-host .composer-order-main { grid-area: main; position: relative; z-index: 2; min-width: 0; }
     .composer-order-inline { grid-area: inline; display: flex; flex-direction: column; gap: .6rem; position: relative; z-index: 2; min-height: 0; }
     .composer-order-inline[hidden] { display: none !important; }
-    .composer-order-inline-head { display: flex; align-items: center; justify-content: space-between; gap: .6rem; }
+    .composer-order-inline-meta { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: .6rem; margin-bottom: .4rem; }
+    .composer-order-inline-meta[hidden] { display: none !important; }
+    .composer-order-inline-meta-head { display: flex; flex-wrap: wrap; align-items: center; gap: .6rem; }
     .composer-order-inline-titles { display: flex; flex-direction: column; gap: .15rem; min-width: 0; }
     .composer-order-inline-title { margin: 0; font-size: .96rem; font-weight: 700; color: var(--text); }
     .composer-order-inline-kind { font-size: .76rem; text-transform: uppercase; letter-spacing: .08em; color: color-mix(in srgb, var(--text) 58%, transparent); }
     .composer-order-inline-stats { display: flex; flex-wrap: wrap; gap: .35rem; font-size: .78rem; color: var(--muted); }
     .composer-order-inline-body { display: flex; flex-direction: column; }
-    .composer-order-inline-footer { display: flex; flex-direction: column; gap: .4rem; margin-top: .35rem; }
-    .composer-order-inline-footer[hidden] { display: none !important; }
     .composer-order-inline-list { display: block; position: relative; z-index: 2; }
     .composer-order-inline-empty { font-size: .85rem; color: var(--muted); border: 1px dashed color-mix(in srgb, var(--border) 85%, transparent); border-radius: 8px; padding: .75rem; text-align: center; }
     .composer-order-inline-lines { position: absolute; inset: 0; pointer-events: none; z-index: 1; }
@@ -1130,6 +1130,17 @@
             <button class="btn-secondary" id="btnReview" type="button" hidden aria-hidden="true">Review</button>
           </div>
         </div>
+        <div class="composer-order-inline-meta" id="composerOrderInlineMeta" hidden>
+          <div class="composer-order-inline-meta-head">
+            <div class="composer-order-inline-titles">
+              <h3 class="composer-order-inline-title">Old order</h3>
+              <span class="composer-order-inline-kind">index.yaml</span>
+            </div>
+            <button type="button" class="btn-secondary btn-compact composer-order-inline-open" data-kind="index" aria-label="Open detailed order diff">Details</button>
+          </div>
+          <div class="composer-order-inline-stats" aria-live="polite"></div>
+        </div>
+
         <!-- Composer Lists -->
         <div class="composer-panels" id="composerPanels">
           <div class="composer-order-host" data-kind="index" id="composerIndexHost">
@@ -1137,16 +1148,6 @@
               <div class="composer-order-inline-body">
                 <div class="composer-order-inline-list" role="list"></div>
                 <div class="composer-order-inline-empty" aria-hidden="false">No entries to compare yet.</div>
-              </div>
-              <div class="composer-order-inline-footer" hidden>
-                <div class="composer-order-inline-head">
-                  <div class="composer-order-inline-titles">
-                    <h3 class="composer-order-inline-title">Old order</h3>
-                    <span class="composer-order-inline-kind">index.yaml</span>
-                  </div>
-                  <button type="button" class="btn-secondary btn-compact composer-order-inline-open" data-kind="index" aria-label="Open detailed order diff">Details</button>
-                </div>
-                <div class="composer-order-inline-stats" aria-live="polite"></div>
               </div>
             </div>
             <div class="composer-order-main">
@@ -1158,16 +1159,6 @@
               <div class="composer-order-inline-body">
                 <div class="composer-order-inline-list" role="list"></div>
                 <div class="composer-order-inline-empty" aria-hidden="false">No entries to compare yet.</div>
-              </div>
-              <div class="composer-order-inline-footer" hidden>
-                <div class="composer-order-inline-head">
-                  <div class="composer-order-inline-titles">
-                    <h3 class="composer-order-inline-title">Old order</h3>
-                    <span class="composer-order-inline-kind">tabs.yaml</span>
-                  </div>
-                  <button type="button" class="btn-secondary btn-compact composer-order-inline-open" data-kind="tabs" aria-label="Open detailed order diff">Details</button>
-                </div>
-                <div class="composer-order-inline-stats" aria-live="polite"></div>
               </div>
             </div>
             <div class="composer-order-main">

--- a/index_editor.html
+++ b/index_editor.html
@@ -915,7 +915,7 @@
       grid-template-areas:
         "meta meta"
         "inline main";
-      column-gap: clamp(1.4rem, 4vw, 2.4rem);
+      column-gap: clamp(2rem, 5vw, 3.2rem);
       row-gap: .7rem;
       align-items: start;
       min-width: 0;
@@ -931,7 +931,7 @@
     .composer-order-inline-kind { font-size: .76rem; text-transform: uppercase; letter-spacing: .08em; color: color-mix(in srgb, var(--text) 58%, transparent); }
     .composer-order-inline-stats { display: flex; flex-wrap: wrap; gap: .35rem; font-size: .78rem; color: var(--muted); }
     .composer-order-inline-body { display: flex; flex-direction: column; }
-    .composer-order-inline-list { display: flex; flex-direction: column; gap: 0; position: relative; z-index: 2; }
+    .composer-order-inline-list { display: block; position: relative; z-index: 2; }
     .composer-order-inline-empty { font-size: .85rem; color: var(--muted); border: 1px dashed color-mix(in srgb, var(--border) 85%, transparent); border-radius: 8px; padding: .75rem; text-align: center; }
     .composer-order-inline-lines { position: absolute; inset: 0; pointer-events: none; z-index: 1; }
     .composer-order-host[data-state="clean"] { grid-template-columns: minmax(0, 1fr); grid-template-areas: "main"; column-gap: 0; }

--- a/index_editor.html
+++ b/index_editor.html
@@ -906,31 +906,34 @@
       body { padding: .75rem; }
     }
 
-    .composer-split { display: grid; gap: 1rem; grid-template-columns: minmax(0, 1fr); align-items: start; }
-    .composer-split.has-preview { grid-template-columns: clamp(220px, 24vw, 280px) minmax(0, 1fr); }
-    .composer-panels { min-width: 0; }
-    .composer-order-preview { border: 1px solid var(--border); border-radius: 12px; background: var(--card); padding: .85rem .9rem 1rem; display: flex; flex-direction: column; gap: .6rem; position: relative; min-height: 0; box-shadow: 0 6px 16px rgba(15, 23, 42, 0.06); }
-    .composer-order-preview[hidden] { display: none !important; }
-    .composer-order-preview[data-state="changed"] { border-color: color-mix(in srgb, var(--primary) 36%, var(--border)); box-shadow: 0 10px 26px rgba(37,99,235,0.12); }
-    .composer-order-preview-head { display: flex; align-items: center; justify-content: space-between; gap: .5rem; }
-    .composer-order-preview-titles { display: flex; flex-direction: column; gap: .1rem; min-width: 0; }
-    .composer-order-preview-title { margin: 0; font-size: .98rem; font-weight: 700; color: var(--text); }
-    .composer-order-preview-kind { font-size: .78rem; text-transform: uppercase; letter-spacing: .08em; color: color-mix(in srgb, var(--text) 58%, transparent); }
-    .composer-order-preview-stats { font-size: .82rem; }
-    .composer-order-preview .composer-order-visual { padding: .4rem 1.8rem 1.25rem; }
-    .composer-order-preview .composer-order-columns { gap: clamp(1.6rem, 4vw, 2.6rem); }
-    .composer-order-preview .composer-order-column-title { font-size: .76rem; }
-    .composer-order-preview .composer-order-list { gap: .35rem; }
-    .composer-order-preview .composer-order-item { gap: .45rem; padding: .32rem .5rem; }
-    .composer-order-preview .composer-order-index { min-width: 1.8rem; font-size: .78rem; }
-    .composer-order-preview .composer-order-key { font-size: .83rem; }
-    .composer-order-preview .composer-order-badge { font-size: .72rem; }
-    .composer-order-preview .composer-order-empty { font-size: .85rem; padding: .8rem; }
-    .composer-order-preview .composer-order-lines { inset: 0; }
-    .composer-order-preview button.btn-secondary { align-self: flex-start; }
+    .composer-panels { min-width: 0; display: grid; gap: 1.25rem; }
+    .composer-order-host { position: relative; display: grid; grid-template-columns: clamp(150px, 24%, 220px) minmax(0, 1fr); gap: 1rem; align-items: start; min-width: 0; }
+    .composer-order-host .composer-order-main { position: relative; z-index: 2; min-width: 0; }
+    .composer-order-inline { border: 1px solid var(--border); border-radius: 12px; background: var(--card); padding: .85rem .9rem 1rem; display: flex; flex-direction: column; gap: .65rem; position: relative; z-index: 2; box-shadow: 0 6px 16px rgba(15, 23, 42, 0.06); min-height: 0; }
+    .composer-order-inline[hidden] { display: none !important; }
+    .composer-order-inline[data-state="changed"] { border-color: color-mix(in srgb, var(--primary) 36%, var(--border)); box-shadow: 0 10px 26px rgba(37,99,235,0.12); }
+    .composer-order-inline-head { display: flex; align-items: center; justify-content: space-between; gap: .6rem; }
+    .composer-order-inline-titles { display: flex; flex-direction: column; gap: .15rem; min-width: 0; }
+    .composer-order-inline-title { margin: 0; font-size: .96rem; font-weight: 700; color: var(--text); }
+    .composer-order-inline-kind { font-size: .76rem; text-transform: uppercase; letter-spacing: .08em; color: color-mix(in srgb, var(--text) 58%, transparent); }
+    .composer-order-inline-stats { display: flex; flex-wrap: wrap; gap: .35rem; font-size: .78rem; color: var(--muted); }
+    .composer-order-inline-body { display: flex; flex-direction: column; gap: .45rem; }
+    .composer-order-inline-list { display: flex; flex-direction: column; gap: .35rem; position: relative; z-index: 2; }
+    .composer-order-inline-empty { font-size: .85rem; color: var(--muted); border: 1px dashed color-mix(in srgb, var(--border) 85%, transparent); border-radius: 8px; padding: .75rem; text-align: center; }
+    .composer-order-inline-lines { position: absolute; inset: 0; pointer-events: none; z-index: 1; }
+    .composer-order-host[data-state="clean"] { grid-template-columns: minmax(0, 1fr); }
+    .composer-order-host[data-state="clean"] .composer-order-inline { border-style: dashed; box-shadow: none; }
+    .composer-order-host[data-state="clean"] .composer-order-inline-lines { display: none; }
+    .composer-order-inline button.btn-secondary { align-self: flex-start; }
+    .composer-order-inline .composer-order-item { gap: .4rem; padding: .32rem .5rem; }
+    .composer-order-inline .composer-order-index { min-width: 1.7rem; font-size: .78rem; }
+    .composer-order-inline .composer-order-key { font-size: .84rem; }
+    .composer-order-inline .composer-order-badge { font-size: .7rem; }
     @media (max-width: 900px) {
-      .composer-split.has-preview { grid-template-columns: 1fr; }
-      .composer-order-preview { order: -1; }
+      .composer-panels { gap: 1rem; }
+      .composer-order-host { grid-template-columns: minmax(0, 1fr); }
+      .composer-order-inline { order: -1; }
+      .composer-order-inline-lines { display: none; }
     }
 
     /* Back-to-top button */
@@ -1105,11 +1108,44 @@
           </div>
         </div>
         <!-- Composer Lists -->
-        <div class="composer-split" id="composerSplit">
-          <aside id="composerOrderPreview" class="composer-order-preview" aria-label="Order changes" hidden></aside>
-          <div class="composer-panels">
-            <div id="composerIndex" aria-label="index.yaml editor" style="display:block;"></div>
-            <div id="composerTabs" aria-label="tabs.yaml editor" style="display:none;"></div>
+        <div class="composer-panels" id="composerPanels">
+          <div class="composer-order-host" data-kind="index" id="composerIndexHost">
+            <div class="composer-order-inline" id="composerOrderInlineIndex" aria-label="Old order for index.yaml" hidden>
+              <div class="composer-order-inline-head">
+                <div class="composer-order-inline-titles">
+                  <h3 class="composer-order-inline-title">Old order</h3>
+                  <span class="composer-order-inline-kind">index.yaml</span>
+                </div>
+                <button type="button" class="btn-secondary btn-compact composer-order-inline-open" data-kind="index" aria-label="Open detailed order diff">Details</button>
+              </div>
+              <div class="composer-order-inline-stats" aria-live="polite"></div>
+              <div class="composer-order-inline-body">
+                <div class="composer-order-inline-list" role="list"></div>
+                <div class="composer-order-inline-empty" aria-hidden="false">No entries to compare yet.</div>
+              </div>
+            </div>
+            <div class="composer-order-main">
+              <div id="composerIndex" aria-label="index.yaml editor" style="display:block;"></div>
+            </div>
+          </div>
+          <div class="composer-order-host" data-kind="tabs" id="composerTabsHost" style="display:none;">
+            <div class="composer-order-inline" id="composerOrderInlineTabs" aria-label="Old order for tabs.yaml" hidden>
+              <div class="composer-order-inline-head">
+                <div class="composer-order-inline-titles">
+                  <h3 class="composer-order-inline-title">Old order</h3>
+                  <span class="composer-order-inline-kind">tabs.yaml</span>
+                </div>
+                <button type="button" class="btn-secondary btn-compact composer-order-inline-open" data-kind="tabs" aria-label="Open detailed order diff">Details</button>
+              </div>
+              <div class="composer-order-inline-stats" aria-live="polite"></div>
+              <div class="composer-order-inline-body">
+                <div class="composer-order-inline-list" role="list"></div>
+                <div class="composer-order-inline-empty" aria-hidden="false">No entries to compare yet.</div>
+              </div>
+            </div>
+            <div class="composer-order-main">
+              <div id="composerTabs" aria-label="tabs.yaml editor" style="display:none;"></div>
+            </div>
           </div>
         </div>
 

--- a/index_editor.html
+++ b/index_editor.html
@@ -907,9 +907,23 @@
     }
 
     .composer-panels { min-width: 0; display: grid; gap: 1.25rem; }
-    .composer-order-host { position: relative; display: grid; grid-template-columns: clamp(150px, 24%, 220px) minmax(0, 1fr); gap: 1rem; align-items: start; min-width: 0; }
-    .composer-order-host .composer-order-main { position: relative; z-index: 2; min-width: 0; }
-    .composer-order-inline { border: 1px solid var(--border); border-radius: 12px; background: var(--card); padding: .85rem .9rem 1rem; display: flex; flex-direction: column; gap: .65rem; position: relative; z-index: 2; box-shadow: 0 6px 16px rgba(15, 23, 42, 0.06); min-height: 0; }
+    .composer-order-host {
+      position: relative;
+      display: grid;
+      grid-template-columns: clamp(150px, 24%, 220px) minmax(0, 1fr);
+      grid-template-rows: auto minmax(0, 1fr);
+      grid-template-areas:
+        "meta meta"
+        "inline main";
+      column-gap: clamp(1.4rem, 4vw, 2.4rem);
+      row-gap: .7rem;
+      align-items: start;
+      min-width: 0;
+    }
+    .composer-order-host .composer-order-main { grid-area: main; position: relative; z-index: 2; min-width: 0; }
+    .composer-order-meta { grid-area: meta; display: flex; flex-direction: column; gap: .4rem; align-items: stretch; min-width: 0; }
+    .composer-order-meta[hidden] { display: none !important; }
+    .composer-order-inline { grid-area: inline; border: 1px solid var(--border); border-radius: 12px; background: var(--card); padding: .65rem .85rem .9rem; display: flex; flex-direction: column; gap: .45rem; position: relative; z-index: 2; box-shadow: 0 6px 16px rgba(15, 23, 42, 0.06); min-height: 0; }
     .composer-order-inline[hidden] { display: none !important; }
     .composer-order-inline[data-state="changed"] { border-color: color-mix(in srgb, var(--primary) 36%, var(--border)); box-shadow: 0 10px 26px rgba(37,99,235,0.12); }
     .composer-order-inline-head { display: flex; align-items: center; justify-content: space-between; gap: .6rem; }
@@ -921,18 +935,25 @@
     .composer-order-inline-list { display: flex; flex-direction: column; gap: .35rem; position: relative; z-index: 2; }
     .composer-order-inline-empty { font-size: .85rem; color: var(--muted); border: 1px dashed color-mix(in srgb, var(--border) 85%, transparent); border-radius: 8px; padding: .75rem; text-align: center; }
     .composer-order-inline-lines { position: absolute; inset: 0; pointer-events: none; z-index: 1; }
-    .composer-order-host[data-state="clean"] { grid-template-columns: minmax(0, 1fr); }
+    .composer-order-host[data-state="clean"] { grid-template-columns: minmax(0, 1fr); grid-template-areas: "main"; column-gap: 0; }
     .composer-order-host[data-state="clean"] .composer-order-inline { border-style: dashed; box-shadow: none; }
     .composer-order-host[data-state="clean"] .composer-order-inline-lines { display: none; }
-    .composer-order-inline button.btn-secondary { align-self: flex-start; }
+    .composer-order-meta .btn-secondary { align-self: flex-start; }
     .composer-order-inline .composer-order-item { gap: .4rem; padding: .32rem .5rem; }
     .composer-order-inline .composer-order-index { min-width: 1.7rem; font-size: .78rem; }
     .composer-order-inline .composer-order-key { font-size: .84rem; }
     .composer-order-inline .composer-order-badge { font-size: .7rem; }
     @media (max-width: 900px) {
       .composer-panels { gap: 1rem; }
-      .composer-order-host { grid-template-columns: minmax(0, 1fr); }
-      .composer-order-inline { order: -1; }
+      .composer-order-host {
+        grid-template-columns: minmax(0, 1fr);
+        grid-template-rows: auto auto minmax(0, 1fr);
+        grid-template-areas:
+          "meta"
+          "inline"
+          "main";
+        column-gap: 0;
+      }
       .composer-order-inline-lines { display: none; }
     }
 
@@ -1110,7 +1131,7 @@
         <!-- Composer Lists -->
         <div class="composer-panels" id="composerPanels">
           <div class="composer-order-host" data-kind="index" id="composerIndexHost">
-            <div class="composer-order-inline" id="composerOrderInlineIndex" aria-label="Old order for index.yaml" hidden>
+            <div class="composer-order-meta" hidden>
               <div class="composer-order-inline-head">
                 <div class="composer-order-inline-titles">
                   <h3 class="composer-order-inline-title">Old order</h3>
@@ -1119,6 +1140,8 @@
                 <button type="button" class="btn-secondary btn-compact composer-order-inline-open" data-kind="index" aria-label="Open detailed order diff">Details</button>
               </div>
               <div class="composer-order-inline-stats" aria-live="polite"></div>
+            </div>
+            <div class="composer-order-inline" id="composerOrderInlineIndex" aria-label="Old order for index.yaml" hidden>
               <div class="composer-order-inline-body">
                 <div class="composer-order-inline-list" role="list"></div>
                 <div class="composer-order-inline-empty" aria-hidden="false">No entries to compare yet.</div>
@@ -1129,7 +1152,7 @@
             </div>
           </div>
           <div class="composer-order-host" data-kind="tabs" id="composerTabsHost" style="display:none;">
-            <div class="composer-order-inline" id="composerOrderInlineTabs" aria-label="Old order for tabs.yaml" hidden>
+            <div class="composer-order-meta" hidden>
               <div class="composer-order-inline-head">
                 <div class="composer-order-inline-titles">
                   <h3 class="composer-order-inline-title">Old order</h3>
@@ -1138,6 +1161,8 @@
                 <button type="button" class="btn-secondary btn-compact composer-order-inline-open" data-kind="tabs" aria-label="Open detailed order diff">Details</button>
               </div>
               <div class="composer-order-inline-stats" aria-live="polite"></div>
+            </div>
+            <div class="composer-order-inline" id="composerOrderInlineTabs" aria-label="Old order for tabs.yaml" hidden>
               <div class="composer-order-inline-body">
                 <div class="composer-order-inline-list" role="list"></div>
                 <div class="composer-order-inline-empty" aria-hidden="false">No entries to compare yet.</div>

--- a/index_editor.html
+++ b/index_editor.html
@@ -906,6 +906,33 @@
       body { padding: .75rem; }
     }
 
+    .composer-split { display: grid; gap: 1rem; grid-template-columns: minmax(0, 1fr); align-items: start; }
+    .composer-split.has-preview { grid-template-columns: clamp(220px, 24vw, 280px) minmax(0, 1fr); }
+    .composer-panels { min-width: 0; }
+    .composer-order-preview { border: 1px solid var(--border); border-radius: 12px; background: var(--card); padding: .85rem .9rem 1rem; display: flex; flex-direction: column; gap: .6rem; position: relative; min-height: 0; box-shadow: 0 6px 16px rgba(15, 23, 42, 0.06); }
+    .composer-order-preview[hidden] { display: none !important; }
+    .composer-order-preview[data-state="changed"] { border-color: color-mix(in srgb, var(--primary) 36%, var(--border)); box-shadow: 0 10px 26px rgba(37,99,235,0.12); }
+    .composer-order-preview-head { display: flex; align-items: center; justify-content: space-between; gap: .5rem; }
+    .composer-order-preview-titles { display: flex; flex-direction: column; gap: .1rem; min-width: 0; }
+    .composer-order-preview-title { margin: 0; font-size: .98rem; font-weight: 700; color: var(--text); }
+    .composer-order-preview-kind { font-size: .78rem; text-transform: uppercase; letter-spacing: .08em; color: color-mix(in srgb, var(--text) 58%, transparent); }
+    .composer-order-preview-stats { font-size: .82rem; }
+    .composer-order-preview .composer-order-visual { padding: .4rem 1.8rem 1.25rem; }
+    .composer-order-preview .composer-order-columns { gap: clamp(1.6rem, 4vw, 2.6rem); }
+    .composer-order-preview .composer-order-column-title { font-size: .76rem; }
+    .composer-order-preview .composer-order-list { gap: .35rem; }
+    .composer-order-preview .composer-order-item { gap: .45rem; padding: .32rem .5rem; }
+    .composer-order-preview .composer-order-index { min-width: 1.8rem; font-size: .78rem; }
+    .composer-order-preview .composer-order-key { font-size: .83rem; }
+    .composer-order-preview .composer-order-badge { font-size: .72rem; }
+    .composer-order-preview .composer-order-empty { font-size: .85rem; padding: .8rem; }
+    .composer-order-preview .composer-order-lines { inset: 0; }
+    .composer-order-preview button.btn-secondary { align-self: flex-start; }
+    @media (max-width: 900px) {
+      .composer-split.has-preview { grid-template-columns: 1fr; }
+      .composer-order-preview { order: -1; }
+    }
+
     /* Back-to-top button */
     .back-to-top { position: fixed; right: 1rem; bottom: 1rem; width: 2.5rem; height: 2.5rem; border-radius: 999px; border: 1px solid var(--border); background: var(--card); color: var(--text); display: inline-flex; align-items: center; justify-content: center; box-shadow: var(--shadow); cursor: pointer; opacity: 0; transform: translateY(8px); pointer-events: none; transition: opacity .18s ease, transform .18s ease, background-color .18s ease; z-index: 999; }
     .back-to-top:hover { background: color-mix(in srgb, var(--text) 4%, var(--card)); }
@@ -1078,8 +1105,13 @@
           </div>
         </div>
         <!-- Composer Lists -->
-        <div id="composerIndex" aria-label="index.yaml editor" style="display:block;"></div>
-        <div id="composerTabs" aria-label="tabs.yaml editor" style="display:none;"></div>
+        <div class="composer-split" id="composerSplit">
+          <aside id="composerOrderPreview" class="composer-order-preview" aria-label="Order changes" hidden></aside>
+          <div class="composer-panels">
+            <div id="composerIndex" aria-label="index.yaml editor" style="display:block;"></div>
+            <div id="composerTabs" aria-label="tabs.yaml editor" style="display:none;"></div>
+          </div>
+        </div>
 
         <!-- YAML preview/export area -->
         <div id="yamlExportWrap" style="display:none; margin-top: .75rem;">

--- a/index_editor.html
+++ b/index_editor.html
@@ -923,23 +923,21 @@
     .composer-order-host .composer-order-main { grid-area: main; position: relative; z-index: 2; min-width: 0; }
     .composer-order-meta { grid-area: meta; display: flex; flex-direction: column; gap: .4rem; align-items: stretch; min-width: 0; }
     .composer-order-meta[hidden] { display: none !important; }
-    .composer-order-inline { grid-area: inline; border: 1px solid var(--border); border-radius: 12px; background: var(--card); padding: .65rem .85rem .9rem; display: flex; flex-direction: column; gap: .45rem; position: relative; z-index: 2; box-shadow: 0 6px 16px rgba(15, 23, 42, 0.06); min-height: 0; }
+    .composer-order-inline { grid-area: inline; display: flex; flex-direction: column; gap: .45rem; position: relative; z-index: 2; min-height: 0; }
     .composer-order-inline[hidden] { display: none !important; }
-    .composer-order-inline[data-state="changed"] { border-color: color-mix(in srgb, var(--primary) 36%, var(--border)); box-shadow: 0 10px 26px rgba(37,99,235,0.12); }
     .composer-order-inline-head { display: flex; align-items: center; justify-content: space-between; gap: .6rem; }
     .composer-order-inline-titles { display: flex; flex-direction: column; gap: .15rem; min-width: 0; }
     .composer-order-inline-title { margin: 0; font-size: .96rem; font-weight: 700; color: var(--text); }
     .composer-order-inline-kind { font-size: .76rem; text-transform: uppercase; letter-spacing: .08em; color: color-mix(in srgb, var(--text) 58%, transparent); }
     .composer-order-inline-stats { display: flex; flex-wrap: wrap; gap: .35rem; font-size: .78rem; color: var(--muted); }
-    .composer-order-inline-body { display: flex; flex-direction: column; gap: .45rem; }
-    .composer-order-inline-list { display: flex; flex-direction: column; gap: .35rem; position: relative; z-index: 2; }
+    .composer-order-inline-body { display: flex; flex-direction: column; }
+    .composer-order-inline-list { display: flex; flex-direction: column; gap: 0; position: relative; z-index: 2; }
     .composer-order-inline-empty { font-size: .85rem; color: var(--muted); border: 1px dashed color-mix(in srgb, var(--border) 85%, transparent); border-radius: 8px; padding: .75rem; text-align: center; }
     .composer-order-inline-lines { position: absolute; inset: 0; pointer-events: none; z-index: 1; }
     .composer-order-host[data-state="clean"] { grid-template-columns: minmax(0, 1fr); grid-template-areas: "main"; column-gap: 0; }
-    .composer-order-host[data-state="clean"] .composer-order-inline { border-style: dashed; box-shadow: none; }
     .composer-order-host[data-state="clean"] .composer-order-inline-lines { display: none; }
     .composer-order-meta .btn-secondary { align-self: flex-start; }
-    .composer-order-inline .composer-order-item { gap: .4rem; padding: .32rem .5rem; }
+    .composer-order-inline .composer-order-item { margin: .5rem 0; }
     .composer-order-inline .composer-order-index { min-width: 1.7rem; font-size: .78rem; }
     .composer-order-inline .composer-order-key { font-size: .84rem; }
     .composer-order-inline .composer-order-badge { font-size: .7rem; }

--- a/index_editor.html
+++ b/index_editor.html
@@ -939,7 +939,13 @@
     .composer-order-meta .btn-secondary { align-self: flex-start; }
     .composer-order-inline .composer-order-item { margin: .5rem 0; }
     .composer-order-inline .composer-order-index { min-width: 1.7rem; font-size: .78rem; }
-    .composer-order-inline .composer-order-key { font-size: .84rem; }
+    .composer-order-inline .composer-order-key {
+      font-size: .84rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      word-break: normal;
+    }
     .composer-order-inline .composer-order-badge { font-size: .7rem; }
     @media (max-width: 900px) {
       .composer-panels { gap: 1rem; }

--- a/index_editor.html
+++ b/index_editor.html
@@ -911,19 +911,14 @@
       position: relative;
       display: grid;
       grid-template-columns: clamp(150px, 24%, 220px) minmax(0, 1fr);
-      grid-template-rows: auto minmax(0, 1fr);
-      grid-template-areas:
-        "meta meta"
-        "inline main";
+      grid-template-rows: minmax(0, 1fr);
+      grid-template-areas: "inline main";
       column-gap: clamp(2rem, 5vw, 3.2rem);
-      row-gap: .7rem;
       align-items: start;
       min-width: 0;
     }
     .composer-order-host .composer-order-main { grid-area: main; position: relative; z-index: 2; min-width: 0; }
-    .composer-order-meta { grid-area: meta; display: flex; flex-direction: column; gap: .4rem; align-items: stretch; min-width: 0; }
-    .composer-order-meta[hidden] { display: none !important; }
-    .composer-order-inline { grid-area: inline; display: flex; flex-direction: column; gap: .45rem; position: relative; z-index: 2; min-height: 0; }
+    .composer-order-inline { grid-area: inline; display: flex; flex-direction: column; gap: .6rem; position: relative; z-index: 2; min-height: 0; }
     .composer-order-inline[hidden] { display: none !important; }
     .composer-order-inline-head { display: flex; align-items: center; justify-content: space-between; gap: .6rem; }
     .composer-order-inline-titles { display: flex; flex-direction: column; gap: .15rem; min-width: 0; }
@@ -931,12 +926,13 @@
     .composer-order-inline-kind { font-size: .76rem; text-transform: uppercase; letter-spacing: .08em; color: color-mix(in srgb, var(--text) 58%, transparent); }
     .composer-order-inline-stats { display: flex; flex-wrap: wrap; gap: .35rem; font-size: .78rem; color: var(--muted); }
     .composer-order-inline-body { display: flex; flex-direction: column; }
+    .composer-order-inline-footer { display: flex; flex-direction: column; gap: .4rem; margin-top: .35rem; }
+    .composer-order-inline-footer[hidden] { display: none !important; }
     .composer-order-inline-list { display: block; position: relative; z-index: 2; }
     .composer-order-inline-empty { font-size: .85rem; color: var(--muted); border: 1px dashed color-mix(in srgb, var(--border) 85%, transparent); border-radius: 8px; padding: .75rem; text-align: center; }
     .composer-order-inline-lines { position: absolute; inset: 0; pointer-events: none; z-index: 1; }
     .composer-order-host[data-state="clean"] { grid-template-columns: minmax(0, 1fr); grid-template-areas: "main"; column-gap: 0; }
     .composer-order-host[data-state="clean"] .composer-order-inline-lines { display: none; }
-    .composer-order-meta .btn-secondary { align-self: flex-start; }
     .composer-order-inline .composer-order-item { margin: .5rem 0; }
     .composer-order-inline .composer-order-index { min-width: 1.7rem; font-size: .78rem; }
     .composer-order-inline .composer-order-key {
@@ -954,9 +950,8 @@
       .composer-panels { gap: 1rem; }
       .composer-order-host {
         grid-template-columns: minmax(0, 1fr);
-        grid-template-rows: auto auto minmax(0, 1fr);
+        grid-template-rows: auto minmax(0, 1fr);
         grid-template-areas:
-          "meta"
           "inline"
           "main";
         column-gap: 0;
@@ -1138,20 +1133,20 @@
         <!-- Composer Lists -->
         <div class="composer-panels" id="composerPanels">
           <div class="composer-order-host" data-kind="index" id="composerIndexHost">
-            <div class="composer-order-meta" hidden>
-              <div class="composer-order-inline-head">
-                <div class="composer-order-inline-titles">
-                  <h3 class="composer-order-inline-title">Old order</h3>
-                  <span class="composer-order-inline-kind">index.yaml</span>
-                </div>
-                <button type="button" class="btn-secondary btn-compact composer-order-inline-open" data-kind="index" aria-label="Open detailed order diff">Details</button>
-              </div>
-              <div class="composer-order-inline-stats" aria-live="polite"></div>
-            </div>
             <div class="composer-order-inline" id="composerOrderInlineIndex" aria-label="Old order for index.yaml" hidden>
               <div class="composer-order-inline-body">
                 <div class="composer-order-inline-list" role="list"></div>
                 <div class="composer-order-inline-empty" aria-hidden="false">No entries to compare yet.</div>
+              </div>
+              <div class="composer-order-inline-footer" hidden>
+                <div class="composer-order-inline-head">
+                  <div class="composer-order-inline-titles">
+                    <h3 class="composer-order-inline-title">Old order</h3>
+                    <span class="composer-order-inline-kind">index.yaml</span>
+                  </div>
+                  <button type="button" class="btn-secondary btn-compact composer-order-inline-open" data-kind="index" aria-label="Open detailed order diff">Details</button>
+                </div>
+                <div class="composer-order-inline-stats" aria-live="polite"></div>
               </div>
             </div>
             <div class="composer-order-main">
@@ -1159,20 +1154,20 @@
             </div>
           </div>
           <div class="composer-order-host" data-kind="tabs" id="composerTabsHost" style="display:none;">
-            <div class="composer-order-meta" hidden>
-              <div class="composer-order-inline-head">
-                <div class="composer-order-inline-titles">
-                  <h3 class="composer-order-inline-title">Old order</h3>
-                  <span class="composer-order-inline-kind">tabs.yaml</span>
-                </div>
-                <button type="button" class="btn-secondary btn-compact composer-order-inline-open" data-kind="tabs" aria-label="Open detailed order diff">Details</button>
-              </div>
-              <div class="composer-order-inline-stats" aria-live="polite"></div>
-            </div>
             <div class="composer-order-inline" id="composerOrderInlineTabs" aria-label="Old order for tabs.yaml" hidden>
               <div class="composer-order-inline-body">
                 <div class="composer-order-inline-list" role="list"></div>
                 <div class="composer-order-inline-empty" aria-hidden="false">No entries to compare yet.</div>
+              </div>
+              <div class="composer-order-inline-footer" hidden>
+                <div class="composer-order-inline-head">
+                  <div class="composer-order-inline-titles">
+                    <h3 class="composer-order-inline-title">Old order</h3>
+                    <span class="composer-order-inline-kind">tabs.yaml</span>
+                  </div>
+                  <button type="button" class="btn-secondary btn-compact composer-order-inline-open" data-kind="tabs" aria-label="Open detailed order diff">Details</button>
+                </div>
+                <div class="composer-order-inline-stats" aria-live="polite"></div>
               </div>
             </div>
             <div class="composer-order-main">

--- a/index_editor.html
+++ b/index_editor.html
@@ -946,7 +946,10 @@
       text-overflow: ellipsis;
       word-break: normal;
     }
-    .composer-order-inline .composer-order-badge { font-size: .7rem; }
+    .composer-order-inline .composer-order-badge {
+      font-size: .7rem;
+      white-space: nowrap;
+    }
     @media (max-width: 900px) {
       .composer-panels { gap: 1rem; }
       .composer-order-host {


### PR DESCRIPTION
## Summary
- embed a dedicated order-change preview sidebar alongside the composer index/tabs editors
- render the inline order diff using the existing diff computation utilities and keep it in sync with state changes
- update composer layout styles so the new sidebar integrates cleanly on desktop and collapses on smaller screens

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d3748715508328aec333cc072900fb