### PR TITLE
Fix editor badge after discarding last tab

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -1507,6 +1507,13 @@ function clearMarkdownDraftForTab(tab) {
   clearMarkdownDraftEntry(tab.path);
   tab.localDraft = null;
   tab.draftConflict = false;
+  tab.isDirty = false;
+  if (tab.button) {
+    try { tab.button.removeAttribute('data-dirty'); }
+    catch (_) {}
+    try { tab.button.removeAttribute('data-draft-state'); }
+    catch (_) {}
+  }
   updateComposerMarkdownDraftIndicators({ path: tab.path });
   try { updateUnsyncedSummary(); } catch (_) {}
 }


### PR DESCRIPTION
## Summary
- reset the markdown tab dirty state when its draft is cleared so pending change indicators update immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d42342992c8328a28dc595ec21cc33