### PR TITLE
Show empty state when no editor tab is open

### DIFF
--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -290,7 +290,34 @@ document.addEventListener('DOMContentLoaded', () => {
   const editor = createHiEditor(ta, 'markdown', false);
   const wrapToggle = document.getElementById('wrapToggle');
   const wrapToggleButtons = wrapToggle ? Array.from(wrapToggle.querySelectorAll('[data-wrap]')) : [];
+  const editorLayoutEl = document.getElementById('mode-editor');
+  const editorSidebarEl = editorLayoutEl ? editorLayoutEl.querySelector('.editor-sidebar') : null;
+  const editorMainEl = editorLayoutEl ? editorLayoutEl.querySelector('.editor-main') : null;
+  const editorEmptyStateEl = document.getElementById('editorEmptyState');
   let wrapEnabled = false;
+
+  const applyEditorEmptyState = (isEmpty) => {
+    const empty = !!isEmpty;
+    if (editorLayoutEl) editorLayoutEl.classList.toggle('is-empty', empty);
+    if (editorSidebarEl) {
+      if (empty) editorSidebarEl.setAttribute('hidden', '');
+      else editorSidebarEl.removeAttribute('hidden');
+    }
+    if (editorMainEl) {
+      if (empty) editorMainEl.setAttribute('hidden', '');
+      else editorMainEl.removeAttribute('hidden');
+    }
+    if (editorEmptyStateEl) {
+      if (empty) {
+        editorEmptyStateEl.removeAttribute('hidden');
+        editorEmptyStateEl.removeAttribute('aria-hidden');
+      } else {
+        editorEmptyStateEl.setAttribute('hidden', '');
+        editorEmptyStateEl.setAttribute('aria-hidden', 'true');
+      }
+    }
+  };
+  applyEditorEmptyState(true);
 
   const readWrapState = () => {
     try {
@@ -573,9 +600,10 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const renderCurrentFileIndicator = () => {
+    const path = currentFileInfo.path ? String(currentFileInfo.path) : '';
+    applyEditorEmptyState(!path);
     const el = ensureCurrentFileElement();
     if (!el) return;
-    const path = currentFileInfo.path ? String(currentFileInfo.path) : '';
     if (!path) {
       el.textContent = '';
       el.removeAttribute('data-file-state');

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -291,7 +291,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const wrapToggle = document.getElementById('wrapToggle');
   const wrapToggleButtons = wrapToggle ? Array.from(wrapToggle.querySelectorAll('[data-wrap]')) : [];
   const editorLayoutEl = document.getElementById('mode-editor');
-  const editorSidebarEl = editorLayoutEl ? editorLayoutEl.querySelector('.editor-sidebar') : null;
   const editorMainEl = editorLayoutEl ? editorLayoutEl.querySelector('.editor-main') : null;
   const editorEmptyStateEl = document.getElementById('editorEmptyState');
   let wrapEnabled = false;
@@ -299,10 +298,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const applyEditorEmptyState = (isEmpty) => {
     const empty = !!isEmpty;
     if (editorLayoutEl) editorLayoutEl.classList.toggle('is-empty', empty);
-    if (editorSidebarEl) {
-      if (empty) editorSidebarEl.setAttribute('hidden', '');
-      else editorSidebarEl.removeAttribute('hidden');
-    }
     if (editorMainEl) {
       if (empty) editorMainEl.setAttribute('hidden', '');
       else editorMainEl.removeAttribute('hidden');

--- a/index_editor.html
+++ b/index_editor.html
@@ -43,13 +43,13 @@
       .editor-layout { grid-template-columns: 1fr; }
     }
     .editor-layout.is-empty .editor-main { display: none; }
-    .editor-empty-state { display: none; grid-column: 1 / -1; min-height: clamp(320px, 60vh, 640px); align-items: center; justify-content: center; text-align: center; padding: 2.5rem 1.5rem; border-radius: 16px; border: 1px dashed color-mix(in srgb, var(--border) 80%, transparent); background: color-mix(in srgb, var(--card) 96%, transparent); color: var(--muted); }
+    .editor-empty-state { display: none; grid-column: 1 / -1; align-self: center; justify-self: center; align-items: center; justify-content: center; text-align: center; padding: clamp(1.75rem, 2vw + 1.2rem, 2.25rem) clamp(1.5rem, 2.8vw + 1rem, 2.75rem); border-radius: 14px; border: 1px dashed color-mix(in srgb, var(--border) 80%, transparent); background: color-mix(in srgb, var(--card) 96%, transparent); color: var(--muted); width: min(100%, 520px); box-shadow: 0 20px 36px rgba(15, 23, 42, 0.08); }
     .editor-layout.is-empty .editor-empty-state { display: flex; }
-    .editor-empty-state .empty-body { display: flex; flex-direction: column; gap: .75rem; align-items: center; justify-content: center; max-width: min(520px, 100%); }
+    .editor-empty-state .empty-body { display: flex; flex-direction: column; gap: .85rem; align-items: center; justify-content: center; }
     .editor-empty-state h2 { margin: 0; font-size: 1.4rem; font-weight: 700; color: var(--text); }
     .editor-empty-state p { margin: 0; font-size: 1rem; line-height: 1.6; }
     @media (max-width: 600px) {
-      .editor-empty-state { padding: 2rem 1.25rem; min-height: clamp(260px, 55vh, 520px); }
+      .editor-empty-state { padding: clamp(1.5rem, 6vw + .75rem, 1.9rem) clamp(1.25rem, 5vw + .85rem, 2.1rem); width: min(100%, 460px); }
       .editor-empty-state h2 { font-size: 1.25rem; }
       .editor-empty-state p { font-size: .95rem; }
     }

--- a/index_editor.html
+++ b/index_editor.html
@@ -1159,8 +1159,8 @@
 
       <div class="editor-empty-state" id="editorEmptyState" role="status" aria-live="polite">
         <div class="empty-body">
-          <h2>没有打开的编辑器</h2>
-          <p>从左侧选择一篇文章或 Tab 文件，或在 Composer 中打开要编辑的 Markdown 内容。</p>
+          <h2>No editor is currently open</h2>
+          <p>Select an article or tab from the left, or open Markdown from the Composer to start editing.</p>
         </div>
       </div>
     </div>

--- a/index_editor.html
+++ b/index_editor.html
@@ -35,15 +35,13 @@
     /* Widen the editor page and reduce side padding */
     body { padding: 0.75rem 1rem; max-width: min(95vw, 1200px); margin: 0 auto; }
     .editor-page { display: block; }
-    /* Two-column layout: sidebar + editor */
-    .editor-layout { display: grid; grid-template-columns: 320px minmax(0, 1fr); gap: 1rem; align-items: start; }
+    /* Editor layout */
+    .editor-layout { display: grid; grid-template-columns: minmax(0, 1fr); gap: 1rem; align-items: start; }
     .editor-layout.is-dynamic { grid-template-columns: minmax(0, 1fr); }
     .editor-layout.is-empty { grid-template-columns: minmax(0, 1fr); align-items: center; justify-items: center; }
     @media (max-width: 900px) {
       .editor-layout { grid-template-columns: 1fr; }
     }
-    .editor-layout.is-dynamic .editor-sidebar { display: none !important; }
-    .editor-layout.is-empty .editor-sidebar,
     .editor-layout.is-empty .editor-main { display: none; }
     .editor-empty-state { display: none; grid-column: 1 / -1; min-height: clamp(320px, 60vh, 640px); align-items: center; justify-content: center; text-align: center; padding: 2.5rem 1.5rem; border-radius: 16px; border: 1px dashed color-mix(in srgb, var(--border) 80%, transparent); background: color-mix(in srgb, var(--card) 96%, transparent); color: var(--muted); }
     .editor-layout.is-empty .editor-empty-state { display: flex; }
@@ -55,12 +53,6 @@
       .editor-empty-state h2 { font-size: 1.25rem; }
       .editor-empty-state p { font-size: .95rem; }
     }
-    .editor-sidebar { position: relative; }
-    .editor-sidebar .sidebar-title { font-size: 1rem; font-weight: 700; margin: 0 0 .5rem; }
-    /* Sidebar tabs for switching between Posts and Tabs */
-    .sidebar-tabs { display: inline-flex; gap: .4rem; margin: .35rem 0 .6rem; }
-    .sidebar-tab { border: 1px solid var(--border); background: var(--card); color: var(--text); border-radius: 999px; padding: .25rem .6rem; font-size: .88rem; cursor: pointer; }
-    .sidebar-tab.is-active { background: color-mix(in srgb, var(--primary) 12%, var(--card)); border-color: color-mix(in srgb, var(--primary) 35%, var(--border)); }
     /* Top mode switch (Editor / Composer): bigger, nav-like */
     .mode-switch {
       display: inline-flex;
@@ -299,20 +291,6 @@
       max-width: 100%;
     }
     .mode-switch-editor[hidden] { display: none !important; }
-    .editor-sidebar .group-title { display:none; }
-    .editor-sidebar .file-list { list-style: none; margin: 0; padding: 0; border: 1px solid var(--border); border-radius: 8px; /* no inner scroll */ max-height: none; overflow: visible; }
-    .editor-sidebar .file-item { display: flex; gap: .5rem; align-items: center; justify-content: space-between; padding: .5rem .6rem; border-bottom: 1px solid var(--border); cursor: pointer; }
-    .editor-sidebar .file-item:last-child { border-bottom: 0; }
-    .editor-sidebar .file-item:hover { background: color-mix(in srgb, var(--text) 4%, transparent); }
-    .editor-sidebar .file-item.is-active { background: color-mix(in srgb, var(--primary) 10%, transparent); }
-    .editor-sidebar .file-main { display: inline-flex; flex-direction: column; gap: .125rem; min-width: 0; }
-    .editor-sidebar .file-label { font-size: .92rem; font-weight: 600; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    .editor-sidebar .file-path { font-size: .78rem; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-    .editor-sidebar .search { margin: 0 0 .5rem; }
-    .editor-sidebar .search input { width: 100%; height: 2.25rem; padding: .4rem .6rem; border: 1px solid var(--border); border-radius: 8px; background: var(--card); color: var(--text); }
-    .editor-sidebar .search input:focus { outline: none; box-shadow: 0 0 0 .12rem color-mix(in srgb, var(--primary) 35%, transparent); border-color: color-mix(in srgb, var(--primary) 45%, var(--border)); }
-    .editor-sidebar .status { margin-top: .4rem; font-size: .78rem; color: var(--muted); }
-    .editor-sidebar .lists { display: block; }
     .current-file { color: var(--muted); font-size: .85rem; margin-left: .5rem; display: flex; flex-direction: column; gap: .18rem; min-width: 0; }
     .current-file .cf-line-main { font-weight: 600; color: color-mix(in srgb, var(--text) 65%, transparent); font-size: .9rem; display: inline-flex; align-items: center; gap: .4rem; min-width: 0; }
     .current-file .cf-line-main .cf-path { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -328,20 +306,6 @@
     .current-file[data-file-state="error"] .cf-line-main { color: color-mix(in srgb, #dc2626 80%, var(--text)); }
     .current-file[data-dirty="1"] .cf-line-main { color: color-mix(in srgb, #f97316 78%, var(--text)); }
     /* Grouped list styles */
-    .editor-sidebar .file-group { border-bottom: 1px solid var(--border); }
-    .editor-sidebar .file-group:last-child { border-bottom: 0; }
-    .editor-sidebar .file-group-header { font-size: .95rem; font-weight: 700; color: var(--text); padding: .5rem .6rem; cursor: pointer; list-style: none; display:flex; align-items:center; gap:.5rem; }
-    .editor-sidebar .file-group-title { flex: 1; min-width: 0; }
-    .editor-sidebar .summary-badges { display:inline-flex; gap:.35rem; align-items:center; }
-    .editor-sidebar .badge { display:inline-flex; align-items:center; gap:.25rem; border:1px solid var(--border); background: var(--card); color: var(--muted); font-size:.72rem; padding:.05rem .4rem; border-radius:999px; }
-    .editor-sidebar .badge-ver { color: var(--primary); border-color: color-mix(in srgb, var(--primary) 40%, var(--border)); }
-    .editor-sidebar .badge-lang { }
-    .editor-sidebar details.file-group > summary::-webkit-details-marker { display: none; }
-    .editor-sidebar details.file-group[open] > summary::after { content: '▾'; float: right; color: var(--muted); }
-    .editor-sidebar details.file-group:not([open]) > summary::after { content: '▸'; float: right; color: var(--muted); }
-    .editor-sidebar .file-sublist { list-style: none; margin: 0; padding: 0 0 .25rem 0; }
-    .editor-sidebar .file-subgroup { padding-top: .25rem; }
-    .editor-sidebar .file-subheader { font-size: .8rem; font-weight: 600; color: var(--muted); padding: .25rem .6rem; text-transform: uppercase; }
     /* Ensure main editor can use full width */
     .editor-main { min-width: 0; overflow: visible; }
     .page-titlebar { display:flex; align-items:flex-end; justify-content:space-between; gap:.5rem; margin-bottom: .75rem; }
@@ -1096,26 +1060,6 @@
 
     <!-- Editor Mode -->
     <div class="editor-layout is-empty" id="mode-editor">
-      <aside class="editor-sidebar" aria-label="Articles sidebar">
-        <div class="sidebar-title">Articles</div>
-        <div class="sidebar-tabs" role="tablist">
-          <button class="sidebar-tab is-active" data-target="index" role="tab" aria-selected="true">Posts</button>
-          <button class="sidebar-tab" data-target="tabs" role="tab" aria-selected="false">Tabs</button>
-        </div>
-        <div class="search"><input id="fileSearch" type="search" placeholder="Search by title or path"></div>
-        <div class="lists">
-          <div class="list-group" id="groupIndex" data-group="index">
-            <div class="group-title">Index</div>
-            <ul class="file-list" id="listIndex"></ul>
-          </div>
-          <div class="list-group" id="groupTabs" data-group="tabs" hidden>
-            <div class="group-title">Tabs</div>
-            <ul class="file-list" id="listTabs"></ul>
-          </div>
-        </div>
-        <div class="status" id="sidebarStatus"></div>
-      </aside>
-
       <section class="box editor-main">
         <nav class="mode-switch-editor" id="modeDynamicTabs" role="tablist" aria-label="Open editor tabs" hidden aria-hidden="true"></nav>
         <div class="toolbar">
@@ -1160,7 +1104,7 @@
       <div class="editor-empty-state" id="editorEmptyState" role="status" aria-live="polite">
         <div class="empty-body">
           <h2>No editor is currently open</h2>
-          <p>Select an article or tab from the left, or open Markdown from the Composer to start editing.</p>
+          <p>Open Markdown from the Composer to start editing.</p>
         </div>
       </div>
     </div>

--- a/index_editor.html
+++ b/index_editor.html
@@ -38,10 +38,23 @@
     /* Two-column layout: sidebar + editor */
     .editor-layout { display: grid; grid-template-columns: 320px minmax(0, 1fr); gap: 1rem; align-items: start; }
     .editor-layout.is-dynamic { grid-template-columns: minmax(0, 1fr); }
+    .editor-layout.is-empty { grid-template-columns: minmax(0, 1fr); align-items: center; justify-items: center; }
     @media (max-width: 900px) {
       .editor-layout { grid-template-columns: 1fr; }
     }
     .editor-layout.is-dynamic .editor-sidebar { display: none !important; }
+    .editor-layout.is-empty .editor-sidebar,
+    .editor-layout.is-empty .editor-main { display: none; }
+    .editor-empty-state { display: none; grid-column: 1 / -1; min-height: clamp(320px, 60vh, 640px); align-items: center; justify-content: center; text-align: center; padding: 2.5rem 1.5rem; border-radius: 16px; border: 1px dashed color-mix(in srgb, var(--border) 80%, transparent); background: color-mix(in srgb, var(--card) 96%, transparent); color: var(--muted); }
+    .editor-layout.is-empty .editor-empty-state { display: flex; }
+    .editor-empty-state .empty-body { display: flex; flex-direction: column; gap: .75rem; align-items: center; justify-content: center; max-width: min(520px, 100%); }
+    .editor-empty-state h2 { margin: 0; font-size: 1.4rem; font-weight: 700; color: var(--text); }
+    .editor-empty-state p { margin: 0; font-size: 1rem; line-height: 1.6; }
+    @media (max-width: 600px) {
+      .editor-empty-state { padding: 2rem 1.25rem; min-height: clamp(260px, 55vh, 520px); }
+      .editor-empty-state h2 { font-size: 1.25rem; }
+      .editor-empty-state p { font-size: .95rem; }
+    }
     .editor-sidebar { position: relative; }
     .editor-sidebar .sidebar-title { font-size: 1rem; font-weight: 700; margin: 0 0 .5rem; }
     /* Sidebar tabs for switching between Posts and Tabs */
@@ -1082,7 +1095,7 @@
     </div>
 
     <!-- Editor Mode -->
-    <div class="editor-layout" id="mode-editor">
+    <div class="editor-layout is-empty" id="mode-editor">
       <aside class="editor-sidebar" aria-label="Articles sidebar">
         <div class="sidebar-title">Articles</div>
         <div class="sidebar-tabs" role="tablist">
@@ -1143,6 +1156,13 @@
           <div id="mainview"></div>
         </div>
       </section>
+
+      <div class="editor-empty-state" id="editorEmptyState" role="status" aria-live="polite">
+        <div class="empty-body">
+          <h2>没有打开的编辑器</h2>
+          <p>从左侧选择一篇文章或 Tab 文件，或在 Composer 中打开要编辑的 Markdown 内容。</p>
+        </div>
+      </div>
     </div>
 
     <!-- Composer Mode -->

--- a/index_editor.html
+++ b/index_editor.html
@@ -43,7 +43,7 @@
       .editor-layout { grid-template-columns: 1fr; }
     }
     .editor-layout.is-empty .editor-main { display: none; }
-    .editor-empty-state { display: none; grid-column: 1 / -1; align-self: center; justify-self: center; align-items: center; justify-content: center; text-align: center; padding: clamp(1.75rem, 2vw + 1.2rem, 2.25rem) clamp(1.5rem, 2.8vw + 1rem, 2.75rem); border-radius: 14px; border: 1px dashed color-mix(in srgb, var(--border) 80%, transparent); background: color-mix(in srgb, var(--card) 96%, transparent); color: var(--muted); width: min(100%, 520px); box-shadow: 0 20px 36px rgba(15, 23, 42, 0.08); }
+    .editor-empty-state { display: none; grid-column: 1 / -1; align-self: center; justify-self: center; align-items: center; justify-content: center; text-align: center; padding: clamp(1.75rem, 2vw + 1.2rem, 2.25rem) clamp(1.5rem, 2.8vw + 1rem, 2.75rem); border-radius: 14px; border: 1px dashed color-mix(in srgb, var(--border) 80%, transparent); background: color-mix(in srgb, var(--card) 96%, transparent); color: var(--muted); width: min(100%, 520px); box-shadow: 0 20px 36px rgba(15, 23, 42, 0.08); margin-top: clamp(1.5rem, 3vw + 0.5rem, 2.75rem); }
     .editor-layout.is-empty .editor-empty-state { display: flex; }
     .editor-empty-state .empty-body { display: flex; flex-direction: column; gap: .85rem; align-items: center; justify-content: center; }
     .editor-empty-state h2 { margin: 0; font-size: 1.4rem; font-weight: 700; color: var(--text); }


### PR DESCRIPTION
## Summary
- add a dedicated empty-state layout to the editor page so users see a friendly message when no file is open
- update the editor controller to toggle the empty-state visibility and hide the sidebar/editor until a document is selected

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d428d206808328aad95a048f604194