### PR TITLE
Add language switcher and i18n support to editor

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -5958,14 +5958,14 @@ async function handleComposerRefresh(btn) {
     button.disabled = false;
     button.classList.remove('is-busy');
     button.removeAttribute('aria-busy');
-    button.textContent = 'Refresh';
+    button.textContent = t('editor.composer.refresh');
   };
   try {
     if (button) {
       button.disabled = true;
       button.classList.add('is-busy');
       button.setAttribute('aria-busy', 'true');
-      button.textContent = 'Refreshing…';
+      button.textContent = t('editor.composer.refreshing');
     }
     const contentRoot = getContentRootSafe();
     const remote = await fetchConfigWithYamlFallback([
@@ -5981,19 +5981,23 @@ async function handleComposerRefresh(btn) {
       setStateSlice(target, deepClone(prepared));
       if (target === 'tabs') rebuildTabsUI();
       else rebuildIndexUI();
-      showStatus(`${target === 'tabs' ? 'tabs' : 'index'}.yaml refreshed from remote`);
+      showStatus(
+        t('editor.composer.statusMessages.refreshSuccess', {
+          name: `${target === 'tabs' ? 'tabs' : 'index'}.yaml`
+        })
+      );
     } else {
       notifyComposerChange(target, { skipAutoSave: true });
       const baselineSignatureAfter = computeBaselineSignature(target);
       if (baselineSignatureAfter !== baselineSignatureBefore) {
-        showStatus('Remote snapshot updated. Highlights now include remote differences.');
+        showStatus(t('editor.composer.statusMessages.remoteUpdated'));
       } else {
-        showStatus('Remote snapshot unchanged.');
+        showStatus(t('editor.composer.statusMessages.remoteUnchanged'));
       }
     }
   } catch (err) {
     console.error('Refresh failed', err);
-    showStatus('Failed to refresh remote snapshot');
+    showStatus(t('editor.composer.statusMessages.refreshFailed'));
   } finally {
     resetButton();
     setTimeout(() => { showStatus(''); }, 2000);

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -1,12 +1,19 @@
 import { fetchConfigWithYamlFallback, parseYAML } from './yaml.js';
+import { t } from './i18n.js';
 
 // Utility helpers
 const $ = (s, r = document) => r.querySelector(s);
 const $$ = (s, r = document) => Array.from(r.querySelectorAll(s));
 
 const PREFERRED_LANG_ORDER = ['en', 'zh', 'ja'];
-const CLEAN_STATUS_MESSAGE = 'No local changes';
+const CLEAN_STATUS_MESSAGE_KEY = 'editor.status.clean';
+const STATUS_UPLOAD_KEY = 'editor.status.upload';
+const STATUS_SYNCED_KEY = 'editor.status.synced';
 const ORDER_LINE_COLORS = ['#2563eb', '#ec4899', '#f97316', '#10b981', '#8b5cf6', '#f59e0b', '#22d3ee'];
+
+const getCleanStatusMessage = () => t(CLEAN_STATUS_MESSAGE_KEY);
+const getUploadLabel = () => t(STATUS_UPLOAD_KEY);
+const getSyncedLabel = () => t(STATUS_SYNCED_KEY);
 
 // --- Persisted UI state keys ---
 const LS_KEYS = {
@@ -3379,7 +3386,7 @@ function updateUnsyncedSummary() {
     if (globalStatusEl) globalStatusEl.setAttribute('data-dirty', '1');
     if (globalArrowEl) globalArrowEl.classList.add('is-pending');
     if (globalArrowLabelEl) {
-      globalArrowLabelEl.textContent = 'UPLOAD';
+      globalArrowLabelEl.textContent = getUploadLabel();
     }
     if (globalLocalStateEl) {
       globalLocalStateEl.textContent = '';
@@ -3399,10 +3406,10 @@ function updateUnsyncedSummary() {
     }
     if (globalStatusEl) globalStatusEl.removeAttribute('data-dirty');
     if (globalArrowEl) globalArrowEl.classList.remove('is-pending');
-    if (globalArrowLabelEl) globalArrowLabelEl.textContent = 'Synced';
+    if (globalArrowLabelEl) globalArrowLabelEl.textContent = getSyncedLabel();
     if (globalLocalStateEl) {
       globalLocalStateEl.hidden = false;
-      globalLocalStateEl.textContent = CLEAN_STATUS_MESSAGE;
+      globalLocalStateEl.textContent = getCleanStatusMessage();
     }
     updateReviewButton([]);
   }
@@ -4179,8 +4186,8 @@ async function performDirectGithubCommit(token, summaryEntries = []) {
       bubble.removeAttribute('aria-busy');
       bubble.setAttribute('aria-label', 'Synchronize drafts to GitHub');
       const pendingCount = computeUnsyncedSummary().length;
-      if (pendingCount) bubble.textContent = 'UPLOAD';
-      else bubble.textContent = 'Synced';
+      if (pendingCount) bubble.textContent = getUploadLabel();
+      else bubble.textContent = getSyncedLabel();
     }
   }
 }
@@ -4190,7 +4197,7 @@ async function handleGlobalBubbleActivation(event) {
   if (gitHubCommitInFlight) return;
   const summary = computeUnsyncedSummary();
   if (!summary.length) {
-    showToast('info', 'No local changes to commit.');
+    showToast('info', t('editor.composer.noLocalChangesToCommit'));
     return;
   }
   const repo = window.__ns_site_repo || {};
@@ -4309,7 +4316,7 @@ function renderComposerInlineSummary(target, diff, options = {}) {
   if (!summary || !summary.hasChanges) {
     const empty = document.createElement('span');
     empty.className = 'composer-inline-summary-empty';
-    empty.textContent = 'No local changes yet.';
+    empty.textContent = t('editor.composer.noLocalChangesYet');
     target.appendChild(empty);
     return;
   }

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -3677,17 +3677,18 @@ function promptForFineGrainedToken(summaryEntries = []) {
     headLeft.className = 'comp-head-left';
     const title = document.createElement('strong');
     title.id = 'nsGithubTokenTitle';
-    title.textContent = 'Synchronize with GitHub';
+    title.textContent = t('editor.composer.github.modal.title');
     const subtitle = document.createElement('span');
     subtitle.className = 'muted';
-    subtitle.textContent = 'Provide a Fine-grained Personal Access Token with repository contents access.';
+    subtitle.textContent = t('editor.composer.github.modal.subtitle');
     headLeft.appendChild(title);
     headLeft.appendChild(subtitle);
     const btnClose = document.createElement('button');
     btnClose.type = 'button';
     btnClose.className = 'ns-modal-close btn-secondary';
-    btnClose.textContent = 'Cancel';
-    btnClose.setAttribute('aria-label', 'Cancel');
+    const cancelLabel = t('editor.dialogs.cancel');
+    btnClose.textContent = cancelLabel;
+    btnClose.setAttribute('aria-label', cancelLabel);
     head.appendChild(headLeft);
     head.appendChild(btnClose);
     dialog.appendChild(head);
@@ -3700,7 +3701,7 @@ function promptForFineGrainedToken(summaryEntries = []) {
     summaryBlock.style.margin = '.25rem 0 1rem';
     if (Array.isArray(summaryEntries) && summaryEntries.length) {
       const info = document.createElement('p');
-      info.textContent = 'The following files will be committed:';
+      info.textContent = t('editor.composer.github.modal.summaryTitle');
       summaryBlock.appendChild(info);
       const list = document.createElement('ul');
       list.style.margin = '.4rem 0 0';
@@ -3717,7 +3718,7 @@ function promptForFineGrainedToken(summaryEntries = []) {
     const tokenField = document.createElement('label');
     tokenField.style.display = 'block';
     tokenField.style.marginBottom = '.75rem';
-    tokenField.textContent = 'Fine-grained Personal Access Token';
+    tokenField.textContent = t('editor.composer.github.modal.tokenLabel');
     const input = document.createElement('input');
     input.type = 'password';
     input.autocomplete = 'off';
@@ -3739,7 +3740,7 @@ function promptForFineGrainedToken(summaryEntries = []) {
     const help = document.createElement('p');
     help.className = 'muted';
     help.style.fontSize = '.85rem';
-    help.innerHTML = 'Create a token at <a href="https://github.com/settings/tokens?type=beta" target="_blank" rel="noopener">github.com/settings/tokens</a> with access to the repository\'s contents. The token is stored for this browser session only.';
+    help.innerHTML = t('editor.composer.github.modal.helpHtml');
     form.appendChild(help);
 
     const errorText = document.createElement('p');
@@ -3759,14 +3760,14 @@ function promptForFineGrainedToken(summaryEntries = []) {
     const btnForget = document.createElement('button');
     btnForget.type = 'button';
     btnForget.className = 'btn-secondary';
-    btnForget.textContent = 'Forget token';
+    btnForget.textContent = t('editor.composer.github.modal.forget');
     if (!cached) btnForget.hidden = true;
     footer.appendChild(btnForget);
 
     const btnSubmit = document.createElement('button');
     btnSubmit.type = 'submit';
     btnSubmit.className = 'btn-primary';
-    btnSubmit.textContent = 'Commit changes';
+    btnSubmit.textContent = t('editor.composer.github.modal.submit');
     footer.appendChild(btnSubmit);
 
     form.appendChild(footer);
@@ -3851,7 +3852,7 @@ function promptForFineGrainedToken(summaryEntries = []) {
       if (event && typeof event.preventDefault === 'function') event.preventDefault();
       const value = String(input.value || '').trim();
       if (!value) {
-        showError('Enter a Fine-grained Personal Access Token to continue.');
+        showError(t('editor.composer.github.modal.errorRequired'));
         try { input.focus({ preventScroll: true }); }
         catch (_) { input.focus(); }
         return;
@@ -7712,7 +7713,11 @@ function applyComposerFile(name, options = {}) {
     } catch (_) {}
     try {
       const btn = $('#btnAddItem');
-      if (btn) btn.textContent = isIndex ? 'Add Post Entry' : 'Add Tab Entry';
+      if (btn) {
+        const key = isIndex ? 'editor.composer.addPost' : 'editor.composer.addTab';
+        btn.setAttribute('data-i18n', key);
+        btn.textContent = t(key);
+      }
     } catch (_) {}
   };
 
@@ -9420,7 +9425,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   } catch (_) {}
 
   const state = { index: {}, tabs: {} };
-  showStatus('Loading config…');
+  showStatus(t('editor.composer.statusMessages.loadingConfig'));
   try {
     const site = await fetchConfigWithYamlFallback(['site.yaml', 'site.yml']);
     const root = (site && site.contentRoot) ? String(site.contentRoot) : 'wwwroot';
@@ -9454,7 +9459,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   if (restoredDrafts.length) {
     const label = restoredDrafts.map(k => (k === 'tabs' ? 'tabs.yaml' : 'index.yaml')).join(' & ');
-    showStatus(`Restored local draft for ${label}`);
+    showStatus(t('editor.composer.statusMessages.restoredDraft', { label }));
     setTimeout(() => { showStatus(''); }, 1800);
   } else {
     showStatus('');

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -2298,16 +2298,12 @@ function collectDynamicMarkdownDraftStates() {
 }
 
 function getDraftIndicatorMessage(state) {
-  switch (state) {
-    case 'conflict':
-      return 'Local draft conflicts with remote file';
-    case 'dirty':
-      return 'Unsaved changes pending in editor';
-    case 'saved':
-      return 'Local draft saved in browser';
-    default:
-      return '';
-  }
+  if (!state) return '';
+  const suffix = `markdown.draftIndicator.${state}`;
+  const value = tComposer(suffix);
+  const fallbackKey = `editor.composer.${suffix}`;
+  if (!value || value === fallbackKey) return '';
+  return value;
 }
 
 function updateComposerDraftContainerState(container) {
@@ -2322,6 +2318,10 @@ function updateComposerDraftContainerState(container) {
   }
   if (childState) container.setAttribute('data-child-draft', childState);
   else container.removeAttribute('data-child-draft');
+}
+
+function updateComposerMarkdownDraftContainerState(container) {
+  updateComposerDraftContainerState(container);
 }
 
 function applyComposerDraftIndicatorState(el, state) {

--- a/assets/js/editor-boot.js
+++ b/assets/js/editor-boot.js
@@ -1,0 +1,94 @@
+import { initI18n, t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage } from './i18n.js';
+
+function applyAttributeTranslation(el, target, value) {
+  if (value == null) return;
+  switch (target) {
+    case 'text':
+      el.textContent = value;
+      break;
+    case 'html':
+      el.innerHTML = value;
+      break;
+    case 'placeholder':
+      el.setAttribute('placeholder', value);
+      if ('placeholder' in el) el.placeholder = value;
+      break;
+    case 'value':
+      if ('value' in el) el.value = value;
+      else el.setAttribute('value', value);
+      break;
+    default: {
+      el.setAttribute(target, value);
+      if (target === 'title' && el.title !== value) el.title = value;
+      if (target === 'aria-label' && el.getAttribute('aria-label') !== value) el.setAttribute('aria-label', value);
+      if (target.startsWith('data-')) {
+        const dataKey = target.slice(5).replace(/-([a-z])/g, (_, ch) => ch.toUpperCase());
+        if (dataKey) el.dataset[dataKey] = value;
+      }
+      break;
+    }
+  }
+}
+
+function applyElementTranslations(root = document) {
+  document.title = t('editor.pageTitle');
+  const elements = root.querySelectorAll('*');
+  elements.forEach((el) => {
+    const key = el.getAttribute('data-i18n');
+    if (key) {
+      const text = t(key);
+      if (text != null) el.textContent = text;
+    }
+    Array.from(el.attributes).forEach((attr) => {
+      if (!attr.name.startsWith('data-i18n-') || attr.name === 'data-i18n') return;
+      const target = attr.name.slice('data-i18n-'.length);
+      if (!target) return;
+      const translated = t(attr.value);
+      applyAttributeTranslation(el, target, translated);
+    });
+  });
+}
+
+function populateLanguageSelect() {
+  const select = document.getElementById('editorLangSelect');
+  if (!select) return;
+  const current = getCurrentLang();
+  const langs = getAvailableLangs();
+  const prev = select.value;
+  select.innerHTML = '';
+  langs.forEach((code) => {
+    const opt = document.createElement('option');
+    opt.value = code;
+    opt.textContent = getLanguageLabel(code);
+    select.appendChild(opt);
+  });
+  select.value = langs.includes(current) ? current : current || prev;
+  if (!select.dataset.boundChange) {
+    select.addEventListener('change', () => {
+      const value = select.value || 'en';
+      switchLanguage(value);
+    });
+    select.dataset.boundChange = '1';
+  }
+}
+
+function applyEditorLanguage() {
+  applyElementTranslations();
+  populateLanguageSelect();
+  document.dispatchEvent(new CustomEvent('ns-editor-language-applied'));
+}
+
+function bootstrap() {
+  initI18n();
+  applyEditorLanguage();
+  window.__ns_softResetLang = () => {
+    initI18n({ persist: false });
+    applyEditorLanguage();
+  };
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', bootstrap);
+} else {
+  bootstrap();
+}

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -220,6 +220,119 @@ const translations = {
           loadingConfig: 'Loading config…',
           restoredDraft: ({ label }) => `Restored local draft for ${label}`
         },
+        diff: {
+          heading: 'Changes',
+          title: ({ label }) => `Changes — ${label}`,
+          close: 'Close',
+          subtitle: {
+            default: 'Review differences compared to the remote baseline.',
+            overview: 'Review a quick summary of the unsynced changes.',
+            entries: 'Inspect added, removed, and modified entries.',
+            order: 'Remote baseline (left) · Current order (right)'
+          },
+          tabs: {
+            overview: 'Overview',
+            entries: 'Entries',
+            order: 'Order'
+          },
+          order: {
+            remoteTitle: 'Remote',
+            currentTitle: 'Current',
+            empty: 'No items to compare yet.',
+            inlineAllNew: 'All current items are new compared with the baseline.',
+            emptyKey: '(empty)',
+            badges: {
+              to: ({ index }) => `→ #${index}`,
+              from: ({ index }) => `from #${index}`,
+              removed: 'Removed',
+              added: 'New'
+            }
+          },
+          orderStats: {
+            empty: 'No direct moves; changes come from additions/removals',
+            moved: ({ count }) => `Moved ${count}`,
+            added: ({ count }) => `+${count} new`,
+            removed: ({ count }) => `-${count} removed`
+          },
+          lists: {
+            more: ({ count }) => `+${count} more`
+          },
+          inlineChips: {
+            added: ({ count }) => `+${count} added`,
+            removed: ({ count }) => `-${count} removed`,
+            modified: ({ count }) => `~${count} modified`,
+            orderChanged: 'Order changed',
+            orderParts: {
+              moved: ({ count }) => `${count} moved`,
+              added: ({ count }) => `+${count} new`,
+              removed: ({ count }) => `-${count} removed`
+            },
+            orderSummary: ({ parts }) => `Order: ${parts}`,
+            langs: ({ summary }) => `Langs: ${summary}`,
+            none: 'Changes detected.'
+          },
+          inline: {
+            title: 'Change summary',
+            ariaOrder: ({ label }) => `Old order for ${label}`,
+            openAria: ({ label }) => `Open change overview for ${label}`
+          },
+          overview: {
+            empty: 'No changes detected for this file.',
+            stats: {
+              added: 'Added',
+              removed: 'Removed',
+              modified: 'Modified',
+              order: 'Order',
+              changed: 'Changed',
+              unchanged: 'Unchanged'
+            },
+            blocks: {
+              added: 'Added entries',
+              removed: 'Removed entries',
+              modified: 'Modified entries'
+            },
+            languagesImpacted: ({ languages }) => `Languages impacted: ${languages}`
+          },
+          entries: {
+            noLanguageContent: 'No language content recorded.',
+            snapshot: {
+              indexValue: ({ count }) => `${count} value${count === 1 ? '' : 's'}`,
+              emptyEntry: 'empty entry',
+              tabTitle: ({ title }) => `title “${title}”`,
+              tabLocation: ({ location }) => `location ${location}`
+            },
+            summary: ({ lang, summary }) => `${lang}: ${summary}`,
+            state: {
+              added: ({ lang }) => `${lang}: added`,
+              removed: ({ lang }) => `${lang}: removed`,
+              updatedFields: ({ lang, fields }) => `${lang}: updated ${fields}`
+            },
+            parts: {
+              typeChanged: 'type changed',
+              addedCount: ({ count }) => `+${count} new`,
+              removedCount: ({ count }) => `-${count} removed`,
+              updatedCount: ({ count }) => `${count} updated`,
+              reordered: 'reordered',
+              contentUpdated: 'content updated'
+            },
+            join: {
+              comma: ', ',
+              and: ' & '
+            },
+            fields: {
+              title: 'title',
+              location: 'location',
+              content: 'content'
+            },
+            empty: 'No content differences detected.',
+            sections: {
+              added: 'Added entries',
+              removed: 'Removed entries',
+              modified: 'Modified entries'
+            },
+            orderOnly: 'Only ordering changed for this file.'
+          }
+        },
         github: {
           modal: {
             title: 'Synchronize with GitHub',
@@ -541,6 +654,119 @@ const translations = {
           loadingConfig: '正在加载配置…',
           restoredDraft: ({ label }) => `已恢复 ${label} 的本地草稿`
         },
+        diff: {
+          heading: '更改',
+          title: ({ label }) => `更改 — ${label}`,
+          close: '关闭',
+          subtitle: {
+            default: '查看与远程基线的差异。',
+            overview: '查看未同步更改的摘要。',
+            entries: '查看新增、删除和修改的条目。',
+            order: '远程基线（左）· 当前顺序（右）'
+          },
+          tabs: {
+            overview: '概览',
+            entries: '条目',
+            order: '顺序'
+          },
+          order: {
+            remoteTitle: '远程',
+            currentTitle: '当前',
+            empty: '暂无可比较的条目。',
+            inlineAllNew: '当前所有条目相较基线均为新增内容。',
+            emptyKey: '（空）',
+            badges: {
+              to: ({ index }) => `→ #${index}`,
+              from: ({ index }) => `来自 #${index}`,
+              removed: '已移除',
+              added: '新条目'
+            }
+          },
+          orderStats: {
+            empty: '无直接移动；更改来自新增或删除',
+            moved: ({ count }) => `移动 ${count}`,
+            added: ({ count }) => `+${count} 新增`,
+            removed: ({ count }) => `-${count} 已移除`
+          },
+          lists: {
+            more: ({ count }) => `+${count} 更多`
+          },
+          inlineChips: {
+            added: ({ count }) => `+${count} 新增`,
+            removed: ({ count }) => `-${count} 已移除`,
+            modified: ({ count }) => `~${count} 已修改`,
+            orderChanged: '顺序已更改',
+            orderParts: {
+              moved: ({ count }) => `${count} 项移动`,
+              added: ({ count }) => `+${count} 新增`,
+              removed: ({ count }) => `-${count} 已移除`
+            },
+            orderSummary: ({ parts }) => `顺序：${parts}`,
+            langs: ({ summary }) => `语言：${summary}`,
+            none: '检测到更改。'
+          },
+          inline: {
+            title: '更改摘要',
+            ariaOrder: ({ label }) => `${label} 的旧顺序`,
+            openAria: ({ label }) => `打开 ${label} 的更改概览`
+          },
+          overview: {
+            empty: '该文件没有检测到更改。',
+            stats: {
+              added: '新增',
+              removed: '已移除',
+              modified: '已修改',
+              order: '顺序',
+              changed: '已更改',
+              unchanged: '未更改'
+            },
+            blocks: {
+              added: '新增条目',
+              removed: '已移除的条目',
+              modified: '已修改的条目'
+            },
+            languagesImpacted: ({ languages }) => `受影响的语言：${languages}`
+          },
+          entries: {
+            noLanguageContent: '未记录任何语言内容。',
+            snapshot: {
+              indexValue: ({ count }) => `${count} 个值`,
+              emptyEntry: '空条目',
+              tabTitle: ({ title }) => `标题 “${title}”`,
+              tabLocation: ({ location }) => `位置 ${location}`
+            },
+            summary: ({ lang, summary }) => `${lang}：${summary}`,
+            state: {
+              added: ({ lang }) => `${lang}：已新增`,
+              removed: ({ lang }) => `${lang}：已移除`,
+              updatedFields: ({ lang, fields }) => `${lang}：已更新 ${fields}`
+            },
+            parts: {
+              typeChanged: '类型已更改',
+              addedCount: ({ count }) => `+${count} 新增`,
+              removedCount: ({ count }) => `-${count} 已移除`,
+              updatedCount: ({ count }) => `${count} 项已更新`,
+              reordered: '顺序已调整',
+              contentUpdated: '内容已更新'
+            },
+            join: {
+              comma: '、',
+              and: ' 和 '
+            },
+            fields: {
+              title: '标题',
+              location: '位置',
+              content: '内容'
+            },
+            empty: '没有检测到内容差异。',
+            sections: {
+              added: '新增条目',
+              removed: '已移除的条目',
+              modified: '已修改的条目'
+            },
+            orderOnly: '该文件仅更改了顺序。'
+          }
+        },
         github: {
           modal: {
             title: '与 GitHub 同步',
@@ -861,6 +1087,119 @@ const translations = {
         statusMessages: {
           loadingConfig: '設定を読み込み中…',
           restoredDraft: ({ label }) => `${label} のローカル下書きを復元しました`
+        },
+        diff: {
+          heading: '変更',
+          title: ({ label }) => `変更 — ${label}`,
+          close: '閉じる',
+          subtitle: {
+            default: 'リモートのベースラインとの差分を確認します。',
+            overview: '未同期の変更内容をざっと確認します。',
+            entries: '追加・削除・変更されたエントリを確認します。',
+            order: 'リモートの基準（左）・現在の順序（右）'
+          },
+          tabs: {
+            overview: '概要',
+            entries: 'エントリ',
+            order: '順序'
+          },
+          order: {
+            remoteTitle: 'リモート',
+            currentTitle: '現在',
+            empty: '比較できる項目がありません。',
+            inlineAllNew: '現在の項目はすべて基準と比べて新規のものです。',
+            emptyKey: '（空）',
+            badges: {
+              to: ({ index }) => `→ #${index}`,
+              from: ({ index }) => `#${index} から`,
+              removed: '削除済み',
+              added: '新規'
+            }
+          },
+          orderStats: {
+            empty: '直接の移動はありません（追加または削除による変更）',
+            moved: ({ count }) => `${count} 件移動`,
+            added: ({ count }) => `+${count} 件追加`,
+            removed: ({ count }) => `-${count} 件削除`
+          },
+          lists: {
+            more: ({ count }) => `他 ${count} 件`
+          },
+          inlineChips: {
+            added: ({ count }) => `+${count} 件追加`,
+            removed: ({ count }) => `-${count} 件削除`,
+            modified: ({ count }) => `~${count} 件変更`,
+            orderChanged: '順序が変更されました',
+            orderParts: {
+              moved: ({ count }) => `${count} 件移動`,
+              added: ({ count }) => `+${count} 件追加`,
+              removed: ({ count }) => `-${count} 件削除`
+            },
+            orderSummary: ({ parts }) => `順序: ${parts}`,
+            langs: ({ summary }) => `言語: ${summary}`,
+            none: '変更が検出されました。'
+          },
+          inline: {
+            title: '変更サマリー',
+            ariaOrder: ({ label }) => `${label} の旧順序`,
+            openAria: ({ label }) => `${label} の変更概要を開く`
+          },
+          overview: {
+            empty: 'このファイルには変更が見つかりませんでした。',
+            stats: {
+              added: '追加',
+              removed: '削除',
+              modified: '変更',
+              order: '順序',
+              changed: '変更あり',
+              unchanged: '変更なし'
+            },
+            blocks: {
+              added: '追加されたエントリ',
+              removed: '削除されたエントリ',
+              modified: '変更されたエントリ'
+            },
+            languagesImpacted: ({ languages }) => `影響を受けた言語: ${languages}`
+          },
+          entries: {
+            noLanguageContent: '言語別の内容は記録されていません。',
+            snapshot: {
+              indexValue: ({ count }) => `${count} 件の値`,
+              emptyEntry: '空のエントリ',
+              tabTitle: ({ title }) => `タイトル「${title}」`,
+              tabLocation: ({ location }) => `場所 ${location}`
+            },
+            summary: ({ lang, summary }) => `${lang}: ${summary}`,
+            state: {
+              added: ({ lang }) => `${lang}: 追加済み`,
+              removed: ({ lang }) => `${lang}: 削除済み`,
+              updatedFields: ({ lang, fields }) => `${lang}: ${fields} を更新`
+            },
+            parts: {
+              typeChanged: '種類が変更されました',
+              addedCount: ({ count }) => `+${count} 件追加`,
+              removedCount: ({ count }) => `-${count} 件削除`,
+              updatedCount: ({ count }) => `${count} 件更新`,
+              reordered: '並び替え済み',
+              contentUpdated: '内容を更新'
+            },
+            join: {
+              comma: '、',
+              and: ' と '
+            },
+            fields: {
+              title: 'タイトル',
+              location: '場所',
+              content: '内容'
+            },
+            empty: '内容の差分は見つかりませんでした。',
+            sections: {
+              added: '追加されたエントリ',
+              removed: '削除されたエントリ',
+              modified: '変更されたエントリ'
+            },
+            orderOnly: 'このファイルでは順序のみが変更されました。'
+          }
         },
         github: {
           modal: {

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -220,6 +220,47 @@ const translations = {
           loadingConfig: 'Loading config…',
           restoredDraft: ({ label }) => `Restored local draft for ${label}`
         },
+        entryRow: {
+          gripHint: 'Drag to reorder',
+          details: 'Details',
+          delete: 'Delete'
+        },
+        languages: {
+          count: ({ count }) => `${count} ${count === 1 ? 'language' : 'languages'}`,
+          addVersion: '+ Version',
+          removeLanguage: 'Remove language',
+          addLanguage: '+ Add language',
+          removedVersions: ({ versions }) => `Removed: ${versions}`,
+          placeholders: {
+            indexPath: 'post/.../file.md',
+            tabPath: 'tab/.../file.md'
+          },
+          fields: {
+            title: 'Title',
+            location: 'Location'
+          },
+          actions: {
+            edit: 'Edit',
+            open: 'Open in editor',
+            moveUp: 'Move up',
+            moveDown: 'Move down',
+            remove: 'Remove'
+          }
+        },
+        entryKinds: {
+          post: {
+            label: 'post',
+            confirm: 'Add Post Entry',
+            placeholder: 'Post key',
+            message: 'Enter a new post key (letters and numbers only):'
+          },
+          tab: {
+            label: 'tab',
+            confirm: 'Add Tab Entry',
+            placeholder: 'Tab key',
+            message: 'Enter a new tab key (letters and numbers only):'
+          }
+        },
         diff: {
           heading: 'Changes',
           title: ({ label }) => `Changes — ${label}`,
@@ -418,6 +459,7 @@ const translations = {
         },
         currentFile: 'current file',
         fileFallback: 'markdown file',
+        openBeforeEditor: 'Enter a markdown location before opening the editor.',
         toastCopiedCreate: 'Markdown copied. GitHub will open to create this file.',
         toastCopiedUpdate: 'Markdown copied. GitHub will open to update this file.',
         blockedCreate: 'Markdown copied. Click “Open GitHub” if the new tab did not appear so you can create this file.',
@@ -654,6 +696,47 @@ const translations = {
           loadingConfig: '正在加载配置…',
           restoredDraft: ({ label }) => `已恢复 ${label} 的本地草稿`
         },
+        entryRow: {
+          gripHint: '拖动以重新排序',
+          details: '详情',
+          delete: '删除'
+        },
+        languages: {
+          count: ({ count }) => `${count} 种语言`,
+          addVersion: '+ 版本',
+          removeLanguage: '删除语言',
+          addLanguage: '+ 添加语言',
+          removedVersions: ({ versions }) => `已移除：${versions}`,
+          placeholders: {
+            indexPath: 'post/.../file.md',
+            tabPath: 'tab/.../file.md'
+          },
+          fields: {
+            title: '标题',
+            location: '路径'
+          },
+          actions: {
+            edit: '编辑',
+            open: '在编辑器中打开',
+            moveUp: '上移',
+            moveDown: '下移',
+            remove: '移除'
+          }
+        },
+        entryKinds: {
+          post: {
+            label: '文章',
+            confirm: '添加文章条目',
+            placeholder: '文章键',
+            message: '请输入新的文章键（仅限字母和数字）：'
+          },
+          tab: {
+            label: '标签页',
+            confirm: '添加标签页条目',
+            placeholder: '标签页键',
+            message: '请输入新的标签页键（仅限字母和数字）：'
+          }
+        },
         diff: {
           heading: '更改',
           title: ({ label }) => `更改 — ${label}`,
@@ -852,6 +935,7 @@ const translations = {
         },
         currentFile: '当前文件',
         fileFallback: 'Markdown 文件',
+        openBeforeEditor: '请输入 Markdown 路径后再打开编辑器。',
         toastCopiedCreate: '已复制 Markdown。GitHub 将打开以创建该文件。',
         toastCopiedUpdate: '已复制 Markdown。GitHub 将打开以更新该文件。',
         blockedCreate: '已复制 Markdown。如未打开新标签页，请点击“打开 GitHub”以创建该文件。',
@@ -1088,6 +1172,47 @@ const translations = {
           loadingConfig: '設定を読み込み中…',
           restoredDraft: ({ label }) => `${label} のローカル下書きを復元しました`
         },
+        entryRow: {
+          gripHint: 'ドラッグして並び替え',
+          details: '詳細',
+          delete: '削除'
+        },
+        languages: {
+          count: ({ count }) => `${count} 言語`,
+          addVersion: '+ バージョン',
+          removeLanguage: '言語を削除',
+          addLanguage: '+ 言語を追加',
+          removedVersions: ({ versions }) => `削除済み: ${versions}`,
+          placeholders: {
+            indexPath: 'post/.../file.md',
+            tabPath: 'tab/.../file.md'
+          },
+          fields: {
+            title: 'タイトル',
+            location: '場所'
+          },
+          actions: {
+            edit: '編集',
+            open: 'エディターで開く',
+            moveUp: '上へ移動',
+            moveDown: '下へ移動',
+            remove: '削除'
+          }
+        },
+        entryKinds: {
+          post: {
+            label: '投稿',
+            confirm: '投稿エントリを追加',
+            placeholder: '投稿キー',
+            message: '新しい投稿キーを入力してください（英数字のみ）：'
+          },
+          tab: {
+            label: 'タブ',
+            confirm: 'タブエントリを追加',
+            placeholder: 'タブキー',
+            message: '新しいタブキーを入力してください（英数字のみ）：'
+          }
+        },
         diff: {
           heading: '変更',
           title: ({ label }) => `変更 — ${label}`,
@@ -1286,6 +1411,7 @@ const translations = {
         },
         currentFile: '現在のファイル',
         fileFallback: 'Markdown ファイル',
+        openBeforeEditor: 'エディターを開く前に Markdown の場所を入力してください。',
         toastCopiedCreate: 'Markdown をコピーしました。GitHub が開いてこのファイルを作成します。',
         toastCopiedUpdate: 'Markdown をコピーしました。GitHub が開いてこのファイルを更新します。',
         blockedCreate: 'Markdown をコピーしました。新しいタブが表示されない場合は「GitHub を開く」をクリックして作成してください。',

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -205,6 +205,7 @@ const translations = {
         addTab: 'Add Tab Entry',
         refresh: 'Refresh',
         refreshTitle: 'Fetch latest remote snapshot',
+        refreshing: 'Refreshing…',
         discard: 'Discard',
         discardTitle: 'Discard local draft and reload remote file',
         changeSummary: 'Change summary',
@@ -218,7 +219,11 @@ const translations = {
         noLocalChangesYet: 'No local changes yet.',
         statusMessages: {
           loadingConfig: 'Loading config…',
-          restoredDraft: ({ label }) => `Restored local draft for ${label}`
+          restoredDraft: ({ label }) => `Restored local draft for ${label}`,
+          refreshSuccess: ({ name }) => `${name} refreshed from remote`,
+          remoteUpdated: 'Remote snapshot updated. Highlights now include remote differences.',
+          remoteUnchanged: 'Remote snapshot unchanged.',
+          refreshFailed: 'Failed to refresh remote snapshot'
         },
         entryRow: {
           gripHint: 'Drag to reorder',
@@ -686,6 +691,7 @@ const translations = {
         addTab: '添加标签条目',
         refresh: '刷新',
         refreshTitle: '获取最新远程快照',
+        refreshing: '正在刷新…',
         discard: '丢弃',
         discardTitle: '丢弃本地草稿并重新加载远程文件',
         changeSummary: '更改摘要',
@@ -699,7 +705,11 @@ const translations = {
         noLocalChangesYet: '暂时没有本地更改。',
         statusMessages: {
           loadingConfig: '正在加载配置…',
-          restoredDraft: ({ label }) => `已恢复 ${label} 的本地草稿`
+          restoredDraft: ({ label }) => `已恢复 ${label} 的本地草稿`,
+          refreshSuccess: ({ name }) => `${name} 已从远程刷新`,
+          remoteUpdated: '远程快照已更新。高亮部分现在包含远程差异。',
+          remoteUnchanged: '远程快照未发生变化。',
+          refreshFailed: '刷新远程快照失败'
         },
         entryRow: {
           gripHint: '拖动以重新排序',
@@ -1167,6 +1177,7 @@ const translations = {
         addTab: 'タブ項目を追加',
         refresh: '更新',
         refreshTitle: '最新のリモートスナップショットを取得',
+        refreshing: '更新中…',
         discard: '破棄',
         discardTitle: 'ローカルの下書きを破棄してリモートを再読み込み',
         changeSummary: '変更の概要',
@@ -1180,7 +1191,11 @@ const translations = {
         noLocalChangesYet: 'ローカルの変更はまだありません。',
         statusMessages: {
           loadingConfig: '設定を読み込み中…',
-          restoredDraft: ({ label }) => `${label} のローカル下書きを復元しました`
+          restoredDraft: ({ label }) => `${label} のローカル下書きを復元しました`,
+          refreshSuccess: ({ name }) => `${name} をリモートから更新しました`,
+          remoteUpdated: 'リモートスナップショットが更新されました。ハイライトにリモートの差分が含まれます。',
+          remoteUnchanged: 'リモートスナップショットは変更されていません。',
+          refreshFailed: 'リモートスナップショットの更新に失敗しました'
         },
         entryRow: {
           gripHint: 'ドラッグして並び替え',

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -457,6 +457,11 @@ const translations = {
             reload: 'Discard local markdown changes (remote snapshot will be reloaded).'
           }
         },
+        draftIndicator: {
+          conflict: 'Local draft conflicts with remote file.',
+          dirty: 'Unsaved changes pending in editor.',
+          saved: 'Local draft saved in browser.'
+        },
         currentFile: 'current file',
         fileFallback: 'markdown file',
         openBeforeEditor: 'Enter a markdown location before opening the editor.',
@@ -933,6 +938,11 @@ const translations = {
             reload: '丢弃本地 Markdown 更改（将重新加载远程快照）。'
           }
         },
+        draftIndicator: {
+          conflict: '本地草稿与远程文件存在冲突。',
+          dirty: '编辑器中有未保存的更改。',
+          saved: '本地草稿已保存在浏览器中。'
+        },
         currentFile: '当前文件',
         fileFallback: 'Markdown 文件',
         openBeforeEditor: '请输入 Markdown 路径后再打开编辑器。',
@@ -1408,6 +1418,11 @@ const translations = {
             noFile: 'ローカル変更を破棄する前に Markdown ファイルを開いてください。',
             reload: 'Markdown のローカル変更を破棄し（リモートスナップショットを再読み込みします）。'
           }
+        },
+        draftIndicator: {
+          conflict: 'ローカルの下書きがリモートファイルと競合しています。',
+          dirty: 'エディターに未保存の変更があります。',
+          saved: 'ローカルの下書きはブラウザーに保存されています。'
         },
         currentFile: '現在のファイル',
         fileFallback: 'Markdown ファイル',

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -390,7 +390,102 @@ const translations = {
             submit: 'Commit changes',
             errorRequired: 'Enter a Fine-grained Personal Access Token to continue.'
           }
-        }
+        },
+        dialogs: {
+          cancel: 'Cancel',
+          confirm: 'Confirm'
+        },
+        addEntryPrompt: {
+          hint: 'Use only English letters and numbers.',
+          confirm: 'Add Entry',
+          defaultType: 'entry',
+          placeholder: 'Entry key',
+          message: ({ label }) => `Enter a new ${label} key:`,
+          errorEmpty: 'Key cannot be empty.',
+          errorInvalid: 'Key must contain only English letters, numbers, underscores, or hyphens.',
+          errorDuplicate: 'That key already exists. Choose a different key.'
+        },
+        discardConfirm: {
+          messageReload: ({ label }) => `Discard local changes for ${label} and reload the remote file? This action cannot be undone.`,
+          messageSimple: ({ label }) => `Discard local changes for ${label}? This action cannot be undone.`,
+          discard: 'Discard',
+          discarding: 'Discarding…',
+          successFresh: ({ label }) => `Discarded local changes; loaded fresh ${label}`,
+          successCached: ({ label }) => `Discarded local changes; restored ${label} from cached snapshot`,
+          failed: 'Failed to discard local changes'
+        },
+        markdown: {
+          push: {
+            labelDefault: 'Synchronize',
+            labelCreate: 'Create on GitHub',
+            labelUpdate: 'Synchronize',
+            tooltips: {
+              default: 'Copy draft to GitHub.',
+              noRepo: 'Configure repo in site.yaml to enable GitHub push.',
+              noFile: 'Open a markdown file to enable GitHub push.',
+              error: 'Resolve file load error before pushing to GitHub.',
+              checking: 'Checking remote version…',
+              loading: 'Loading remote snapshot…',
+              create: 'Copy draft and create this file on GitHub.',
+              update: 'Copy draft and update this file on GitHub.'
+            }
+          },
+          discard: {
+            label: 'Discard',
+            busy: 'Discarding…',
+            tooltips: {
+              default: 'Discard local markdown changes and restore the last loaded version.',
+              noFile: 'Open a markdown file to discard local changes.',
+              reload: 'Discard local markdown changes (remote snapshot will be reloaded).'
+            }
+          },
+          draftIndicator: {
+            conflict: 'Local draft conflicts with remote file.',
+            dirty: 'Unsaved changes pending in editor.',
+            saved: 'Local draft saved in browser.'
+          },
+          currentFile: 'current file',
+          fileFallback: 'markdown file',
+          openBeforeEditor: 'Enter a markdown location before opening the editor.',
+          toastCopiedCreate: 'Markdown copied. GitHub will open to create this file.',
+          toastCopiedUpdate: 'Markdown copied. GitHub will open to update this file.',
+          blockedCreate: 'Markdown copied. Click “Open GitHub” if the new tab did not appear so you can create this file.',
+          blockedUpdate: 'Markdown copied. Click “Open GitHub” if the new tab did not appear so you can update this file.'
+        },
+        yaml: {
+          toastCopiedUpdate: ({ name }) => `${name} copied. GitHub will open so you can paste the update.`,
+          toastCopiedCreate: ({ name }) => `${name} copied. GitHub will open so you can create the file.`,
+          blocked: ({ name }) => `${name} copied. Click “Open GitHub” if the new tab did not appear.`
+        },
+        remoteWatcher: {
+          waitingForCreate: ({ label }) => `Waiting for GitHub to create ${label}`,
+          waitingForUpdate: ({ label }) => `Waiting for GitHub to update ${label}`,
+          waitingForCommitStatus: 'Waiting for GitHub commit…',
+          checkingRemoteChanges: 'Checking remote changes…',
+          waitingForCommit: 'Waiting for commit…',
+          stopWaiting: 'Stop waiting',
+          waitingForRemoteResponse: 'Waiting for remote response…',
+          remoteCheckFailedRetry: 'Remote check failed. Retrying…',
+          remoteFileNotFoundYet: 'Remote file not found yet…',
+          remoteFileStillMissing: 'Remote file still missing…',
+          updateDetectedRefreshing: 'Update detected. Refreshing…',
+          remoteFileDiffersWaiting: 'Remote file still differs from local content. Waiting…',
+          remoteFileExistsDiffersWaiting: 'Remote file exists but content differs. Waiting…',
+          mismatchAdvice: 'If your GitHub commit intentionally differs, cancel and use Refresh to review it.',
+          remoteCheckCanceled: 'Remote check canceled',
+          errorWithDetail: ({ message }) => `Error: ${message}`,
+          networkError: 'Network error',
+          fileNotFoundOnServer: 'File not found on server',
+          remoteSnapshotUpdated: 'Remote snapshot updated',
+          waitingForGitHub: 'Waiting for GitHub…',
+          preparing: 'Preparing…',
+          waitingForLabel: ({ label }) => `Waiting for ${label} to update on GitHub…`,
+          waitingForRemote: 'Waiting for remote…',
+          yamlNotFoundYet: ({ label }) => `${label} not found on remote yet…`,
+          remoteYamlDiffersWaiting: 'Remote YAML still differs from the local snapshot. Waiting…',
+          remoteYamlExistsDiffersWaiting: 'Remote YAML updated but content differs. Waiting…',
+          yamlMismatchAdvice: 'If the commit was different from your draft, cancel and click Refresh to pull it in.'
+        },
       },
       github: {
         status: {
@@ -413,101 +508,6 @@ const translations = {
           configUnavailable: 'GitHub configuration unavailable',
           readFailed: 'Failed to read site.yaml.'
         }
-      },
-      dialogs: {
-        cancel: 'Cancel',
-        confirm: 'Confirm'
-      },
-      addEntryPrompt: {
-        hint: 'Use only English letters and numbers.',
-        confirm: 'Add Entry',
-        defaultType: 'entry',
-        placeholder: 'Entry key',
-        message: ({ label }) => `Enter a new ${label} key:`,
-        errorEmpty: 'Key cannot be empty.',
-        errorInvalid: 'Key must contain only English letters, numbers, underscores, or hyphens.',
-        errorDuplicate: 'That key already exists. Choose a different key.'
-      },
-      discardConfirm: {
-        messageReload: ({ label }) => `Discard local changes for ${label} and reload the remote file? This action cannot be undone.`,
-        messageSimple: ({ label }) => `Discard local changes for ${label}? This action cannot be undone.`,
-        discard: 'Discard',
-        discarding: 'Discarding…',
-        successFresh: ({ label }) => `Discarded local changes; loaded fresh ${label}`,
-        successCached: ({ label }) => `Discarded local changes; restored ${label} from cached snapshot`,
-        failed: 'Failed to discard local changes'
-      },
-      markdown: {
-        push: {
-          labelDefault: 'Synchronize',
-          labelCreate: 'Create on GitHub',
-          labelUpdate: 'Synchronize',
-          tooltips: {
-            default: 'Copy draft to GitHub.',
-            noRepo: 'Configure repo in site.yaml to enable GitHub push.',
-            noFile: 'Open a markdown file to enable GitHub push.',
-            error: 'Resolve file load error before pushing to GitHub.',
-            checking: 'Checking remote version…',
-            loading: 'Loading remote snapshot…',
-            create: 'Copy draft and create this file on GitHub.',
-            update: 'Copy draft and update this file on GitHub.'
-          }
-        },
-        discard: {
-          label: 'Discard',
-          busy: 'Discarding…',
-          tooltips: {
-            default: 'Discard local markdown changes and restore the last loaded version.',
-            noFile: 'Open a markdown file to discard local changes.',
-            reload: 'Discard local markdown changes (remote snapshot will be reloaded).'
-          }
-        },
-        draftIndicator: {
-          conflict: 'Local draft conflicts with remote file.',
-          dirty: 'Unsaved changes pending in editor.',
-          saved: 'Local draft saved in browser.'
-        },
-        currentFile: 'current file',
-        fileFallback: 'markdown file',
-        openBeforeEditor: 'Enter a markdown location before opening the editor.',
-        toastCopiedCreate: 'Markdown copied. GitHub will open to create this file.',
-        toastCopiedUpdate: 'Markdown copied. GitHub will open to update this file.',
-        blockedCreate: 'Markdown copied. Click “Open GitHub” if the new tab did not appear so you can create this file.',
-        blockedUpdate: 'Markdown copied. Click “Open GitHub” if the new tab did not appear so you can update this file.'
-      },
-      yaml: {
-        toastCopiedUpdate: ({ name }) => `${name} copied. GitHub will open so you can paste the update.`,
-        toastCopiedCreate: ({ name }) => `${name} copied. GitHub will open so you can create the file.`,
-        blocked: ({ name }) => `${name} copied. Click “Open GitHub” if the new tab did not appear.`
-      },
-      remoteWatcher: {
-        waitingForCreate: ({ label }) => `Waiting for GitHub to create ${label}`,
-        waitingForUpdate: ({ label }) => `Waiting for GitHub to update ${label}`,
-        waitingForCommitStatus: 'Waiting for GitHub commit…',
-        checkingRemoteChanges: 'Checking remote changes…',
-        waitingForCommit: 'Waiting for commit…',
-        stopWaiting: 'Stop waiting',
-        waitingForRemoteResponse: 'Waiting for remote response…',
-        remoteCheckFailedRetry: 'Remote check failed. Retrying…',
-        remoteFileNotFoundYet: 'Remote file not found yet…',
-        remoteFileStillMissing: 'Remote file still missing…',
-        updateDetectedRefreshing: 'Update detected. Refreshing…',
-        remoteFileDiffersWaiting: 'Remote file still differs from local content. Waiting…',
-        remoteFileExistsDiffersWaiting: 'Remote file exists but content differs. Waiting…',
-        mismatchAdvice: 'If your GitHub commit intentionally differs, cancel and use Refresh to review it.',
-        remoteCheckCanceled: 'Remote check canceled',
-        errorWithDetail: ({ message }) => `Error: ${message}`,
-        networkError: 'Network error',
-        fileNotFoundOnServer: 'File not found on server',
-        remoteSnapshotUpdated: 'Remote snapshot updated',
-        waitingForGitHub: 'Waiting for GitHub…',
-        preparing: 'Preparing…',
-        waitingForLabel: ({ label }) => `Waiting for ${label} to update on GitHub…`,
-        waitingForRemote: 'Waiting for remote…',
-        yamlNotFoundYet: ({ label }) => `${label} not found on remote yet…`,
-        remoteYamlDiffersWaiting: 'Remote YAML still differs from the local snapshot. Waiting…',
-        remoteYamlExistsDiffersWaiting: 'Remote YAML updated but content differs. Waiting…',
-        yamlMismatchAdvice: 'If the commit was different from your draft, cancel and click Refresh to pull it in.'
       },
       footerNote: 'Crafted with ❤️ using <a href="https://deemoe404.github.io/NanoSite/" target="_blank" rel="noopener">NanoSite</a>. Stay inspired and keep creating.'
     }
@@ -876,7 +876,102 @@ const translations = {
             submit: '提交更改',
             errorRequired: '请输入精细化个人访问令牌以继续。'
           }
-        }
+        },
+        dialogs: {
+          cancel: '取消',
+          confirm: '确认'
+        },
+        addEntryPrompt: {
+          hint: '仅使用英文字母和数字。',
+          confirm: '添加条目',
+          defaultType: '条目',
+          placeholder: '条目键名',
+          message: ({ label }) => `请输入新的 ${label} 键名：`,
+          errorEmpty: '键名不能为空。',
+          errorInvalid: '键名只能包含英文字母、数字、下划线或连字符。',
+          errorDuplicate: '该键名已存在，请使用其他键名。'
+        },
+        discardConfirm: {
+          messageReload: ({ label }) => `丢弃 ${label} 的本地更改并重新加载远程文件？此操作无法撤销。`,
+          messageSimple: ({ label }) => `丢弃 ${label} 的本地更改？此操作无法撤销。`,
+          discard: '丢弃',
+          discarding: '正在丢弃…',
+          successFresh: ({ label }) => `已丢弃本地更改；已加载最新的 ${label}`,
+          successCached: ({ label }) => `已丢弃本地更改；已从缓存快照恢复 ${label}`,
+          failed: '丢弃本地更改失败。'
+        },
+        markdown: {
+          push: {
+            labelDefault: '同步',
+            labelCreate: '在 GitHub 上创建',
+            labelUpdate: '同步',
+            tooltips: {
+              default: '复制草稿到 GitHub。',
+              noRepo: '请在 site.yaml 中配置仓库以启用 GitHub 推送。',
+              noFile: '请先打开一个 Markdown 文件以启用 GitHub 推送。',
+              error: '推送前请先解决文件加载错误。',
+              checking: '正在检查远程版本…',
+              loading: '正在加载远程快照…',
+              create: '复制草稿并在 GitHub 上创建该文件。',
+              update: '复制草稿并在 GitHub 上更新该文件。'
+            }
+          },
+          discard: {
+            label: '丢弃',
+            busy: '正在丢弃…',
+            tooltips: {
+              default: '丢弃本地 Markdown 更改并恢复上次加载的版本。',
+              noFile: '请先打开一个 Markdown 文件再丢弃本地更改。',
+              reload: '丢弃本地 Markdown 更改（将重新加载远程快照）。'
+            }
+          },
+          draftIndicator: {
+            conflict: '本地草稿与远程文件存在冲突。',
+            dirty: '编辑器中有未保存的更改。',
+            saved: '本地草稿已保存在浏览器中。'
+          },
+          currentFile: '当前文件',
+          fileFallback: 'Markdown 文件',
+          openBeforeEditor: '请输入 Markdown 路径后再打开编辑器。',
+          toastCopiedCreate: '已复制 Markdown。GitHub 将打开以创建该文件。',
+          toastCopiedUpdate: '已复制 Markdown。GitHub 将打开以更新该文件。',
+          blockedCreate: '已复制 Markdown。如未打开新标签页，请点击“打开 GitHub”以创建该文件。',
+          blockedUpdate: '已复制 Markdown。如未打开新标签页，请点击“打开 GitHub”以更新该文件。'
+        },
+        yaml: {
+          toastCopiedUpdate: ({ name }) => `已复制 ${name}。GitHub 将打开以粘贴更新。`,
+          toastCopiedCreate: ({ name }) => `已复制 ${name}。GitHub 将打开以创建该文件。`,
+          blocked: ({ name }) => `已复制 ${name}。如未打开新标签页，请点击“打开 GitHub”。`
+        },
+        remoteWatcher: {
+          waitingForCreate: ({ label }) => `正在等待 GitHub 创建 ${label}`,
+          waitingForUpdate: ({ label }) => `正在等待 GitHub 更新 ${label}`,
+          waitingForCommitStatus: '正在等待 GitHub 提交…',
+          checkingRemoteChanges: '正在检查远程更改…',
+          waitingForCommit: '正在等待提交…',
+          stopWaiting: '停止等待',
+          waitingForRemoteResponse: '正在等待远程响应…',
+          remoteCheckFailedRetry: '远程检查失败，正在重试…',
+          remoteFileNotFoundYet: '远程文件尚未找到…',
+          remoteFileStillMissing: '远程文件仍缺失…',
+          updateDetectedRefreshing: '检测到更新，正在刷新…',
+          remoteFileDiffersWaiting: '远程文件内容与本地仍不一致，继续等待…',
+          remoteFileExistsDiffersWaiting: '远程文件已存在但内容不同，继续等待…',
+          mismatchAdvice: '如果你的 GitHub 提交确实不同，请取消并使用“刷新”查看。',
+          remoteCheckCanceled: '远程检查已取消',
+          errorWithDetail: ({ message }) => `错误：${message}`,
+          networkError: '网络错误',
+          fileNotFoundOnServer: '服务器上未找到文件',
+          remoteSnapshotUpdated: '远程快照已更新',
+          waitingForGitHub: '正在等待 GitHub…',
+          preparing: '正在准备…',
+          waitingForLabel: ({ label }) => `正在等待 ${label} 在 GitHub 上更新…`,
+          waitingForRemote: '正在等待远程…',
+          yamlNotFoundYet: ({ label }) => `${label} 在远程尚未找到…`,
+          remoteYamlDiffersWaiting: '远程 YAML 与本地快照仍不一致，继续等待…',
+          remoteYamlExistsDiffersWaiting: '远程 YAML 已更新但内容不同，继续等待…',
+          yamlMismatchAdvice: '如果提交与草稿不同，请取消并点击“刷新”以拉取。'
+        },
       },
       github: {
         status: {
@@ -899,101 +994,6 @@ const translations = {
           configUnavailable: '无法获取 GitHub 配置',
           readFailed: '读取 site.yaml 失败。'
         }
-      },
-      dialogs: {
-        cancel: '取消',
-        confirm: '确认'
-      },
-      addEntryPrompt: {
-        hint: '仅使用英文字母和数字。',
-        confirm: '添加条目',
-        defaultType: '条目',
-        placeholder: '条目键名',
-        message: ({ label }) => `请输入新的 ${label} 键名：`,
-        errorEmpty: '键名不能为空。',
-        errorInvalid: '键名只能包含英文字母、数字、下划线或连字符。',
-        errorDuplicate: '该键名已存在，请使用其他键名。'
-      },
-      discardConfirm: {
-        messageReload: ({ label }) => `丢弃 ${label} 的本地更改并重新加载远程文件？此操作无法撤销。`,
-        messageSimple: ({ label }) => `丢弃 ${label} 的本地更改？此操作无法撤销。`,
-        discard: '丢弃',
-        discarding: '正在丢弃…',
-        successFresh: ({ label }) => `已丢弃本地更改；已加载最新的 ${label}`,
-        successCached: ({ label }) => `已丢弃本地更改；已从缓存快照恢复 ${label}`,
-        failed: '丢弃本地更改失败。'
-      },
-      markdown: {
-        push: {
-          labelDefault: '同步',
-          labelCreate: '在 GitHub 上创建',
-          labelUpdate: '同步',
-          tooltips: {
-            default: '复制草稿到 GitHub。',
-            noRepo: '请在 site.yaml 中配置仓库以启用 GitHub 推送。',
-            noFile: '请先打开一个 Markdown 文件以启用 GitHub 推送。',
-            error: '推送前请先解决文件加载错误。',
-            checking: '正在检查远程版本…',
-            loading: '正在加载远程快照…',
-            create: '复制草稿并在 GitHub 上创建该文件。',
-            update: '复制草稿并在 GitHub 上更新该文件。'
-          }
-        },
-        discard: {
-          label: '丢弃',
-          busy: '正在丢弃…',
-          tooltips: {
-            default: '丢弃本地 Markdown 更改并恢复上次加载的版本。',
-            noFile: '请先打开一个 Markdown 文件再丢弃本地更改。',
-            reload: '丢弃本地 Markdown 更改（将重新加载远程快照）。'
-          }
-        },
-        draftIndicator: {
-          conflict: '本地草稿与远程文件存在冲突。',
-          dirty: '编辑器中有未保存的更改。',
-          saved: '本地草稿已保存在浏览器中。'
-        },
-        currentFile: '当前文件',
-        fileFallback: 'Markdown 文件',
-        openBeforeEditor: '请输入 Markdown 路径后再打开编辑器。',
-        toastCopiedCreate: '已复制 Markdown。GitHub 将打开以创建该文件。',
-        toastCopiedUpdate: '已复制 Markdown。GitHub 将打开以更新该文件。',
-        blockedCreate: '已复制 Markdown。如未打开新标签页，请点击“打开 GitHub”以创建该文件。',
-        blockedUpdate: '已复制 Markdown。如未打开新标签页，请点击“打开 GitHub”以更新该文件。'
-      },
-      yaml: {
-        toastCopiedUpdate: ({ name }) => `已复制 ${name}。GitHub 将打开以粘贴更新。`,
-        toastCopiedCreate: ({ name }) => `已复制 ${name}。GitHub 将打开以创建该文件。`,
-        blocked: ({ name }) => `已复制 ${name}。如未打开新标签页，请点击“打开 GitHub”。`
-      },
-      remoteWatcher: {
-        waitingForCreate: ({ label }) => `正在等待 GitHub 创建 ${label}`,
-        waitingForUpdate: ({ label }) => `正在等待 GitHub 更新 ${label}`,
-        waitingForCommitStatus: '正在等待 GitHub 提交…',
-        checkingRemoteChanges: '正在检查远程更改…',
-        waitingForCommit: '正在等待提交…',
-        stopWaiting: '停止等待',
-        waitingForRemoteResponse: '正在等待远程响应…',
-        remoteCheckFailedRetry: '远程检查失败，正在重试…',
-        remoteFileNotFoundYet: '远程文件尚未找到…',
-        remoteFileStillMissing: '远程文件仍缺失…',
-        updateDetectedRefreshing: '检测到更新，正在刷新…',
-        remoteFileDiffersWaiting: '远程文件内容与本地仍不一致，继续等待…',
-        remoteFileExistsDiffersWaiting: '远程文件已存在但内容不同，继续等待…',
-        mismatchAdvice: '如果你的 GitHub 提交确实不同，请取消并使用“刷新”查看。',
-        remoteCheckCanceled: '远程检查已取消',
-        errorWithDetail: ({ message }) => `错误：${message}`,
-        networkError: '网络错误',
-        fileNotFoundOnServer: '服务器上未找到文件',
-        remoteSnapshotUpdated: '远程快照已更新',
-        waitingForGitHub: '正在等待 GitHub…',
-        preparing: '正在准备…',
-        waitingForLabel: ({ label }) => `正在等待 ${label} 在 GitHub 上更新…`,
-        waitingForRemote: '正在等待远程…',
-        yamlNotFoundYet: ({ label }) => `${label} 在远程尚未找到…`,
-        remoteYamlDiffersWaiting: '远程 YAML 与本地快照仍不一致，继续等待…',
-        remoteYamlExistsDiffersWaiting: '远程 YAML 已更新但内容不同，继续等待…',
-        yamlMismatchAdvice: '如果提交与草稿不同，请取消并点击“刷新”以拉取。'
       },
       footerNote: '由 ❤️ 打造，基于 <a href="https://deemoe404.github.io/NanoSite/" target="_blank" rel="noopener">NanoSite</a>。保持灵感，持续创作。'
     },
@@ -1362,7 +1362,102 @@ const translations = {
             submit: '変更をコミット',
             errorRequired: '続行するにはファイングレインド Personal Access Token を入力してください。'
           }
-        }
+        },
+        dialogs: {
+          cancel: 'キャンセル',
+          confirm: '確認'
+        },
+        addEntryPrompt: {
+          hint: '英数字のみを使用してください。',
+          confirm: 'エントリーを追加',
+          defaultType: 'エントリー',
+          placeholder: 'エントリーキー',
+          message: ({ label }) => `新しい ${label} のキーを入力してください：`,
+          errorEmpty: 'キーは必須です。',
+          errorInvalid: 'キーには英数字、アンダースコア、ハイフンのみ使用できます。',
+          errorDuplicate: 'そのキーは既に存在します。別のキーを選んでください。'
+        },
+        discardConfirm: {
+          messageReload: ({ label }) => `${label} のローカル変更を破棄してリモートファイルを再読み込みしますか？この操作は取り消せません。`,
+          messageSimple: ({ label }) => `${label} のローカル変更を破棄しますか？この操作は取り消せません。`,
+          discard: '破棄',
+          discarding: '破棄中…',
+          successFresh: ({ label }) => `ローカル変更を破棄し、最新の ${label} を読み込みました`,
+          successCached: ({ label }) => `ローカル変更を破棄し、キャッシュの ${label} を復元しました`,
+          failed: 'ローカル変更を破棄できませんでした。'
+        },
+        markdown: {
+          push: {
+            labelDefault: '同期',
+            labelCreate: 'GitHub で作成',
+            labelUpdate: '同期',
+            tooltips: {
+              default: 'ドラフトを GitHub にコピーします。',
+              noRepo: 'GitHub プッシュを有効にするには site.yaml でリポジトリを設定してください。',
+              noFile: 'GitHub にプッシュする前に Markdown ファイルを開いてください。',
+              error: 'プッシュする前にファイル読み込みエラーを解決してください。',
+              checking: 'リモート版を確認中…',
+              loading: 'リモートスナップショットを読み込み中…',
+              create: 'ドラフトをコピーして GitHub でこのファイルを作成します。',
+              update: 'ドラフトをコピーして GitHub でこのファイルを更新します。'
+            }
+          },
+          discard: {
+            label: '破棄',
+            busy: '破棄中…',
+            tooltips: {
+              default: 'Markdown のローカル変更を破棄し、最後に読み込んだ版を復元します。',
+              noFile: 'ローカル変更を破棄する前に Markdown ファイルを開いてください。',
+              reload: 'Markdown のローカル変更を破棄し（リモートスナップショットを再読み込みします）。'
+            }
+          },
+          draftIndicator: {
+            conflict: 'ローカルの下書きがリモートファイルと競合しています。',
+            dirty: 'エディターに未保存の変更があります。',
+            saved: 'ローカルの下書きはブラウザーに保存されています。'
+          },
+          currentFile: '現在のファイル',
+          fileFallback: 'Markdown ファイル',
+          openBeforeEditor: 'エディターを開く前に Markdown の場所を入力してください。',
+          toastCopiedCreate: 'Markdown をコピーしました。GitHub が開いてこのファイルを作成します。',
+          toastCopiedUpdate: 'Markdown をコピーしました。GitHub が開いてこのファイルを更新します。',
+          blockedCreate: 'Markdown をコピーしました。新しいタブが表示されない場合は「GitHub を開く」をクリックして作成してください。',
+          blockedUpdate: 'Markdown をコピーしました。新しいタブが表示されない場合は「GitHub を開く」をクリックして更新してください。'
+        },
+        yaml: {
+          toastCopiedUpdate: ({ name }) => `${name} をコピーしました。GitHub が開いて更新内容を貼り付けられます。`,
+          toastCopiedCreate: ({ name }) => `${name} をコピーしました。GitHub が開いてファイルを作成できます。`,
+          blocked: ({ name }) => `${name} をコピーしました。新しいタブが表示されない場合は「GitHub を開く」をクリックしてください。`
+        },
+        remoteWatcher: {
+          waitingForCreate: ({ label }) => `GitHub で ${label} が作成されるのを待機しています`,
+          waitingForUpdate: ({ label }) => `GitHub で ${label} が更新されるのを待機しています`,
+          waitingForCommitStatus: 'GitHub のコミットを待機中…',
+          checkingRemoteChanges: 'リモートの変更を確認中…',
+          waitingForCommit: 'コミットを待機中…',
+          stopWaiting: '待機を停止',
+          waitingForRemoteResponse: 'リモートの応答を待機しています…',
+          remoteCheckFailedRetry: 'リモートチェックに失敗しました。再試行します…',
+          remoteFileNotFoundYet: 'リモートファイルがまだ見つかりません…',
+          remoteFileStillMissing: 'リモートファイルがまだ存在しません…',
+          updateDetectedRefreshing: '更新を検出しました。再読み込みしています…',
+          remoteFileDiffersWaiting: 'リモートファイルがローカル内容とまだ一致しません。待機中…',
+          remoteFileExistsDiffersWaiting: 'リモートファイルは存在しますが内容が異なります。待機中…',
+          mismatchAdvice: 'GitHub のコミットが意図的に異なる場合はキャンセルし、「更新」で内容を確認してください。',
+          remoteCheckCanceled: 'リモートチェックをキャンセルしました',
+          errorWithDetail: ({ message }) => `エラー: ${message}`,
+          networkError: 'ネットワークエラー',
+          fileNotFoundOnServer: 'サーバーでファイルが見つかりません',
+          remoteSnapshotUpdated: 'リモートスナップショットを更新しました',
+          waitingForGitHub: 'GitHub を待機中…',
+          preparing: '準備中…',
+          waitingForLabel: ({ label }) => `GitHub で ${label} の更新を待機しています…`,
+          waitingForRemote: 'リモートを待機中…',
+          yamlNotFoundYet: ({ label }) => `リモートで ${label} がまだ見つかりません…`,
+          remoteYamlDiffersWaiting: 'リモート YAML がローカルのスナップショットとまだ一致しません。待機中…',
+          remoteYamlExistsDiffersWaiting: 'リモート YAML は更新されていますが内容が異なります。待機中…',
+          yamlMismatchAdvice: 'コミット内容が下書きと異なる場合はキャンセルし、「更新」をクリックして取得してください。'
+        },
       },
       github: {
         status: {
@@ -1385,101 +1480,6 @@ const translations = {
           configUnavailable: 'GitHub 設定を取得できません',
           readFailed: 'site.yaml の読み込みに失敗しました。'
         }
-      },
-      dialogs: {
-        cancel: 'キャンセル',
-        confirm: '確認'
-      },
-      addEntryPrompt: {
-        hint: '英数字のみを使用してください。',
-        confirm: 'エントリーを追加',
-        defaultType: 'エントリー',
-        placeholder: 'エントリーキー',
-        message: ({ label }) => `新しい ${label} のキーを入力してください：`,
-        errorEmpty: 'キーは必須です。',
-        errorInvalid: 'キーには英数字、アンダースコア、ハイフンのみ使用できます。',
-        errorDuplicate: 'そのキーは既に存在します。別のキーを選んでください。'
-      },
-      discardConfirm: {
-        messageReload: ({ label }) => `${label} のローカル変更を破棄してリモートファイルを再読み込みしますか？この操作は取り消せません。`,
-        messageSimple: ({ label }) => `${label} のローカル変更を破棄しますか？この操作は取り消せません。`,
-        discard: '破棄',
-        discarding: '破棄中…',
-        successFresh: ({ label }) => `ローカル変更を破棄し、最新の ${label} を読み込みました`,
-        successCached: ({ label }) => `ローカル変更を破棄し、キャッシュの ${label} を復元しました`,
-        failed: 'ローカル変更を破棄できませんでした。'
-      },
-      markdown: {
-        push: {
-          labelDefault: '同期',
-          labelCreate: 'GitHub で作成',
-          labelUpdate: '同期',
-          tooltips: {
-            default: 'ドラフトを GitHub にコピーします。',
-            noRepo: 'GitHub プッシュを有効にするには site.yaml でリポジトリを設定してください。',
-            noFile: 'GitHub にプッシュする前に Markdown ファイルを開いてください。',
-            error: 'プッシュする前にファイル読み込みエラーを解決してください。',
-            checking: 'リモート版を確認中…',
-            loading: 'リモートスナップショットを読み込み中…',
-            create: 'ドラフトをコピーして GitHub でこのファイルを作成します。',
-            update: 'ドラフトをコピーして GitHub でこのファイルを更新します。'
-          }
-        },
-        discard: {
-          label: '破棄',
-          busy: '破棄中…',
-          tooltips: {
-            default: 'Markdown のローカル変更を破棄し、最後に読み込んだ版を復元します。',
-            noFile: 'ローカル変更を破棄する前に Markdown ファイルを開いてください。',
-            reload: 'Markdown のローカル変更を破棄し（リモートスナップショットを再読み込みします）。'
-          }
-        },
-        draftIndicator: {
-          conflict: 'ローカルの下書きがリモートファイルと競合しています。',
-          dirty: 'エディターに未保存の変更があります。',
-          saved: 'ローカルの下書きはブラウザーに保存されています。'
-        },
-        currentFile: '現在のファイル',
-        fileFallback: 'Markdown ファイル',
-        openBeforeEditor: 'エディターを開く前に Markdown の場所を入力してください。',
-        toastCopiedCreate: 'Markdown をコピーしました。GitHub が開いてこのファイルを作成します。',
-        toastCopiedUpdate: 'Markdown をコピーしました。GitHub が開いてこのファイルを更新します。',
-        blockedCreate: 'Markdown をコピーしました。新しいタブが表示されない場合は「GitHub を開く」をクリックして作成してください。',
-        blockedUpdate: 'Markdown をコピーしました。新しいタブが表示されない場合は「GitHub を開く」をクリックして更新してください。'
-      },
-      yaml: {
-        toastCopiedUpdate: ({ name }) => `${name} をコピーしました。GitHub が開いて更新内容を貼り付けられます。`,
-        toastCopiedCreate: ({ name }) => `${name} をコピーしました。GitHub が開いてファイルを作成できます。`,
-        blocked: ({ name }) => `${name} をコピーしました。新しいタブが表示されない場合は「GitHub を開く」をクリックしてください。`
-      },
-      remoteWatcher: {
-        waitingForCreate: ({ label }) => `GitHub で ${label} が作成されるのを待機しています`,
-        waitingForUpdate: ({ label }) => `GitHub で ${label} が更新されるのを待機しています`,
-        waitingForCommitStatus: 'GitHub のコミットを待機中…',
-        checkingRemoteChanges: 'リモートの変更を確認中…',
-        waitingForCommit: 'コミットを待機中…',
-        stopWaiting: '待機を停止',
-        waitingForRemoteResponse: 'リモートの応答を待機しています…',
-        remoteCheckFailedRetry: 'リモートチェックに失敗しました。再試行します…',
-        remoteFileNotFoundYet: 'リモートファイルがまだ見つかりません…',
-        remoteFileStillMissing: 'リモートファイルがまだ存在しません…',
-        updateDetectedRefreshing: '更新を検出しました。再読み込みしています…',
-        remoteFileDiffersWaiting: 'リモートファイルがローカル内容とまだ一致しません。待機中…',
-        remoteFileExistsDiffersWaiting: 'リモートファイルは存在しますが内容が異なります。待機中…',
-        mismatchAdvice: 'GitHub のコミットが意図的に異なる場合はキャンセルし、「更新」で内容を確認してください。',
-        remoteCheckCanceled: 'リモートチェックをキャンセルしました',
-        errorWithDetail: ({ message }) => `エラー: ${message}`,
-        networkError: 'ネットワークエラー',
-        fileNotFoundOnServer: 'サーバーでファイルが見つかりません',
-        remoteSnapshotUpdated: 'リモートスナップショットを更新しました',
-        waitingForGitHub: 'GitHub を待機中…',
-        preparing: '準備中…',
-        waitingForLabel: ({ label }) => `GitHub で ${label} の更新を待機しています…`,
-        waitingForRemote: 'リモートを待機中…',
-        yamlNotFoundYet: ({ label }) => `リモートで ${label} がまだ見つかりません…`,
-        remoteYamlDiffersWaiting: 'リモート YAML がローカルのスナップショットとまだ一致しません。待機中…',
-        remoteYamlExistsDiffersWaiting: 'リモート YAML は更新されていますが内容が異なります。待機中…',
-        yamlMismatchAdvice: 'コミット内容が下書きと異なる場合はキャンセルし、「更新」をクリックして取得してください。'
       },
       footerNote: '❤️ で作られた <a href="https://deemoe404.github.io/NanoSite/" target="_blank" rel="noopener">NanoSite</a> を使って創作を楽しみましょう。'
     },

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -134,6 +134,21 @@ const translations = {
         wrapAria: 'Wrap setting',
         viewAria: 'View switch'
       },
+      toast: {
+        openAction: 'Open',
+        closeAria: 'Close notification'
+      },
+      toasts: {
+        remoteMarkdownMismatch: 'Remote markdown differs from the local draft. Review the changes before continuing.',
+        markdownSynced: 'Markdown synchronized with GitHub.',
+        remoteCheckCanceledUseRefresh: 'Remote check canceled. Use Refresh after your commit is ready.',
+        yamlParseFailed: ({ label }) => `Fetched ${label} but failed to parse YAML.`,
+        yamlUpdatedDifferently: ({ label }) => `${label} was updated differently on GitHub. Review the highlighted differences.`,
+        yamlSynced: ({ label }) => `${label} synchronized with GitHub.`,
+        remoteCheckCanceledClickRefresh: 'Remote check canceled. Click Refresh when your commit is ready.',
+        popupBlocked: 'Your browser blocked the GitHub window. Allow pop-ups for this site and try again.',
+        openGithubAction: 'Open GitHub'
+      },
       editorTools: {
         aria: 'Editor tools',
         formatGroupAria: 'Formatting shortcuts',
@@ -176,6 +191,35 @@ const translations = {
         tabsEditorAria: 'tabs.yaml editor',
         noLocalChangesToCommit: 'No local changes to commit.',
         noLocalChangesYet: 'No local changes yet.'
+      },
+      remoteWatcher: {
+        waitingForCreate: ({ label }) => `Waiting for GitHub to create ${label}`,
+        waitingForUpdate: ({ label }) => `Waiting for GitHub to update ${label}`,
+        waitingForCommitStatus: 'Waiting for GitHub commit…',
+        checkingRemoteChanges: 'Checking remote changes…',
+        waitingForCommit: 'Waiting for commit…',
+        stopWaiting: 'Stop waiting',
+        waitingForRemoteResponse: 'Waiting for remote response…',
+        remoteCheckFailedRetry: 'Remote check failed. Retrying…',
+        remoteFileNotFoundYet: 'Remote file not found yet…',
+        remoteFileStillMissing: 'Remote file still missing…',
+        updateDetectedRefreshing: 'Update detected. Refreshing…',
+        remoteFileDiffersWaiting: 'Remote file still differs from local content. Waiting…',
+        remoteFileExistsDiffersWaiting: 'Remote file exists but content differs. Waiting…',
+        mismatchAdvice: 'If your GitHub commit intentionally differs, cancel and use Refresh to review it.',
+        remoteCheckCanceled: 'Remote check canceled',
+        errorWithDetail: ({ message }) => `Error: ${message}`,
+        networkError: 'Network error',
+        fileNotFoundOnServer: 'File not found on server',
+        remoteSnapshotUpdated: 'Remote snapshot updated',
+        waitingForGitHub: 'Waiting for GitHub…',
+        preparing: 'Preparing…',
+        waitingForLabel: ({ label }) => `Waiting for ${label} to update on GitHub…`,
+        waitingForRemote: 'Waiting for remote…',
+        yamlNotFoundYet: ({ label }) => `${label} not found on remote yet…`,
+        remoteYamlDiffersWaiting: 'Remote YAML still differs from the local snapshot. Waiting…',
+        remoteYamlExistsDiffersWaiting: 'Remote YAML updated but content differs. Waiting…',
+        yamlMismatchAdvice: 'If the commit was different from your draft, cancel and click Refresh to pull it in.'
       },
       footerNote: 'Crafted with ❤️ using <a href="https://deemoe404.github.io/NanoSite/" target="_blank" rel="noopener">NanoSite</a>. Stay inspired and keep creating.'
     }
@@ -288,6 +332,21 @@ const translations = {
         wrapAria: '换行设置',
         viewAria: '视图切换'
       },
+      toast: {
+        openAction: '打开',
+        closeAria: '关闭通知'
+      },
+      toasts: {
+        remoteMarkdownMismatch: '远程 Markdown 与本地草稿不同。继续前请检查差异。',
+        markdownSynced: 'Markdown 已与 GitHub 同步。',
+        remoteCheckCanceledUseRefresh: '远程检查已取消。提交准备好后请点击“刷新”。',
+        yamlParseFailed: ({ label }) => `已获取 ${label}，但无法解析 YAML。`,
+        yamlUpdatedDifferently: ({ label }) => `${label} 在 GitHub 上的更新不同。请检查高亮的差异。`,
+        yamlSynced: ({ label }) => `${label} 已与 GitHub 同步。`,
+        remoteCheckCanceledClickRefresh: '远程检查已取消。提交准备好后请点击“刷新”。',
+        popupBlocked: '浏览器阻止了 GitHub 窗口。请允许此站点的弹出窗口后重试。',
+        openGithubAction: '打开 GitHub'
+      },
       editorTools: {
         aria: '编辑器工具',
         formatGroupAria: '格式快捷键',
@@ -331,8 +390,37 @@ const translations = {
         noLocalChangesToCommit: '没有本地更改可提交。',
         noLocalChangesYet: '暂时没有本地更改。'
       },
+      remoteWatcher: {
+        waitingForCreate: ({ label }) => `正在等待 GitHub 创建 ${label}`,
+        waitingForUpdate: ({ label }) => `正在等待 GitHub 更新 ${label}`,
+        waitingForCommitStatus: '正在等待 GitHub 提交…',
+        checkingRemoteChanges: '正在检查远程更改…',
+        waitingForCommit: '正在等待提交…',
+        stopWaiting: '停止等待',
+        waitingForRemoteResponse: '正在等待远程响应…',
+        remoteCheckFailedRetry: '远程检查失败，正在重试…',
+        remoteFileNotFoundYet: '远程文件尚未找到…',
+        remoteFileStillMissing: '远程文件仍缺失…',
+        updateDetectedRefreshing: '检测到更新，正在刷新…',
+        remoteFileDiffersWaiting: '远程文件内容与本地仍不一致，继续等待…',
+        remoteFileExistsDiffersWaiting: '远程文件已存在但内容不同，继续等待…',
+        mismatchAdvice: '如果你的 GitHub 提交确实不同，请取消并使用“刷新”查看。',
+        remoteCheckCanceled: '远程检查已取消',
+        errorWithDetail: ({ message }) => `错误：${message}`,
+        networkError: '网络错误',
+        fileNotFoundOnServer: '服务器上未找到文件',
+        remoteSnapshotUpdated: '远程快照已更新',
+        waitingForGitHub: '正在等待 GitHub…',
+        preparing: '正在准备…',
+        waitingForLabel: ({ label }) => `正在等待 ${label} 在 GitHub 上更新…`,
+        waitingForRemote: '正在等待远程…',
+        yamlNotFoundYet: ({ label }) => `${label} 在远程尚未找到…`,
+        remoteYamlDiffersWaiting: '远程 YAML 与本地快照仍不一致，继续等待…',
+        remoteYamlExistsDiffersWaiting: '远程 YAML 已更新但内容不同，继续等待…',
+        yamlMismatchAdvice: '如果提交与草稿不同，请取消并点击“刷新”以拉取。'
+      },
       footerNote: '由 ❤️ 打造，基于 <a href="https://deemoe404.github.io/NanoSite/" target="_blank" rel="noopener">NanoSite</a>。保持灵感，持续创作。'
-    }
+    },
   },
   ja: {
     ui: {
@@ -428,7 +516,7 @@ const translations = {
         upload: 'アップロード',
         remoteLabel: 'GitHub',
         loadingRepo: 'GitHub 設定を読み込み中…',
-        checkingConnection: '接続を確認しています…',
+        checkingConnection: '接続を確認中…',
         clean: 'ローカルの変更はありません'
       },
       toolbar: {
@@ -440,11 +528,26 @@ const translations = {
         viewPreview: 'プレビュー',
         discard: '破棄',
         wrapAria: '折り返し設定',
-        viewAria: '表示切り替え'
+        viewAria: '表示の切り替え'
+      },
+      toast: {
+        openAction: '開く',
+        closeAria: '通知を閉じる'
+      },
+      toasts: {
+        remoteMarkdownMismatch: 'リモートの Markdown がローカルの下書きと異なります。続行する前に差分を確認してください。',
+        markdownSynced: 'Markdown を GitHub と同期しました。',
+        remoteCheckCanceledUseRefresh: 'リモートチェックをキャンセルしました。コミットの準備ができたら「更新」をクリックしてください。',
+        yamlParseFailed: ({ label }) => `${label} を取得しましたが、YAML を解析できませんでした。`,
+        yamlUpdatedDifferently: ({ label }) => `${label} は GitHub 上で異なる更新が行われています。ハイライトされた差分を確認してください。`,
+        yamlSynced: ({ label }) => `${label} を GitHub と同期しました。`,
+        remoteCheckCanceledClickRefresh: 'リモートチェックをキャンセルしました。コミットの準備ができたら「更新」をクリックしてください。',
+        popupBlocked: 'ブラウザが GitHub ウィンドウをブロックしました。このサイトのポップアップを許可してから再試行してください。',
+        openGithubAction: 'GitHub を開く'
       },
       editorTools: {
-        aria: 'エディターツール',
-        formatGroupAria: '書式設定ショートカット',
+        aria: 'エディターのツール',
+        formatGroupAria: '書式ショートカット',
         bold: '太字',
         italic: '斜体',
         strike: '取り消し線',
@@ -457,12 +560,12 @@ const translations = {
         insertImage: '画像を挿入',
         cardDialogAria: '記事カードを挿入',
         cardSearch: '記事を検索…',
-        cardEmpty: '一致する記事がありません'
+        cardEmpty: '該当する記事はありません'
       },
-      editorPlaceholder: '# こんにちは、NanoSite\n\nMarkdown を入力しましょう…',
+      editorPlaceholder: '# こんにちは、NanoSite\n\nMarkdown の入力を始めましょう…',
       editorTextareaAria: 'Markdown ソース',
       empty: {
-        title: '開いているエディターはありません',
+        title: '現在開いているエディターはありません',
         body: 'コンポーザーから Markdown を開いて編集を開始してください。'
       },
       composer: {
@@ -470,23 +573,52 @@ const translations = {
         fileLabel: 'ファイル:',
         fileArticles: '記事',
         filePages: 'ページ',
-        addPost: '記事を追加',
+        addPost: '記事エントリーを追加',
         refresh: '更新',
         refreshTitle: '最新のリモートスナップショットを取得',
         discard: '破棄',
-        discardTitle: 'ローカル下書きを破棄してリモートファイルを再読み込み',
-        changeSummary: '変更サマリー',
+        discardTitle: 'ローカルの下書きを破棄してリモートを再読み込み',
+        changeSummary: '変更の概要',
         reviewChanges: '変更を確認',
-        inlineEmpty: '比較できる項目がまだありません。',
+        inlineEmpty: '比較できるエントリーはまだありません。',
         indexInlineAria: 'index.yaml の旧順序',
         indexEditorAria: 'index.yaml エディター',
         tabsInlineAria: 'tabs.yaml の旧順序',
         tabsEditorAria: 'tabs.yaml エディター',
         noLocalChangesToCommit: 'コミットするローカルの変更はありません。',
-        noLocalChangesYet: '現在ローカルの変更はありません。'
+        noLocalChangesYet: 'ローカルの変更はまだありません。'
       },
-      footerNote: '❤️ を込めて <a href="https://deemoe404.github.io/NanoSite/" target="_blank" rel="noopener">NanoSite</a> で作りました。インスピレーションを保ち、創作を続けましょう。'
-    }
+      remoteWatcher: {
+        waitingForCreate: ({ label }) => `GitHub で ${label} が作成されるのを待機しています`,
+        waitingForUpdate: ({ label }) => `GitHub で ${label} が更新されるのを待機しています`,
+        waitingForCommitStatus: 'GitHub のコミットを待機中…',
+        checkingRemoteChanges: 'リモートの変更を確認中…',
+        waitingForCommit: 'コミットを待機中…',
+        stopWaiting: '待機を停止',
+        waitingForRemoteResponse: 'リモートの応答を待機しています…',
+        remoteCheckFailedRetry: 'リモートチェックに失敗しました。再試行します…',
+        remoteFileNotFoundYet: 'リモートファイルがまだ見つかりません…',
+        remoteFileStillMissing: 'リモートファイルがまだ存在しません…',
+        updateDetectedRefreshing: '更新を検出しました。再読み込みしています…',
+        remoteFileDiffersWaiting: 'リモートファイルがローカル内容とまだ一致しません。待機中…',
+        remoteFileExistsDiffersWaiting: 'リモートファイルは存在しますが内容が異なります。待機中…',
+        mismatchAdvice: 'GitHub のコミットが意図的に異なる場合はキャンセルし、「更新」で内容を確認してください。',
+        remoteCheckCanceled: 'リモートチェックをキャンセルしました',
+        errorWithDetail: ({ message }) => `エラー: ${message}`,
+        networkError: 'ネットワークエラー',
+        fileNotFoundOnServer: 'サーバーでファイルが見つかりません',
+        remoteSnapshotUpdated: 'リモートスナップショットを更新しました',
+        waitingForGitHub: 'GitHub を待機中…',
+        preparing: '準備中…',
+        waitingForLabel: ({ label }) => `GitHub で ${label} の更新を待機しています…`,
+        waitingForRemote: 'リモートを待機中…',
+        yamlNotFoundYet: ({ label }) => `リモートで ${label} がまだ見つかりません…`,
+        remoteYamlDiffersWaiting: 'リモート YAML がローカルのスナップショットとまだ一致しません。待機中…',
+        remoteYamlExistsDiffersWaiting: 'リモート YAML は更新されていますが内容が異なります。待機中…',
+        yamlMismatchAdvice: 'コミット内容が下書きと異なる場合はキャンセルし、「更新」をクリックして取得してください。'
+      },
+      footerNote: '❤️ で作られた <a href="https://deemoe404.github.io/NanoSite/" target="_blank" rel="noopener">NanoSite</a> を使って創作を楽しみましょう。'
+    },
   }
   // Additional languages can be added here
 };

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -105,6 +105,8 @@ const translations = {
     editor: {
       pageTitle: 'Markdown Editor - NanoSite',
       languageLabel: 'Language',
+      verifying: 'Verifying…',
+      verify: 'Verify',
       nav: {
         modeSwitchAria: 'Mode switch',
         dynamicTabsAria: 'Open editor tabs'
@@ -147,7 +149,29 @@ const translations = {
         yamlSynced: ({ label }) => `${label} synchronized with GitHub.`,
         remoteCheckCanceledClickRefresh: 'Remote check canceled. Click Refresh when your commit is ready.',
         popupBlocked: 'Your browser blocked the GitHub window. Allow pop-ups for this site and try again.',
-        openGithubAction: 'Open GitHub'
+        openGithubAction: 'Open GitHub',
+        markdownOpenBeforeInsert: 'Open a markdown file before inserting images.',
+        assetAttached: ({ label }) => `Attached ${label}`,
+        noPendingChanges: 'No pending changes to commit.',
+        siteWaitStopped: 'Stopped waiting for the live site. Your commit is already on GitHub, but it may take a few minutes to appear.',
+        siteWaitTimedOut: 'Committed files to GitHub, but the live site did not update in time. Check the deploy status manually.',
+        commitSuccess: ({ count }) => `Committed ${count} ${count === 1 ? 'file' : 'files'} to GitHub.`,
+        githubCommitFailed: 'GitHub commit failed.',
+        githubTokenRejected: 'GitHub rejected the access token. Enter a new Fine-grained Personal Access Token.',
+        repoOwnerMissing: 'Configure repo.owner and repo.name in site.yaml to enable GitHub synchronization.',
+        markdownOpenBeforePush: 'Open a markdown file before pushing to GitHub.',
+        repoConfigMissing: 'Configure repo in site.yaml to enable GitHub push.',
+        invalidMarkdownPath: 'Invalid markdown path.',
+        unableLoadLatestMarkdown: 'Unable to load the latest markdown before pushing.',
+        markdownNotReady: 'Markdown file is not ready to push yet.',
+        unableResolveGithubFile: 'Unable to resolve GitHub URL for this file.',
+        markdownOpenBeforeDiscard: 'Open a markdown file before discarding local changes.',
+        noLocalMarkdownChanges: 'No local markdown changes to discard.',
+        discardSuccess: ({ label }) => `Discarded local changes for ${label}.`,
+        discardFailed: 'Failed to discard local markdown changes.',
+        unableResolveYamlSync: 'Unable to resolve GitHub URL for YAML synchronization.',
+        yamlUpToDate: ({ name }) => `${name} is up to date.`,
+        yamlCopiedNoRepo: 'YAML copied. Configure repo in site.yaml to open GitHub.'
       },
       editorTools: {
         aria: 'Editor tools',
@@ -191,6 +215,66 @@ const translations = {
         tabsEditorAria: 'tabs.yaml editor',
         noLocalChangesToCommit: 'No local changes to commit.',
         noLocalChangesYet: 'No local changes yet.'
+      },
+      dialogs: {
+        cancel: 'Cancel',
+        confirm: 'Confirm'
+      },
+      addEntryPrompt: {
+        hint: 'Use only English letters and numbers.',
+        confirm: 'Add Entry',
+        defaultType: 'entry',
+        placeholder: 'Entry key',
+        message: ({ label }) => `Enter a new ${label} key:`,
+        errorEmpty: 'Key cannot be empty.',
+        errorInvalid: 'Key must contain only English letters, numbers, underscores, or hyphens.',
+        errorDuplicate: 'That key already exists. Choose a different key.'
+      },
+      discardConfirm: {
+        messageReload: ({ label }) => `Discard local changes for ${label} and reload the remote file? This action cannot be undone.`,
+        messageSimple: ({ label }) => `Discard local changes for ${label}? This action cannot be undone.`,
+        discard: 'Discard',
+        discarding: 'Discarding…',
+        successFresh: ({ label }) => `Discarded local changes; loaded fresh ${label}`,
+        successCached: ({ label }) => `Discarded local changes; restored ${label} from cached snapshot`,
+        failed: 'Failed to discard local changes'
+      },
+      markdown: {
+        push: {
+          labelDefault: 'Synchronize',
+          labelCreate: 'Create on GitHub',
+          labelUpdate: 'Synchronize',
+          tooltips: {
+            default: 'Copy draft to GitHub.',
+            noRepo: 'Configure repo in site.yaml to enable GitHub push.',
+            noFile: 'Open a markdown file to enable GitHub push.',
+            error: 'Resolve file load error before pushing to GitHub.',
+            checking: 'Checking remote version…',
+            loading: 'Loading remote snapshot…',
+            create: 'Copy draft and create this file on GitHub.',
+            update: 'Copy draft and update this file on GitHub.'
+          }
+        },
+        discard: {
+          label: 'Discard',
+          busy: 'Discarding…',
+          tooltips: {
+            default: 'Discard local markdown changes and restore the last loaded version.',
+            noFile: 'Open a markdown file to discard local changes.',
+            reload: 'Discard local markdown changes (remote snapshot will be reloaded).'
+          }
+        },
+        currentFile: 'current file',
+        fileFallback: 'markdown file',
+        toastCopiedCreate: 'Markdown copied. GitHub will open to create this file.',
+        toastCopiedUpdate: 'Markdown copied. GitHub will open to update this file.',
+        blockedCreate: 'Markdown copied. Click “Open GitHub” if the new tab did not appear so you can create this file.',
+        blockedUpdate: 'Markdown copied. Click “Open GitHub” if the new tab did not appear so you can update this file.'
+      },
+      yaml: {
+        toastCopiedUpdate: ({ name }) => `${name} copied. GitHub will open so you can paste the update.`,
+        toastCopiedCreate: ({ name }) => `${name} copied. GitHub will open so you can create the file.`,
+        blocked: ({ name }) => `${name} copied. Click “Open GitHub” if the new tab did not appear.`
       },
       remoteWatcher: {
         waitingForCreate: ({ label }) => `Waiting for GitHub to create ${label}`,
@@ -303,6 +387,8 @@ const translations = {
     editor: {
       pageTitle: 'Markdown 编辑器 - NanoSite',
       languageLabel: '语言',
+      verifying: '正在验证…',
+      verify: '验证',
       nav: {
         modeSwitchAria: '模式切换',
         dynamicTabsAria: '打开编辑器标签'
@@ -345,7 +431,29 @@ const translations = {
         yamlSynced: ({ label }) => `${label} 已与 GitHub 同步。`,
         remoteCheckCanceledClickRefresh: '远程检查已取消。提交准备好后请点击“刷新”。',
         popupBlocked: '浏览器阻止了 GitHub 窗口。请允许此站点的弹出窗口后重试。',
-        openGithubAction: '打开 GitHub'
+        openGithubAction: '打开 GitHub',
+        markdownOpenBeforeInsert: '请先打开一个 Markdown 文件再插入图片。',
+        assetAttached: ({ label }) => `已附加 ${label}`,
+        noPendingChanges: '没有待提交的更改。',
+        siteWaitStopped: '已停止等待线上站点。提交已在 GitHub 上，但显示可能还需要几分钟。',
+        siteWaitTimedOut: '已将文件提交到 GitHub，但线上站点未及时更新。请手动检查部署状态。',
+        commitSuccess: ({ count }) => `已将 ${count} 个文件提交到 GitHub。`,
+        githubCommitFailed: '提交到 GitHub 失败。',
+        githubTokenRejected: 'GitHub 拒绝了访问令牌。请输入新的细粒度个人访问令牌。',
+        repoOwnerMissing: '请在 site.yaml 中配置 repo.owner 和 repo.name 以启用 GitHub 同步。',
+        markdownOpenBeforePush: '请先打开一个 Markdown 文件再推送到 GitHub。',
+        repoConfigMissing: '请在 site.yaml 中配置仓库信息以启用 GitHub 推送。',
+        invalidMarkdownPath: '无效的 Markdown 路径。',
+        unableLoadLatestMarkdown: '在推送前无法加载最新的 Markdown。',
+        markdownNotReady: 'Markdown 文件尚未准备好推送。',
+        unableResolveGithubFile: '无法解析此文件的 GitHub 链接。',
+        markdownOpenBeforeDiscard: '请先打开一个 Markdown 文件再丢弃本地更改。',
+        noLocalMarkdownChanges: '没有可丢弃的本地 Markdown 更改。',
+        discardSuccess: ({ label }) => `已丢弃 ${label} 的本地更改。`,
+        discardFailed: '丢弃本地 Markdown 更改失败。',
+        unableResolveYamlSync: '无法解析用于 YAML 同步的 GitHub 链接。',
+        yamlUpToDate: ({ name }) => `${name} 已是最新。`,
+        yamlCopiedNoRepo: '已复制 YAML。请在 site.yaml 中配置仓库以打开 GitHub。'
       },
       editorTools: {
         aria: '编辑器工具',
@@ -389,6 +497,66 @@ const translations = {
         tabsEditorAria: 'tabs.yaml 编辑器',
         noLocalChangesToCommit: '没有本地更改可提交。',
         noLocalChangesYet: '暂时没有本地更改。'
+      },
+      dialogs: {
+        cancel: '取消',
+        confirm: '确认'
+      },
+      addEntryPrompt: {
+        hint: '仅使用英文字母和数字。',
+        confirm: '添加条目',
+        defaultType: '条目',
+        placeholder: '条目键名',
+        message: ({ label }) => `请输入新的 ${label} 键名：`,
+        errorEmpty: '键名不能为空。',
+        errorInvalid: '键名只能包含英文字母、数字、下划线或连字符。',
+        errorDuplicate: '该键名已存在，请使用其他键名。'
+      },
+      discardConfirm: {
+        messageReload: ({ label }) => `丢弃 ${label} 的本地更改并重新加载远程文件？此操作无法撤销。`,
+        messageSimple: ({ label }) => `丢弃 ${label} 的本地更改？此操作无法撤销。`,
+        discard: '丢弃',
+        discarding: '正在丢弃…',
+        successFresh: ({ label }) => `已丢弃本地更改；已加载最新的 ${label}`,
+        successCached: ({ label }) => `已丢弃本地更改；已从缓存快照恢复 ${label}`,
+        failed: '丢弃本地更改失败。'
+      },
+      markdown: {
+        push: {
+          labelDefault: '同步',
+          labelCreate: '在 GitHub 上创建',
+          labelUpdate: '同步',
+          tooltips: {
+            default: '复制草稿到 GitHub。',
+            noRepo: '请在 site.yaml 中配置仓库以启用 GitHub 推送。',
+            noFile: '请先打开一个 Markdown 文件以启用 GitHub 推送。',
+            error: '推送前请先解决文件加载错误。',
+            checking: '正在检查远程版本…',
+            loading: '正在加载远程快照…',
+            create: '复制草稿并在 GitHub 上创建该文件。',
+            update: '复制草稿并在 GitHub 上更新该文件。'
+          }
+        },
+        discard: {
+          label: '丢弃',
+          busy: '正在丢弃…',
+          tooltips: {
+            default: '丢弃本地 Markdown 更改并恢复上次加载的版本。',
+            noFile: '请先打开一个 Markdown 文件再丢弃本地更改。',
+            reload: '丢弃本地 Markdown 更改（将重新加载远程快照）。'
+          }
+        },
+        currentFile: '当前文件',
+        fileFallback: 'Markdown 文件',
+        toastCopiedCreate: '已复制 Markdown。GitHub 将打开以创建该文件。',
+        toastCopiedUpdate: '已复制 Markdown。GitHub 将打开以更新该文件。',
+        blockedCreate: '已复制 Markdown。如未打开新标签页，请点击“打开 GitHub”以创建该文件。',
+        blockedUpdate: '已复制 Markdown。如未打开新标签页，请点击“打开 GitHub”以更新该文件。'
+      },
+      yaml: {
+        toastCopiedUpdate: ({ name }) => `已复制 ${name}。GitHub 将打开以粘贴更新。`,
+        toastCopiedCreate: ({ name }) => `已复制 ${name}。GitHub 将打开以创建该文件。`,
+        blocked: ({ name }) => `已复制 ${name}。如未打开新标签页，请点击“打开 GitHub”。`
       },
       remoteWatcher: {
         waitingForCreate: ({ label }) => `正在等待 GitHub 创建 ${label}`,
@@ -501,6 +669,8 @@ const translations = {
     editor: {
       pageTitle: 'Markdown エディター - NanoSite',
       languageLabel: '言語',
+      verifying: '検証中…',
+      verify: '検証',
       nav: {
         modeSwitchAria: 'モード切り替え',
         dynamicTabsAria: 'エディタータブを開く'
@@ -543,7 +713,29 @@ const translations = {
         yamlSynced: ({ label }) => `${label} を GitHub と同期しました。`,
         remoteCheckCanceledClickRefresh: 'リモートチェックをキャンセルしました。コミットの準備ができたら「更新」をクリックしてください。',
         popupBlocked: 'ブラウザが GitHub ウィンドウをブロックしました。このサイトのポップアップを許可してから再試行してください。',
-        openGithubAction: 'GitHub を開く'
+        openGithubAction: 'GitHub を開く',
+        markdownOpenBeforeInsert: '画像を挿入する前に Markdown ファイルを開いてください。',
+        assetAttached: ({ label }) => `${label} を添付しました`,
+        noPendingChanges: 'コミットする変更はありません。',
+        siteWaitStopped: 'ライブサイトの更新待機を停止しました。コミットは GitHub にありますが、反映まで数分かかる場合があります。',
+        siteWaitTimedOut: 'GitHub にファイルをコミットしましたが、ライブサイトが時間内に更新されませんでした。デプロイ状況を手動で確認してください。',
+        commitSuccess: ({ count }) => `${count} 件のファイルを GitHub にコミットしました。`,
+        githubCommitFailed: 'GitHub へのコミットに失敗しました。',
+        githubTokenRejected: 'GitHub がアクセストークンを拒否しました。新しい細分化されたパーソナルアクセストークンを入力してください。',
+        repoOwnerMissing: 'GitHub 同期を有効にするには site.yaml の repo.owner と repo.name を設定してください。',
+        markdownOpenBeforePush: 'GitHub にプッシュする前に Markdown ファイルを開いてください。',
+        repoConfigMissing: 'GitHub プッシュを有効にするには site.yaml にリポジトリ情報を設定してください。',
+        invalidMarkdownPath: '無効な Markdown パスです。',
+        unableLoadLatestMarkdown: 'プッシュ前に最新の Markdown を読み込めませんでした。',
+        markdownNotReady: 'Markdown ファイルはまだプッシュできる状態ではありません。',
+        unableResolveGithubFile: 'このファイルの GitHub URL を解決できません。',
+        markdownOpenBeforeDiscard: 'ローカル変更を破棄する前に Markdown ファイルを開いてください。',
+        noLocalMarkdownChanges: '破棄できる Markdown のローカル変更はありません。',
+        discardSuccess: ({ label }) => `${label} のローカル変更を破棄しました。`,
+        discardFailed: 'Markdown のローカル変更を破棄できませんでした。',
+        unableResolveYamlSync: 'YAML 同期用の GitHub URL を解決できません。',
+        yamlUpToDate: ({ name }) => `${name} は最新です。`,
+        yamlCopiedNoRepo: 'YAML をコピーしました。GitHub を開くには site.yaml でリポジトリを設定してください。'
       },
       editorTools: {
         aria: 'エディターのツール',
@@ -587,6 +779,66 @@ const translations = {
         tabsEditorAria: 'tabs.yaml エディター',
         noLocalChangesToCommit: 'コミットするローカルの変更はありません。',
         noLocalChangesYet: 'ローカルの変更はまだありません。'
+      },
+      dialogs: {
+        cancel: 'キャンセル',
+        confirm: '確認'
+      },
+      addEntryPrompt: {
+        hint: '英数字のみを使用してください。',
+        confirm: 'エントリーを追加',
+        defaultType: 'エントリー',
+        placeholder: 'エントリーキー',
+        message: ({ label }) => `新しい ${label} のキーを入力してください：`,
+        errorEmpty: 'キーは必須です。',
+        errorInvalid: 'キーには英数字、アンダースコア、ハイフンのみ使用できます。',
+        errorDuplicate: 'そのキーは既に存在します。別のキーを選んでください。'
+      },
+      discardConfirm: {
+        messageReload: ({ label }) => `${label} のローカル変更を破棄してリモートファイルを再読み込みしますか？この操作は取り消せません。`,
+        messageSimple: ({ label }) => `${label} のローカル変更を破棄しますか？この操作は取り消せません。`,
+        discard: '破棄',
+        discarding: '破棄中…',
+        successFresh: ({ label }) => `ローカル変更を破棄し、最新の ${label} を読み込みました`,
+        successCached: ({ label }) => `ローカル変更を破棄し、キャッシュの ${label} を復元しました`,
+        failed: 'ローカル変更を破棄できませんでした。'
+      },
+      markdown: {
+        push: {
+          labelDefault: '同期',
+          labelCreate: 'GitHub で作成',
+          labelUpdate: '同期',
+          tooltips: {
+            default: 'ドラフトを GitHub にコピーします。',
+            noRepo: 'GitHub プッシュを有効にするには site.yaml でリポジトリを設定してください。',
+            noFile: 'GitHub にプッシュする前に Markdown ファイルを開いてください。',
+            error: 'プッシュする前にファイル読み込みエラーを解決してください。',
+            checking: 'リモート版を確認中…',
+            loading: 'リモートスナップショットを読み込み中…',
+            create: 'ドラフトをコピーして GitHub でこのファイルを作成します。',
+            update: 'ドラフトをコピーして GitHub でこのファイルを更新します。'
+          }
+        },
+        discard: {
+          label: '破棄',
+          busy: '破棄中…',
+          tooltips: {
+            default: 'Markdown のローカル変更を破棄し、最後に読み込んだ版を復元します。',
+            noFile: 'ローカル変更を破棄する前に Markdown ファイルを開いてください。',
+            reload: 'Markdown のローカル変更を破棄し（リモートスナップショットを再読み込みします）。'
+          }
+        },
+        currentFile: '現在のファイル',
+        fileFallback: 'Markdown ファイル',
+        toastCopiedCreate: 'Markdown をコピーしました。GitHub が開いてこのファイルを作成します。',
+        toastCopiedUpdate: 'Markdown をコピーしました。GitHub が開いてこのファイルを更新します。',
+        blockedCreate: 'Markdown をコピーしました。新しいタブが表示されない場合は「GitHub を開く」をクリックして作成してください。',
+        blockedUpdate: 'Markdown をコピーしました。新しいタブが表示されない場合は「GitHub を開く」をクリックして更新してください。'
+      },
+      yaml: {
+        toastCopiedUpdate: ({ name }) => `${name} をコピーしました。GitHub が開いて更新内容を貼り付けられます。`,
+        toastCopiedCreate: ({ name }) => `${name} をコピーしました。GitHub が開いてファイルを作成できます。`,
+        blocked: ({ name }) => `${name} をコピーしました。新しいタブが表示されない場合は「GitHub を開く」をクリックしてください。`
       },
       remoteWatcher: {
         waitingForCreate: ({ label }) => `GitHub で ${label} が作成されるのを待機しています`,

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -202,6 +202,7 @@ const translations = {
         fileArticles: 'Articles',
         filePages: 'Pages',
         addPost: 'Add Post Entry',
+        addTab: 'Add Tab Entry',
         refresh: 'Refresh',
         refreshTitle: 'Fetch latest remote snapshot',
         discard: 'Discard',
@@ -214,7 +215,45 @@ const translations = {
         tabsInlineAria: 'Old order for tabs.yaml',
         tabsEditorAria: 'tabs.yaml editor',
         noLocalChangesToCommit: 'No local changes to commit.',
-        noLocalChangesYet: 'No local changes yet.'
+        noLocalChangesYet: 'No local changes yet.',
+        statusMessages: {
+          loadingConfig: 'Loading config…',
+          restoredDraft: ({ label }) => `Restored local draft for ${label}`
+        },
+        github: {
+          modal: {
+            title: 'Synchronize with GitHub',
+            subtitle: 'Provide a Fine-grained Personal Access Token with repository contents access.',
+            summaryTitle: 'The following files will be committed:',
+            tokenLabel: 'Fine-grained Personal Access Token',
+            helpHtml: 'Create a token at <a href="https://github.com/settings/tokens?type=beta" target="_blank" rel="noopener">github.com/settings/tokens</a> with access to the repository\'s contents. The token is stored for this browser session only.',
+            forget: 'Forget token',
+            submit: 'Commit changes',
+            errorRequired: 'Enter a Fine-grained Personal Access Token to continue.'
+          }
+        }
+      },
+      github: {
+        status: {
+          arrowWarn: 'Check repo',
+          arrowDefault: 'Status',
+          loadingRepo: 'Loading GitHub settings…',
+          readingConfig: 'Reading site.yaml for GitHub connection details…',
+          repoNotConfigured: 'GitHub repository not configured',
+          repoConfigHint: 'Add repo.owner and repo.name to site.yaml to enable pushing your drafts.',
+          checkingRepo: 'Checking repository access…',
+          rateLimited: 'GitHub rate limit hit. Try again later.',
+          repoNotFound: 'Repository not found on GitHub.',
+          networkError: 'Could not reach GitHub. Check your connection.',
+          repoCheckFailed: 'Repository check failed.',
+          repoConnectedDefault: ({ branch }) => `Repository connected · Default branch “${branch}”`,
+          checkingBranch: 'Checking branch access…',
+          branchNotFound: 'Branch not found on GitHub.',
+          branchCheckFailed: 'Branch check failed.',
+          repoConnected: 'Repository connected',
+          configUnavailable: 'GitHub configuration unavailable',
+          readFailed: 'Failed to read site.yaml.'
+        }
       },
       dialogs: {
         cancel: 'Cancel',
@@ -484,6 +523,7 @@ const translations = {
         fileArticles: '文章',
         filePages: '页面',
         addPost: '添加文章条目',
+        addTab: '添加标签条目',
         refresh: '刷新',
         refreshTitle: '获取最新远程快照',
         discard: '丢弃',
@@ -496,7 +536,45 @@ const translations = {
         tabsInlineAria: 'tabs.yaml 的旧顺序',
         tabsEditorAria: 'tabs.yaml 编辑器',
         noLocalChangesToCommit: '没有本地更改可提交。',
-        noLocalChangesYet: '暂时没有本地更改。'
+        noLocalChangesYet: '暂时没有本地更改。',
+        statusMessages: {
+          loadingConfig: '正在加载配置…',
+          restoredDraft: ({ label }) => `已恢复 ${label} 的本地草稿`
+        },
+        github: {
+          modal: {
+            title: '与 GitHub 同步',
+            subtitle: '请提供具备仓库内容访问权限的精细化个人访问令牌。',
+            summaryTitle: '将提交以下文件：',
+            tokenLabel: '精细化个人访问令牌',
+            helpHtml: '请在 <a href="https://github.com/settings/tokens?type=beta" target="_blank" rel="noopener">github.com/settings/tokens</a> 创建一个具有仓库内容访问权限的令牌。该令牌仅在当前浏览器会话中存储。',
+            forget: '忘记令牌',
+            submit: '提交更改',
+            errorRequired: '请输入精细化个人访问令牌以继续。'
+          }
+        }
+      },
+      github: {
+        status: {
+          arrowWarn: '检查仓库',
+          arrowDefault: '状态',
+          loadingRepo: '正在加载 GitHub 设置…',
+          readingConfig: '正在读取 site.yaml 中的 GitHub 连接配置…',
+          repoNotConfigured: '尚未配置 GitHub 仓库',
+          repoConfigHint: '请在 site.yaml 中配置 repo.owner 和 repo.name，以启用草稿推送。',
+          checkingRepo: '正在检查仓库访问权限…',
+          rateLimited: '已触发 GitHub 速率限制，请稍后再试。',
+          repoNotFound: '在 GitHub 上未找到该仓库。',
+          networkError: '无法连接到 GitHub，请检查网络。',
+          repoCheckFailed: '仓库检查失败。',
+          repoConnectedDefault: ({ branch }) => `仓库已连接 · 默认分支“${branch}”`,
+          checkingBranch: '正在检查分支访问权限…',
+          branchNotFound: '在 GitHub 上未找到该分支。',
+          branchCheckFailed: '分支检查失败。',
+          repoConnected: '仓库已连接',
+          configUnavailable: '无法获取 GitHub 配置',
+          readFailed: '读取 site.yaml 失败。'
+        }
       },
       dialogs: {
         cancel: '取消',
@@ -766,6 +844,7 @@ const translations = {
         fileArticles: '記事',
         filePages: 'ページ',
         addPost: '記事エントリーを追加',
+        addTab: 'タブ項目を追加',
         refresh: '更新',
         refreshTitle: '最新のリモートスナップショットを取得',
         discard: '破棄',
@@ -778,7 +857,45 @@ const translations = {
         tabsInlineAria: 'tabs.yaml の旧順序',
         tabsEditorAria: 'tabs.yaml エディター',
         noLocalChangesToCommit: 'コミットするローカルの変更はありません。',
-        noLocalChangesYet: 'ローカルの変更はまだありません。'
+        noLocalChangesYet: 'ローカルの変更はまだありません。',
+        statusMessages: {
+          loadingConfig: '設定を読み込み中…',
+          restoredDraft: ({ label }) => `${label} のローカル下書きを復元しました`
+        },
+        github: {
+          modal: {
+            title: 'GitHub と同期',
+            subtitle: 'リポジトリの内容にアクセスできるファイングレインド Personal Access Token を入力してください。',
+            summaryTitle: '以下のファイルがコミットされます:',
+            tokenLabel: 'ファイングレインド Personal Access Token',
+            helpHtml: '<a href="https://github.com/settings/tokens?type=beta" target="_blank" rel="noopener">github.com/settings/tokens</a> でリポジトリ内容にアクセスできるトークンを作成してください。このトークンはこのブラウザセッションにのみ保存されます。',
+            forget: 'トークンを削除',
+            submit: '変更をコミット',
+            errorRequired: '続行するにはファイングレインド Personal Access Token を入力してください。'
+          }
+        }
+      },
+      github: {
+        status: {
+          arrowWarn: 'リポジトリを確認',
+          arrowDefault: 'ステータス',
+          loadingRepo: 'GitHub 設定を読み込み中…',
+          readingConfig: 'site.yaml から GitHub 接続設定を読み込んでいます…',
+          repoNotConfigured: 'GitHub リポジトリが設定されていません',
+          repoConfigHint: 'site.yaml に repo.owner と repo.name を設定し、下書きのプッシュを有効にしてください。',
+          checkingRepo: 'リポジトリへのアクセスを確認しています…',
+          rateLimited: 'GitHub のレート制限に達しました。しばらくしてから再試行してください。',
+          repoNotFound: 'GitHub にリポジトリが見つかりませんでした。',
+          networkError: 'GitHub に接続できません。ネットワークを確認してください。',
+          repoCheckFailed: 'リポジトリの確認に失敗しました。',
+          repoConnectedDefault: ({ branch }) => `リポジトリに接続しました · 既定ブランチ「${branch}」`,
+          checkingBranch: 'ブランチへのアクセスを確認しています…',
+          branchNotFound: 'GitHub にブランチが見つかりませんでした。',
+          branchCheckFailed: 'ブランチの確認に失敗しました。',
+          repoConnected: 'リポジトリに接続しました',
+          configUnavailable: 'GitHub 設定を取得できません',
+          readFailed: 'site.yaml の読み込みに失敗しました。'
+        }
       },
       dialogs: {
         cancel: 'キャンセル',

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -101,6 +101,83 @@ const translations = {
     titles: {
       allPosts: 'All Posts',
       search: (q) => `Search: ${q}`
+    },
+    editor: {
+      pageTitle: 'Markdown Editor - NanoSite',
+      languageLabel: 'Language',
+      nav: {
+        modeSwitchAria: 'Mode switch',
+        dynamicTabsAria: 'Open editor tabs'
+      },
+      modes: {
+        composer: 'Composer',
+        editor: 'Editor'
+      },
+      status: {
+        localLabel: 'LOCAL',
+        checkingDrafts: 'Checking drafts…',
+        synced: 'Synced',
+        upload: 'UPLOAD',
+        remoteLabel: 'GitHub',
+        loadingRepo: 'Loading GitHub settings…',
+        checkingConnection: 'Checking connection…',
+        clean: 'No local changes'
+      },
+      toolbar: {
+        wrap: 'Wrap:',
+        wrapOn: 'on',
+        wrapOff: 'off',
+        view: 'View:',
+        viewEdit: 'Editor',
+        viewPreview: 'Preview',
+        discard: 'Discard',
+        wrapAria: 'Wrap setting',
+        viewAria: 'View switch'
+      },
+      editorTools: {
+        aria: 'Editor tools',
+        formatGroupAria: 'Formatting shortcuts',
+        bold: 'Bold',
+        italic: 'Italic',
+        strike: 'Strikethrough',
+        heading: 'Heading',
+        quote: 'Quote',
+        code: 'Inline code',
+        codeBlock: 'Code Block',
+        articleCard: 'Article Card',
+        insertCardTitle: 'Insert article card',
+        insertImage: 'Insert Image',
+        cardDialogAria: 'Insert article card',
+        cardSearch: 'Search articles…',
+        cardEmpty: 'No matching articles'
+      },
+      editorPlaceholder: '# Hello NanoSite\n\nStart typing Markdown…',
+      editorTextareaAria: 'Markdown source',
+      empty: {
+        title: 'No editor is currently open',
+        body: 'Open Markdown from the Composer to start editing.'
+      },
+      composer: {
+        fileSwitchAria: 'File switch',
+        fileLabel: 'File:',
+        fileArticles: 'Articles',
+        filePages: 'Pages',
+        addPost: 'Add Post Entry',
+        refresh: 'Refresh',
+        refreshTitle: 'Fetch latest remote snapshot',
+        discard: 'Discard',
+        discardTitle: 'Discard local draft and reload remote file',
+        changeSummary: 'Change summary',
+        reviewChanges: 'Review changes',
+        inlineEmpty: 'No entries to compare yet.',
+        indexInlineAria: 'Old order for index.yaml',
+        indexEditorAria: 'index.yaml editor',
+        tabsInlineAria: 'Old order for tabs.yaml',
+        tabsEditorAria: 'tabs.yaml editor',
+        noLocalChangesToCommit: 'No local changes to commit.',
+        noLocalChangesYet: 'No local changes yet.'
+      },
+      footerNote: 'Crafted with ❤️ using <a href="https://deemoe404.github.io/NanoSite/" target="_blank" rel="noopener">NanoSite</a>. Stay inspired and keep creating.'
     }
   },
   zh: {
@@ -178,6 +255,83 @@ const translations = {
     titles: {
       allPosts: '全部文章',
       search: (q) => `搜索：${q}`
+    },
+    editor: {
+      pageTitle: 'Markdown 编辑器 - NanoSite',
+      languageLabel: '语言',
+      nav: {
+        modeSwitchAria: '模式切换',
+        dynamicTabsAria: '打开编辑器标签'
+      },
+      modes: {
+        composer: '编排器',
+        editor: '编辑器'
+      },
+      status: {
+        localLabel: '本地',
+        checkingDrafts: '正在检查草稿…',
+        synced: '已同步',
+        upload: '上传',
+        remoteLabel: 'GitHub',
+        loadingRepo: '正在加载 GitHub 设置…',
+        checkingConnection: '正在检查连接…',
+        clean: '没有本地更改'
+      },
+      toolbar: {
+        wrap: '换行：',
+        wrapOn: '开',
+        wrapOff: '关',
+        view: '视图：',
+        viewEdit: '编辑',
+        viewPreview: '预览',
+        discard: '丢弃',
+        wrapAria: '换行设置',
+        viewAria: '视图切换'
+      },
+      editorTools: {
+        aria: '编辑器工具',
+        formatGroupAria: '格式快捷键',
+        bold: '加粗',
+        italic: '斜体',
+        strike: '删除线',
+        heading: '标题',
+        quote: '引用',
+        code: '行内代码',
+        codeBlock: '代码块',
+        articleCard: '文章卡片',
+        insertCardTitle: '插入文章卡片',
+        insertImage: '插入图片',
+        cardDialogAria: '插入文章卡片',
+        cardSearch: '搜索文章…',
+        cardEmpty: '没有匹配的文章'
+      },
+      editorPlaceholder: '# 你好，NanoSite\n\n开始撰写 Markdown…',
+      editorTextareaAria: 'Markdown 源',
+      empty: {
+        title: '当前没有打开编辑器',
+        body: '从编排器打开 Markdown 以开始编辑。'
+      },
+      composer: {
+        fileSwitchAria: '文件切换',
+        fileLabel: '文件：',
+        fileArticles: '文章',
+        filePages: '页面',
+        addPost: '添加文章条目',
+        refresh: '刷新',
+        refreshTitle: '获取最新远程快照',
+        discard: '丢弃',
+        discardTitle: '丢弃本地草稿并重新加载远程文件',
+        changeSummary: '更改摘要',
+        reviewChanges: '查看更改',
+        inlineEmpty: '暂无可比较的条目。',
+        indexInlineAria: 'index.yaml 的旧顺序',
+        indexEditorAria: 'index.yaml 编辑器',
+        tabsInlineAria: 'tabs.yaml 的旧顺序',
+        tabsEditorAria: 'tabs.yaml 编辑器',
+        noLocalChangesToCommit: '没有本地更改可提交。',
+        noLocalChangesYet: '暂时没有本地更改。'
+      },
+      footerNote: '由 ❤️ 打造，基于 <a href="https://deemoe404.github.io/NanoSite/" target="_blank" rel="noopener">NanoSite</a>。保持灵感，持续创作。'
     }
   },
   ja: {
@@ -255,6 +409,83 @@ const translations = {
     titles: {
       allPosts: 'すべての記事',
       search: (q) => `検索: ${q}`
+    },
+    editor: {
+      pageTitle: 'Markdown エディター - NanoSite',
+      languageLabel: '言語',
+      nav: {
+        modeSwitchAria: 'モード切り替え',
+        dynamicTabsAria: 'エディタータブを開く'
+      },
+      modes: {
+        composer: 'コンポーザー',
+        editor: 'エディター'
+      },
+      status: {
+        localLabel: 'ローカル',
+        checkingDrafts: '下書きを確認中…',
+        synced: '同期済み',
+        upload: 'アップロード',
+        remoteLabel: 'GitHub',
+        loadingRepo: 'GitHub 設定を読み込み中…',
+        checkingConnection: '接続を確認しています…',
+        clean: 'ローカルの変更はありません'
+      },
+      toolbar: {
+        wrap: '折り返し:',
+        wrapOn: 'オン',
+        wrapOff: 'オフ',
+        view: '表示:',
+        viewEdit: '編集',
+        viewPreview: 'プレビュー',
+        discard: '破棄',
+        wrapAria: '折り返し設定',
+        viewAria: '表示切り替え'
+      },
+      editorTools: {
+        aria: 'エディターツール',
+        formatGroupAria: '書式設定ショートカット',
+        bold: '太字',
+        italic: '斜体',
+        strike: '取り消し線',
+        heading: '見出し',
+        quote: '引用',
+        code: 'インラインコード',
+        codeBlock: 'コードブロック',
+        articleCard: '記事カード',
+        insertCardTitle: '記事カードを挿入',
+        insertImage: '画像を挿入',
+        cardDialogAria: '記事カードを挿入',
+        cardSearch: '記事を検索…',
+        cardEmpty: '一致する記事がありません'
+      },
+      editorPlaceholder: '# こんにちは、NanoSite\n\nMarkdown を入力しましょう…',
+      editorTextareaAria: 'Markdown ソース',
+      empty: {
+        title: '開いているエディターはありません',
+        body: 'コンポーザーから Markdown を開いて編集を開始してください。'
+      },
+      composer: {
+        fileSwitchAria: 'ファイル切り替え',
+        fileLabel: 'ファイル:',
+        fileArticles: '記事',
+        filePages: 'ページ',
+        addPost: '記事を追加',
+        refresh: '更新',
+        refreshTitle: '最新のリモートスナップショットを取得',
+        discard: '破棄',
+        discardTitle: 'ローカル下書きを破棄してリモートファイルを再読み込み',
+        changeSummary: '変更サマリー',
+        reviewChanges: '変更を確認',
+        inlineEmpty: '比較できる項目がまだありません。',
+        indexInlineAria: 'index.yaml の旧順序',
+        indexEditorAria: 'index.yaml エディター',
+        tabsInlineAria: 'tabs.yaml の旧順序',
+        tabsEditorAria: 'tabs.yaml エディター',
+        noLocalChangesToCommit: 'コミットするローカルの変更はありません。',
+        noLocalChangesYet: '現在ローカルの変更はありません。'
+      },
+      footerNote: '❤️ を込めて <a href="https://deemoe404.github.io/NanoSite/" target="_blank" rel="noopener">NanoSite</a> で作りました。インスピレーションを保ち、創作を続けましょう。'
     }
   }
   // Additional languages can be added here

--- a/index_editor.html
+++ b/index_editor.html
@@ -322,7 +322,42 @@
     /* Grouped list styles */
     /* Ensure main editor can use full width */
     .editor-main { min-width: 0; overflow: visible; position: relative; }
-    .page-titlebar { display:flex; align-items:flex-end; justify-content:space-between; gap:.5rem; margin-bottom: .75rem; }
+    .page-titlebar { display:flex; align-items:flex-end; justify-content:space-between; gap:.5rem; margin-bottom: .75rem; flex-wrap: wrap; }
+    .editor-lang-switcher {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: .3rem;
+      min-width: 0;
+      padding: .25rem .5rem;
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      box-shadow: var(--shadow);
+    }
+    .editor-lang-switcher label {
+      font-size: .7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      color: color-mix(in srgb, var(--muted) 85%, transparent);
+    }
+    .editor-lang-switcher select {
+      appearance: none;
+      border: 1px solid color-mix(in srgb, var(--border) 85%, transparent);
+      background: color-mix(in srgb, var(--card) 94%, transparent);
+      color: var(--text);
+      border-radius: 8px;
+      padding: .3rem .65rem;
+      font-size: .9rem;
+      line-height: 1.4;
+      cursor: pointer;
+      min-width: 120px;
+    }
+    .editor-lang-switcher select:focus-visible {
+      outline: 2px solid color-mix(in srgb, var(--primary) 48%, transparent);
+      outline-offset: 2px;
+    }
     .page-titlebar h1 { font-size: 1.35rem; margin: 0; }
     /* GitHub connection status */
     .status-stack { display:flex; flex-direction:column; align-items:stretch; gap:.75rem; }
@@ -1127,13 +1162,17 @@
 <body>
   <div class="editor-page">
     <div class="page-titlebar">
-      <nav class="mode-switch" role="tablist" aria-label="Mode switch">
-        <button class="mode-tab is-active" data-mode="composer" data-tab-label="Composer" role="tab" aria-controls="mode-composer" aria-selected="true" aria-label="Composer">
-          Composer
+      <div class="editor-lang-switcher" id="editorLangSwitcher">
+        <label for="editorLangSelect" data-i18n="editor.languageLabel">Language</label>
+        <select id="editorLangSelect" data-i18n-aria-label="editor.languageLabel"></select>
+      </div>
+      <nav class="mode-switch" role="tablist" aria-label="Mode switch" data-i18n-aria-label="editor.nav.modeSwitchAria">
+        <button class="mode-tab is-active" data-mode="composer" data-tab-label="Composer" data-i18n-data-tab-label="editor.modes.composer" role="tab" aria-controls="mode-composer" aria-selected="true" aria-label="Composer" data-i18n-aria-label="editor.modes.composer">
+          <span class="mode-tab-text" data-i18n="editor.modes.composer">Composer</span>
           <span class="mode-tab-badge" aria-hidden="true" hidden></span>
         </button>
-        <button class="mode-tab" data-mode="editor" data-tab-label="Editor" role="tab" aria-controls="mode-editor" aria-selected="false" aria-label="Editor">
-          Editor
+        <button class="mode-tab" data-mode="editor" data-tab-label="Editor" data-i18n-data-tab-label="editor.modes.editor" role="tab" aria-controls="mode-editor" aria-selected="false" aria-label="Editor" data-i18n-aria-label="editor.modes.editor">
+          <span class="mode-tab-text" data-i18n="editor.modes.editor">Editor</span>
           <span class="mode-tab-badge" aria-hidden="true" hidden></span>
         </button>
       </nav>
@@ -1149,14 +1188,14 @@
                     <path d="M9 16v1.25A1.75 1.75 0 0 0 10.75 19h2.5A1.75 1.75 0 0 0 15 17.25V16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
                   </svg>
                 </span>
-                <span class="gs-node-label">LOCAL</span>
+                <span class="gs-node-label" data-i18n="editor.status.localLabel">LOCAL</span>
               </div>
-              <span class="gs-node-state" id="globalLocalState">Checking drafts…</span>
+              <span class="gs-node-state" id="globalLocalState" data-i18n="editor.status.checkingDrafts">Checking drafts…</span>
               <div id="localDraftSummary" class="gs-node-drafts" hidden aria-live="polite"></div>
             </div>
             <span class="gs-arrow" aria-hidden="true">
               <span class="gs-arrow-tail"></span>
-              <span class="gs-arrow-bubble" id="globalArrowLabel">Synced</span>
+              <span class="gs-arrow-bubble" id="globalArrowLabel" data-i18n="editor.status.synced">Synced</span>
               <span class="gs-arrow-head"></span>
             </span>
             <div class="gs-node gs-node-remote">
@@ -1166,10 +1205,10 @@
                     <path fill-rule="evenodd" clip-rule="evenodd" d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z" fill="currentColor"/>
                   </svg>
                 </span>
-                <span class="gs-node-label">GitHub</span>
+                <span class="gs-node-label" data-i18n="editor.status.remoteLabel">GitHub</span>
               </div>
-              <span class="gs-repo" id="globalStatusRepo">Loading GitHub settings…</span>
-              <span class="gs-message" id="globalStatusMessage">Checking connection…</span>
+              <span class="gs-repo" id="globalStatusRepo" data-i18n="editor.status.loadingRepo">Loading GitHub settings…</span>
+              <span class="gs-message" id="globalStatusMessage" data-i18n="editor.status.checkingConnection">Checking connection…</span>
             </div>
           </div>
         </div>
@@ -1179,58 +1218,58 @@
     <!-- Editor Mode -->
     <div class="editor-layout is-empty" id="mode-editor">
       <section class="box editor-main">
-        <nav class="mode-switch-editor" id="modeDynamicTabs" role="tablist" aria-label="Open editor tabs" hidden aria-hidden="true"></nav>
+        <nav class="mode-switch-editor" id="modeDynamicTabs" role="tablist" aria-label="Open editor tabs" data-i18n-aria-label="editor.nav.dynamicTabsAria" hidden aria-hidden="true"></nav>
         <div class="toolbar">
           <div class="left-actions">
             <span class="current-file" id="currentFile" aria-live="polite"></span>
           </div>
           <div class="right-actions">
-            <div class="wrap-toggle view-toggle" id="wrapToggle" aria-label="Wrap setting">
-              <span class="vt-label">Wrap:</span>
-              <a href="#" class="vt-btn" data-wrap="on" role="button">on</a>
+            <div class="wrap-toggle view-toggle" id="wrapToggle" aria-label="Wrap setting" data-i18n-aria-label="editor.toolbar.wrapAria">
+              <span class="vt-label" data-i18n="editor.toolbar.wrap">Wrap:</span>
+              <a href="#" class="vt-btn" data-wrap="on" role="button" data-i18n="editor.toolbar.wrapOn">on</a>
               <span class="dim" aria-hidden="true">/</span>
-              <a href="#" class="vt-btn active" data-wrap="off" role="button">off</a>
+              <a href="#" class="vt-btn active" data-wrap="off" role="button" data-i18n="editor.toolbar.wrapOff">off</a>
             </div>
-            <div class="view-toggle" aria-label="View switch">
-              <span class="vt-label">View:</span>
-              <a href="#" class="vt-btn active" data-view="edit">Editor</a>
+            <div class="view-toggle" aria-label="View switch" data-i18n-aria-label="editor.toolbar.viewAria">
+              <span class="vt-label" data-i18n="editor.toolbar.view">View:</span>
+              <a href="#" class="vt-btn active" data-view="edit" data-i18n="editor.toolbar.viewEdit">Editor</a>
               <span class="dim" aria-hidden="true">/</span>
-              <a href="#" class="vt-btn" data-view="preview">Preview</a>
+              <a href="#" class="vt-btn" data-view="preview" data-i18n="editor.toolbar.viewPreview">Preview</a>
             </div>
             <button type="button" class="btn-secondary" id="btnDiscardMarkdown" disabled>
-              <span class="btn-label">Discard</span>
+              <span class="btn-label" data-i18n="editor.toolbar.discard">Discard</span>
             </button>
           </div>
         </div>
 
-        <div class="editor-tools" id="editorToolbar" aria-label="Editor tools">
-          <div class="editor-tools-left" role="group" aria-label="Formatting shortcuts">
-            <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnFmtBold" title="Bold" aria-label="Bold" disabled>Bold</button>
-            <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnFmtItalic" title="Italic" aria-label="Italic" disabled>Italic</button>
-            <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnFmtStrike" title="Strikethrough" aria-label="Strikethrough" disabled>Strike</button>
-            <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnFmtHeading" title="Heading" aria-label="Heading" disabled>Heading</button>
-            <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnFmtQuote" title="Quote" aria-label="Quote" disabled>Quote</button>
-            <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnFmtCode" title="Inline code" aria-label="Inline code" disabled>Code</button>
-            <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnFmtCodeBlock" title="Code block" aria-label="Code block" disabled>Code Block</button>
+        <div class="editor-tools" id="editorToolbar" aria-label="Editor tools" data-i18n-aria-label="editor.editorTools.aria">
+          <div class="editor-tools-left" role="group" aria-label="Formatting shortcuts" data-i18n-aria-label="editor.editorTools.formatGroupAria">
+            <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnFmtBold" title="Bold" aria-label="Bold" disabled data-i18n="editor.editorTools.bold" data-i18n-title="editor.editorTools.bold" data-i18n-aria-label="editor.editorTools.bold">Bold</button>
+            <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnFmtItalic" title="Italic" aria-label="Italic" disabled data-i18n="editor.editorTools.italic" data-i18n-title="editor.editorTools.italic" data-i18n-aria-label="editor.editorTools.italic">Italic</button>
+            <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnFmtStrike" title="Strikethrough" aria-label="Strikethrough" disabled data-i18n="editor.editorTools.strike" data-i18n-title="editor.editorTools.strike" data-i18n-aria-label="editor.editorTools.strike">Strike</button>
+            <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnFmtHeading" title="Heading" aria-label="Heading" disabled data-i18n="editor.editorTools.heading" data-i18n-title="editor.editorTools.heading" data-i18n-aria-label="editor.editorTools.heading">Heading</button>
+            <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnFmtQuote" title="Quote" aria-label="Quote" disabled data-i18n="editor.editorTools.quote" data-i18n-title="editor.editorTools.quote" data-i18n-aria-label="editor.editorTools.quote">Quote</button>
+            <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnFmtCode" title="Inline code" aria-label="Inline code" disabled data-i18n="editor.editorTools.code" data-i18n-title="editor.editorTools.code" data-i18n-aria-label="editor.editorTools.code">Code</button>
+            <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnFmtCodeBlock" title="Code block" aria-label="Code block" disabled data-i18n="editor.editorTools.codeBlock" data-i18n-title="editor.editorTools.codeBlock" data-i18n-aria-label="editor.editorTools.codeBlock">Code Block</button>
           </div>
           <div class="editor-tools-right">
-            <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnInsertCard" title="Insert article card" aria-haspopup="dialog" aria-expanded="false">Article Card</button>
+            <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnInsertCard" title="Insert article card" aria-haspopup="dialog" aria-expanded="false" data-i18n="editor.editorTools.articleCard" data-i18n-title="editor.editorTools.insertCardTitle">Article Card</button>
             <button type="button" class="btn-secondary btn-compact editor-tool-btn" id="btnInsertImage">
-              <span class="btn-label">Insert Image</span>
+              <span class="btn-label" data-i18n="editor.editorTools.insertImage">Insert Image</span>
             </button>
             <input type="file" id="editorImageInput" accept="image/*" multiple hidden>
           </div>
-          <div class="editor-card-popover" id="editorCardPicker" hidden aria-hidden="true" role="dialog" aria-label="Insert article card">
+          <div class="editor-card-popover" id="editorCardPicker" hidden aria-hidden="true" role="dialog" aria-label="Insert article card" data-i18n-aria-label="editor.editorTools.cardDialogAria">
             <div class="card-picker-search">
-              <input type="search" id="cardPickerSearch" placeholder="Search articles…" aria-label="Search articles">
+              <input type="search" id="cardPickerSearch" placeholder="Search articles…" aria-label="Search articles" data-i18n-placeholder="editor.editorTools.cardSearch" data-i18n-aria-label="editor.editorTools.cardSearch">
             </div>
             <div class="card-picker-list" id="cardPickerList" role="listbox"></div>
-            <div class="card-picker-empty" id="cardPickerEmpty" hidden>No matching articles</div>
+            <div class="card-picker-empty" id="cardPickerEmpty" hidden data-i18n="editor.editorTools.cardEmpty">No matching articles</div>
           </div>
         </div>
 
         <div id="editor-wrap">
-          <textarea id="mdInput" placeholder="# Hello NanoSite\n\nStart typing Markdown…" aria-label="Markdown source"></textarea>
+          <textarea id="mdInput" placeholder="# Hello NanoSite\n\nStart typing Markdown…" aria-label="Markdown source" data-i18n-placeholder="editor.editorPlaceholder" data-i18n-aria-label="editor.editorTextareaAria"></textarea>
         </div>
 
         <div id="preview-wrap" style="display:none;">
@@ -1241,8 +1280,8 @@
 
       <div class="editor-empty-state" id="editorEmptyState" role="status" aria-live="polite">
         <div class="empty-body">
-          <h2>No editor is currently open</h2>
-          <p>Open Markdown from the Composer to start editing.</p>
+          <h2 data-i18n="editor.empty.title">No editor is currently open</h2>
+          <p data-i18n="editor.empty.body">Open Markdown from the Composer to start editing.</p>
         </div>
       </div>
     </div>
@@ -1252,27 +1291,27 @@
       <section class="box editor-main" style="grid-column: 1 / -1;">
         <div class="toolbar">
           <div class="left-actions">
-            <div class="view-toggle" aria-label="File switch">
-              <span class="vt-label">File:</span>
-              <a href="#" class="vt-btn active" data-cfile="index">Articles</a>
+            <div class="view-toggle" aria-label="File switch" data-i18n-aria-label="editor.composer.fileSwitchAria">
+              <span class="vt-label" data-i18n="editor.composer.fileLabel">File:</span>
+              <a href="#" class="vt-btn active" data-cfile="index" data-i18n="editor.composer.fileArticles">Articles</a>
               <span class="dim" aria-hidden="true">/</span>
-              <a href="#" class="vt-btn" data-cfile="tabs">Pages</a>
+              <a href="#" class="vt-btn" data-cfile="tabs" data-i18n="editor.composer.filePages">Pages</a>
             </div>
           </div>
           <div class="right-actions">
-            <button class="btn-secondary" id="btnAddItem">Add Post Entry</button>
-            <button class="btn-secondary" id="btnRefresh" title="Fetch latest remote snapshot">Refresh</button>
+            <button class="btn-secondary" id="btnAddItem" data-i18n="editor.composer.addPost">Add Post Entry</button>
+            <button class="btn-secondary" id="btnRefresh" title="Fetch latest remote snapshot" data-i18n="editor.composer.refresh" data-i18n-title="editor.composer.refreshTitle">Refresh</button>
 
-            <button class="btn-secondary" id="btnDiscard" title="Discard local draft and reload remote file" hidden>Discard</button>
+            <button class="btn-secondary" id="btnDiscard" title="Discard local draft and reload remote file" data-i18n="editor.composer.discard" data-i18n-title="editor.composer.discardTitle" hidden>Discard</button>
           </div>
         </div>
         <div class="composer-order-inline-meta" id="composerOrderInlineMeta" hidden>
           <div class="composer-order-inline-meta-head">
             <div class="composer-order-inline-titles">
-              <h3 class="composer-order-inline-title">Change summary</h3>
+              <h3 class="composer-order-inline-title" data-i18n="editor.composer.changeSummary">Change summary</h3>
               <span class="composer-order-inline-kind">index.yaml</span>
             </div>
-            <button type="button" class="btn-secondary btn-compact composer-order-inline-open" data-kind="index" aria-label="Open change overview">Review changes</button>
+            <button type="button" class="btn-secondary btn-compact composer-order-inline-open" data-kind="index" aria-label="Open change overview" data-i18n="editor.composer.reviewChanges" data-i18n-aria-label="editor.composer.reviewChanges">Review changes</button>
           </div>
           <div class="composer-order-inline-stats" aria-live="polite"></div>
         </div>
@@ -1280,25 +1319,25 @@
         <!-- Composer Lists -->
         <div class="composer-panels" id="composerPanels">
           <div class="composer-order-host" data-kind="index" data-inline-active="false" id="composerIndexHost">
-            <div class="composer-order-inline" id="composerOrderInlineIndex" aria-label="Old order for index.yaml" hidden>
+            <div class="composer-order-inline" id="composerOrderInlineIndex" aria-label="Old order for index.yaml" data-i18n-aria-label="editor.composer.indexInlineAria" hidden>
               <div class="composer-order-inline-body">
                 <div class="composer-order-inline-list" role="list"></div>
-                <div class="composer-order-inline-empty" aria-hidden="false">No entries to compare yet.</div>
+                <div class="composer-order-inline-empty" aria-hidden="false" data-i18n="editor.composer.inlineEmpty">No entries to compare yet.</div>
               </div>
             </div>
             <div class="composer-order-main">
-              <div id="composerIndex" aria-label="index.yaml editor" style="display:block;"></div>
+              <div id="composerIndex" aria-label="index.yaml editor" data-i18n-aria-label="editor.composer.indexEditorAria" style="display:block;"></div>
             </div>
           </div>
           <div class="composer-order-host" data-kind="tabs" data-inline-active="false" id="composerTabsHost" style="display:none;">
-            <div class="composer-order-inline" id="composerOrderInlineTabs" aria-label="Old order for tabs.yaml" hidden>
+            <div class="composer-order-inline" id="composerOrderInlineTabs" aria-label="Old order for tabs.yaml" data-i18n-aria-label="editor.composer.tabsInlineAria" hidden>
               <div class="composer-order-inline-body">
                 <div class="composer-order-inline-list" role="list"></div>
-                <div class="composer-order-inline-empty" aria-hidden="false">No entries to compare yet.</div>
+                <div class="composer-order-inline-empty" aria-hidden="false" data-i18n="editor.composer.inlineEmpty">No entries to compare yet.</div>
               </div>
             </div>
             <div class="composer-order-main">
-              <div id="composerTabs" aria-label="tabs.yaml editor" style="display:none;"></div>
+              <div id="composerTabs" aria-label="tabs.yaml editor" data-i18n-aria-label="editor.composer.tabsEditorAria" style="display:none;"></div>
             </div>
           </div>
         </div>
@@ -1312,8 +1351,9 @@
   </div>
 
   <footer class="site-footer">
-    <p>Crafted with ❤️ using <a href="https://deemoe404.github.io/NanoSite/" target="_blank" rel="noopener">NanoSite</a>. Stay inspired and keep creating.</p>
+    <p data-i18n-html="editor.footerNote">Crafted with ❤️ using <a href="https://deemoe404.github.io/NanoSite/" target="_blank" rel="noopener">NanoSite</a>. Stay inspired and keep creating.</p>
   </footer>
+  <script type="module" src="assets/js/editor-boot.js"></script>
   <script type="module" src="assets/js/editor-main.js"></script>
   <script type="module" src="assets/js/composer.js"></script>
   <script type="module" src="assets/js/editor-github.js"></script>

--- a/index_editor.html
+++ b/index_editor.html
@@ -324,16 +324,18 @@
     .editor-main { min-width: 0; overflow: visible; position: relative; }
     .page-titlebar { display:flex; align-items:flex-end; justify-content:space-between; gap:.5rem; margin-bottom: .75rem; flex-wrap: wrap; }
     .editor-lang-switcher {
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-      gap: .3rem;
+      display: inline-flex;
+      flex-direction: row;
+      align-items: center;
+      gap: .5rem;
       min-width: 0;
-      padding: .25rem .5rem;
+      padding: .35rem .65rem;
       background: var(--card);
       border: 1px solid var(--border);
       border-radius: 10px;
       box-shadow: var(--shadow);
+      align-self: flex-start;
+      margin-right: auto;
     }
     .editor-lang-switcher label {
       font-size: .7rem;
@@ -341,6 +343,7 @@
       text-transform: uppercase;
       letter-spacing: .08em;
       color: color-mix(in srgb, var(--muted) 85%, transparent);
+      white-space: nowrap;
     }
     .editor-lang-switcher select {
       appearance: none;
@@ -348,7 +351,7 @@
       background: color-mix(in srgb, var(--card) 94%, transparent);
       color: var(--text);
       border-radius: 8px;
-      padding: .3rem .65rem;
+      padding: .3rem .8rem;
       font-size: .9rem;
       line-height: 1.4;
       cursor: pointer;


### PR DESCRIPTION
## Summary
- add a localized language picker to the editor layout and mark UI text with i18n attributes for translation
- initialize editor-specific translations via a new editor boot module and extend global translations for English, Chinese, and Japanese
- update composer status text to use i18n keys for upload/synced states and no-change messages

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d582dc23e083289179d270f38b477d