### PR TITLE
Fix composer inline preview removed items expansion

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -5250,6 +5250,10 @@ function drawOrderDiffLines(state) {
   if (fallbackHeight > 0 && leftMap && typeof leftMap.forEach === 'function') {
     leftMap.forEach(el => {
       if (!el || !el.style) return;
+      const status = (el.dataset && typeof el.dataset.status === 'string')
+        ? el.dataset.status
+        : '';
+      if (status === 'removed') return;
       const fallbackValue = `${fallbackHeight}px`;
       if (!el.style.minHeight) {
         el.style.minHeight = fallbackValue;


### PR DESCRIPTION
## Summary
- prevent the inline diff fallback height logic from touching removed entries so they keep their natural size

## Testing
- Manual verification in the browser

------
https://chatgpt.com/codex/tasks/task_e_68d531d973548328b19db6c6cf3ec4c1