### PR TITLE
Remove composer review button

### DIFF
--- a/index_editor.html
+++ b/index_editor.html
@@ -1182,7 +1182,6 @@
             <button class="btn-secondary" id="btnRefresh" title="Fetch latest remote snapshot">Refresh</button>
 
             <button class="btn-secondary" id="btnDiscard" title="Discard local draft and reload remote file" hidden>Discard</button>
-            <button class="btn-secondary" id="btnReview" type="button" hidden aria-hidden="true">Review</button>
           </div>
         </div>
         <div class="composer-order-inline-meta" id="composerOrderInlineMeta" hidden>


### PR DESCRIPTION
## Summary
- remove the unused Review button from the composer toolbar to eliminate duplicate review controls

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d43fa392e88328a3ac819c21b755ad