### PR TITLE
Remove GitHub sync controls from editor interface

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -4735,7 +4735,6 @@ function ensureComposerDiffModal() {
     }
     const safeKind = kind === 'tabs' ? 'tabs' : 'index';
     activeKind = safeKind;
-    syncBtn.dataset.kind = safeKind;
     const label = safeKind === 'tabs' ? 'tabs.yaml' : 'index.yaml';
     title.textContent = `Changes — ${label}`;
     activeDiff = composerDiffCache[safeKind] || recomputeDiff(safeKind);

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -4315,24 +4315,8 @@ function ensureComposerDiffModal() {
   dialog.appendChild(tabsWrap);
   dialog.appendChild(viewsWrap);
 
-  const actions = document.createElement('div');
-  actions.className = 'composer-diff-actions';
-  const syncBtn = document.createElement('button');
-  syncBtn.type = 'button';
-  syncBtn.className = 'btn-secondary composer-diff-sync';
-  syncBtn.id = 'btnVerify';
-  syncBtn.innerHTML = `
-    <svg aria-hidden="true" width="16" height="16" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg">
-      <path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="currentColor"/>
-    </svg>
-    <span class="btn-label">Synchronize</span>
-  `;
-  actions.appendChild(syncBtn);
-  dialog.appendChild(actions);
   modal.appendChild(dialog);
   document.body.appendChild(modal);
-
-  document.dispatchEvent(new CustomEvent('composer:verify-button-ready', { detail: { button: syncBtn } }));
 
   const focusableSelector = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])';
   let lastActive = null;
@@ -8922,11 +8906,8 @@ function bindComposerUI(state) {
       });
       }
 
-      attach(document.getElementById('btnVerify'));
-      document.addEventListener('composer:verify-button-ready', (event) => {
-        const target = event && event.detail && event.detail.button;
-        attach(target || document.getElementById('btnVerify'));
-      });
+      const initialVerifyButton = document.getElementById('btnVerify');
+      if (initialVerifyButton) attach(initialVerifyButton);
     })();
   }
 

--- a/index_editor.html
+++ b/index_editor.html
@@ -865,39 +865,6 @@
     #btnDraft.is-clean::after { content: '✓'; position: absolute; top: -0.45rem; right: -0.45rem; font-size: .72rem; color: #15803d; background: var(--card); border: 1px solid color-mix(in srgb, #16a34a 55%, var(--border)); border-radius: 999px; width: 1.1rem; height: 1.1rem; display: inline-flex; align-items:center; justify-content:center; }
     #btnDraft.is-stale { position: relative; }
     #btnDraft.is-stale::after { content: '\26A0'; position: absolute; top: -0.45rem; right: -0.45rem; font-size: .72rem; color: #dc2626; background: var(--card); border: 1px solid color-mix(in srgb, #dc2626 55%, var(--border)); border-radius: 999px; width: 1.1rem; height: 1.1rem; display: inline-flex; align-items:center; justify-content:center; }
-    /* Make the GitHub sync button GitHub-green with icon (override theme packs with !important) */
-    button#btnVerify.btn-secondary {
-      background:#428646 !important;  /*66 134 70*/
-      color:#ffffff !important;
-      border:1px solid #3d7741 !important;  /*61 119 65*/
-      border-radius:8px !important;
-    }
-    button#btnVerify.btn-secondary:hover { background:#3d7741 !important; }
-    button#btnVerify.btn-secondary:active { background:#298e46 !important; }
-    button#btnVerify.btn-secondary:focus-visible { outline:2px solid #2ea44f66; outline-offset:2px; }
-    button#btnPushMarkdown.btn-secondary {
-      background:#428646 !important;
-      color:#ffffff !important;
-      border:1px solid #3d7741 !important;
-      border-radius:8px !important;
-    }
-    button#btnPushMarkdown.btn-secondary:hover { background:#3d7741 !important; }
-    button#btnPushMarkdown.btn-secondary:active { background:#298e46 !important; }
-    button#btnPushMarkdown.btn-secondary:focus-visible { outline:2px solid #2ea44f66; outline-offset:2px; }
-    button#btnPushMarkdown.btn-secondary:disabled {
-      opacity:.6;
-      cursor:not-allowed;
-      color:rgba(255,255,255,.85) !important;
-    }
-    button#btnPushMarkdown.btn-secondary svg {
-      width:16px;
-      height:16px;
-      flex:0 0 auto;
-    }
-    button#btnPushMarkdown.btn-secondary .btn-label {
-      font-weight:600;
-      white-space:nowrap;
-    }
     button#btnDiscard.btn-secondary {
       background:#e15b5b !important;
       color:#3f1010 !important;
@@ -1215,12 +1182,6 @@
             </div>
             <button type="button" class="btn-secondary" id="btnDiscardMarkdown" disabled>
               <span class="btn-label">Discard</span>
-            </button>
-            <button type="button" class="btn-secondary" id="btnPushMarkdown" disabled>
-              <svg aria-hidden="true" width="16" height="16" viewBox="0 0 98 96" xmlns="http://www.w3.org/2000/svg">
-                <path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="currentColor"/>
-              </svg>
-              <span class="btn-label">Synchronize</span>
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- remove the GitHub synchronize button from the editor toolbar
- drop the GitHub sync action button from the composer diff modal and related styling

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d5169c4d548328b11ba74ba463d473