### PR TITLE
Update pending bubble label to upload

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -2774,8 +2774,7 @@ function updateUnsyncedSummary() {
     if (globalStatusEl) globalStatusEl.setAttribute('data-dirty', '1');
     if (globalArrowEl) globalArrowEl.classList.add('is-pending');
     if (globalArrowLabelEl) {
-      if (count === 1) globalArrowLabelEl.textContent = '1 pending';
-      else globalArrowLabelEl.textContent = `${count} pending`;
+      globalArrowLabelEl.textContent = 'UPLOAD';
     }
     if (globalLocalStateEl) {
       globalLocalStateEl.textContent = '';
@@ -3448,7 +3447,7 @@ async function performDirectGithubCommit(token, summaryEntries = []) {
       bubble.removeAttribute('aria-busy');
       bubble.setAttribute('aria-label', 'Synchronize drafts to GitHub');
       const pendingCount = computeUnsyncedSummary().length;
-      if (pendingCount) bubble.textContent = pendingCount === 1 ? '1 pending' : `${pendingCount} pending`;
+      if (pendingCount) bubble.textContent = 'UPLOAD';
       else bubble.textContent = 'Synced';
     }
   }


### PR DESCRIPTION
## Summary
- change the global status arrow bubble label to "UPLOAD" whenever there are unsynced drafts
- keep the bubble label as "Synced" once all pending changes are cleared

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d43d75ec2c8328b2f0e2722c237fa7