### PR TITLE
Add markdown editor image upload support

### DIFF
--- a/index_editor.html
+++ b/index_editor.html
@@ -1168,6 +1168,10 @@
             <span class="current-file" id="currentFile" aria-live="polite"></span>
           </div>
           <div class="right-actions">
+            <button type="button" class="btn-secondary" id="btnInsertImage">
+              <span class="btn-label">Insert Image</span>
+            </button>
+            <input type="file" id="editorImageInput" accept="image/*" multiple hidden>
             <div class="wrap-toggle view-toggle" id="wrapToggle" aria-label="Wrap setting">
               <span class="vt-label">Wrap:</span>
               <a href="#" class="vt-btn" data-wrap="on" role="button">on</a>


### PR DESCRIPTION
## Summary
- add an Insert Image control to the editor toolbar to expose image uploads
- handle dropped or selected images by reading the files, inserting markdown, and dispatching asset metadata to the composer
- persist pending markdown assets in the composer, bundle them into GitHub syncs, and reflect pending asset counts in summaries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d51dafeb4c8328813a10c1430dc83a