### PR TITLE
feat: show composer change summary inline

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -3499,15 +3499,10 @@ function renderComposerInlineSummary(target, diff, options = {}) {
     return text;
   };
 
-  const withKeySummary = (keys, baseLabel) => {
-    const summaryText = formatKeyList(keys);
-    return summaryText ? `${baseLabel}: ${summaryText}` : baseLabel;
-  };
-
   const chips = [];
-  if (addedCount) chips.push({ variant: 'added', label: withKeySummary(summary.addedKeys, `+${addedCount} added`) });
-  if (removedCount) chips.push({ variant: 'removed', label: withKeySummary(summary.removedKeys, `-${removedCount} removed`) });
-  if (modifiedCount) chips.push({ variant: 'modified', label: withKeySummary(modifiedKeys, `~${modifiedCount} modified`) });
+  if (addedCount) chips.push({ variant: 'added', label: `+${addedCount} added` });
+  if (removedCount) chips.push({ variant: 'removed', label: `-${removedCount} removed` });
+  if (modifiedCount) chips.push({ variant: 'modified', label: `~${modifiedCount} modified` });
   if (orderChanged) {
     let orderLabel = 'Order changed';
     if (orderHasStats) {

--- a/index_editor.html
+++ b/index_editor.html
@@ -940,24 +940,15 @@
       font-size: .72rem;
       color: color-mix(in srgb, var(--text) 70%, transparent);
     }
-    .composer-inline-chip[data-variant="added"],
-    .composer-inline-detail[data-variant="added"] .composer-inline-detail-label { color: #166534; }
+    .composer-inline-chip[data-variant="added"] { color: #166534; }
     .composer-inline-chip[data-variant="added"] { border-color: color-mix(in srgb, #16a34a 55%, var(--border)); background: color-mix(in srgb, #16a34a 12%, transparent); }
-    .composer-inline-chip[data-variant="removed"],
-    .composer-inline-detail[data-variant="removed"] .composer-inline-detail-label { color: #b91c1c; }
+    .composer-inline-chip[data-variant="removed"] { color: #b91c1c; }
     .composer-inline-chip[data-variant="removed"] { border-color: color-mix(in srgb, #dc2626 55%, var(--border)); background: color-mix(in srgb, #dc2626 12%, transparent); }
-    .composer-inline-chip[data-variant="modified"],
-    .composer-inline-detail[data-variant="modified"] .composer-inline-detail-label { color: #1d4ed8; }
+    .composer-inline-chip[data-variant="modified"] { color: #1d4ed8; }
     .composer-inline-chip[data-variant="modified"] { border-color: color-mix(in srgb, #2563eb 55%, var(--border)); background: color-mix(in srgb, #2563eb 12%, transparent); }
-    .composer-inline-chip[data-variant="order"],
-    .composer-inline-detail[data-variant="order"] .composer-inline-detail-label { color: #7c3aed; }
+    .composer-inline-chip[data-variant="order"] { color: #7c3aed; }
     .composer-inline-chip[data-variant="order"] { border-color: color-mix(in srgb, #7c3aed 55%, var(--border)); background: color-mix(in srgb, #7c3aed 14%, transparent); }
-    .composer-inline-chip[data-variant="langs"],
-    .composer-inline-detail[data-variant="langs"] .composer-inline-detail-label { color: color-mix(in srgb, var(--text) 60%, transparent); }
-    .composer-inline-details { display: grid; gap: .25rem; }
-    .composer-inline-detail { display: flex; flex-wrap: wrap; gap: .35rem; align-items: baseline; font-size: .74rem; color: color-mix(in srgb, var(--muted) 88%, transparent); }
-    .composer-inline-detail-label { font-weight: 600; font-size: .75rem; color: color-mix(in srgb, var(--text) 80%, transparent); }
-    .composer-inline-detail-value { min-width: 0; word-break: break-word; }
+    .composer-inline-chip[data-variant="langs"] { color: color-mix(in srgb, var(--text) 60%, transparent); }
     .composer-inline-summary-empty { font-size: .78rem; color: var(--muted); }
     .composer-order-inline-body { display: flex; flex-direction: column; }
     .composer-order-inline-list { display: block; position: relative; z-index: 2; }

--- a/index_editor.html
+++ b/index_editor.html
@@ -926,7 +926,39 @@
     .composer-order-inline-titles { display: flex; flex-direction: column; gap: .15rem; min-width: 0; }
     .composer-order-inline-title { margin: 0; font-size: .96rem; font-weight: 700; color: var(--text); }
     .composer-order-inline-kind { font-size: .76rem; text-transform: uppercase; letter-spacing: .08em; color: color-mix(in srgb, var(--text) 58%, transparent); }
-    .composer-order-inline-stats { display: flex; flex-wrap: wrap; gap: .35rem; font-size: .78rem; color: var(--muted); }
+    .composer-order-inline-stats { display: flex; flex-direction: column; gap: .4rem; font-size: .78rem; color: var(--muted); }
+    .composer-inline-chip-row { display: flex; flex-wrap: wrap; gap: .35rem; }
+    .composer-inline-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: .3rem;
+      border-radius: 999px;
+      padding: .18rem .55rem;
+      border: 1px solid color-mix(in srgb, var(--text) 16%, var(--border));
+      background: color-mix(in srgb, var(--text) 4%, var(--card));
+      font-weight: 600;
+      font-size: .72rem;
+      color: color-mix(in srgb, var(--text) 70%, transparent);
+    }
+    .composer-inline-chip[data-variant="added"],
+    .composer-inline-detail[data-variant="added"] .composer-inline-detail-label { color: #166534; }
+    .composer-inline-chip[data-variant="added"] { border-color: color-mix(in srgb, #16a34a 55%, var(--border)); background: color-mix(in srgb, #16a34a 12%, transparent); }
+    .composer-inline-chip[data-variant="removed"],
+    .composer-inline-detail[data-variant="removed"] .composer-inline-detail-label { color: #b91c1c; }
+    .composer-inline-chip[data-variant="removed"] { border-color: color-mix(in srgb, #dc2626 55%, var(--border)); background: color-mix(in srgb, #dc2626 12%, transparent); }
+    .composer-inline-chip[data-variant="modified"],
+    .composer-inline-detail[data-variant="modified"] .composer-inline-detail-label { color: #1d4ed8; }
+    .composer-inline-chip[data-variant="modified"] { border-color: color-mix(in srgb, #2563eb 55%, var(--border)); background: color-mix(in srgb, #2563eb 12%, transparent); }
+    .composer-inline-chip[data-variant="order"],
+    .composer-inline-detail[data-variant="order"] .composer-inline-detail-label { color: #7c3aed; }
+    .composer-inline-chip[data-variant="order"] { border-color: color-mix(in srgb, #7c3aed 55%, var(--border)); background: color-mix(in srgb, #7c3aed 14%, transparent); }
+    .composer-inline-chip[data-variant="langs"],
+    .composer-inline-detail[data-variant="langs"] .composer-inline-detail-label { color: color-mix(in srgb, var(--text) 60%, transparent); }
+    .composer-inline-details { display: grid; gap: .25rem; }
+    .composer-inline-detail { display: flex; flex-wrap: wrap; gap: .35rem; align-items: baseline; font-size: .74rem; color: color-mix(in srgb, var(--muted) 88%, transparent); }
+    .composer-inline-detail-label { font-weight: 600; font-size: .75rem; color: color-mix(in srgb, var(--text) 80%, transparent); }
+    .composer-inline-detail-value { min-width: 0; word-break: break-word; }
+    .composer-inline-summary-empty { font-size: .78rem; color: var(--muted); }
     .composer-order-inline-body { display: flex; flex-direction: column; }
     .composer-order-inline-list { display: block; position: relative; z-index: 2; }
     .composer-order-inline-empty { font-size: .85rem; color: var(--muted); border: 1px dashed color-mix(in srgb, var(--border) 85%, transparent); border-radius: 8px; padding: .75rem; text-align: center; }
@@ -1133,10 +1165,10 @@
         <div class="composer-order-inline-meta" id="composerOrderInlineMeta" hidden>
           <div class="composer-order-inline-meta-head">
             <div class="composer-order-inline-titles">
-              <h3 class="composer-order-inline-title">Old order</h3>
+              <h3 class="composer-order-inline-title">Change summary</h3>
               <span class="composer-order-inline-kind">index.yaml</span>
             </div>
-            <button type="button" class="btn-secondary btn-compact composer-order-inline-open" data-kind="index" aria-label="Open detailed order diff">Details</button>
+            <button type="button" class="btn-secondary btn-compact composer-order-inline-open" data-kind="index" aria-label="Open change overview">Review changes</button>
           </div>
           <div class="composer-order-inline-stats" aria-live="polite"></div>
         </div>


### PR DESCRIPTION
## Summary
- restyle the composer inline meta area so it can display an aggregated change summary with chips and detail rows
- add a helper that builds the summary from the computed diff, update the order preview logic, and make the review button open the Overview tab

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d38f0843748328ad304744a1d0e79d