### PR TITLE
Make editor toolbars sticky

### DIFF
--- a/index_editor.html
+++ b/index_editor.html
@@ -37,6 +37,7 @@
       --composer-inline-ease: cubic-bezier(0.16, 1, 0.3, 1);
       --composer-inline-duration-in: 480ms;
       --composer-inline-duration-out: 380ms;
+      --editor-toolbar-offset: 0px;
     }
     @media (prefers-reduced-motion: reduce) {
       :root {
@@ -767,7 +768,20 @@
       font-weight:500;
       color: color-mix(in srgb, var(--muted) 88%, transparent);
     }
-    .toolbar { display:flex; align-items:center; justify-content:space-between; gap:.75rem; flex-wrap:wrap; margin-bottom:.75rem; padding-bottom:.5rem; border-bottom:1px solid #d0d7de; }
+    .toolbar {
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      gap:.75rem;
+      flex-wrap:wrap;
+      margin-bottom:.75rem;
+      padding:.35rem 0 .5rem;
+      border-bottom:1px solid #d0d7de;
+      position:sticky;
+      top:0;
+      z-index:120;
+      background:color-mix(in srgb, var(--card) 96%, transparent);
+    }
     .left-actions, .right-actions { display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; }
     .btn-secondary { display:inline-flex; align-items:center; justify-content:center; gap:.35rem; background: var(--card); color: var(--text); border:1px solid var(--border); padding:.45rem .8rem; border-radius:8px; cursor:pointer; font-size:.93rem; height:2.25rem; line-height:1; text-decoration:none; }
     .btn-secondary.btn-compact { padding:.3rem .65rem; height:2rem; font-size:.85rem; font-weight:600; }
@@ -775,7 +789,20 @@
     .btn-secondary:hover { background: color-mix(in srgb, var(--text) 5%, var(--card)); }
     a.btn-secondary:visited { color: var(--text); }
     .btn-secondary.is-busy { opacity:.6; cursor:progress; pointer-events:none; }
-    .editor-tools { display:flex; align-items:center; justify-content:space-between; gap:.65rem; flex-wrap:wrap; margin-bottom:.75rem; position:sticky; top:0; z-index:110; background:color-mix(in srgb, var(--card) 96%, transparent); padding-top:.35rem; padding-bottom:.35rem; }
+    .editor-tools {
+      display:flex;
+      align-items:center;
+      justify-content:space-between;
+      gap:.65rem;
+      flex-wrap:wrap;
+      margin-bottom:.75rem;
+      position:sticky;
+      top:calc(var(--editor-toolbar-offset, 0px));
+      z-index:110;
+      background:color-mix(in srgb, var(--card) 96%, transparent);
+      padding-top:.35rem;
+      padding-bottom:.35rem;
+    }
     .editor-tools-left, .editor-tools-right { display:flex; align-items:center; gap:.4rem; flex-wrap:wrap; }
     .editor-tool-btn { white-space:nowrap; }
     .editor-tool-btn[disabled] { opacity:.55; cursor:not-allowed; }
@@ -1356,6 +1383,44 @@
   <footer class="site-footer">
     <p data-i18n-html="editor.footerNote">Crafted with ❤️ using <a href="https://deemoe404.github.io/NanoSite/" target="_blank" rel="noopener">NanoSite</a>. Stay inspired and keep creating.</p>
   </footer>
+  <script>
+    (function () {
+      const root = document.documentElement;
+      const toolbarNodes = Array.from(document.querySelectorAll('.editor-main .toolbar'));
+      if (!toolbarNodes.length) return;
+
+      const updateOffset = () => {
+        let maxOffset = 0;
+        for (const toolbar of toolbarNodes) {
+          if (!toolbar.isConnected) continue;
+          if (toolbar.getClientRects().length === 0) continue;
+          const styles = getComputedStyle(toolbar);
+          const height = toolbar.offsetHeight;
+          const marginBottom = parseFloat(styles.marginBottom) || 0;
+          if (height > 0) {
+            maxOffset = Math.max(maxOffset, height + marginBottom);
+          }
+        }
+        root.style.setProperty('--editor-toolbar-offset', `${maxOffset}px`);
+      };
+
+      if (typeof ResizeObserver !== 'undefined') {
+        const ro = new ResizeObserver(updateOffset);
+        toolbarNodes.forEach((toolbar) => ro.observe(toolbar));
+      }
+
+      const layouts = ['mode-editor', 'mode-composer']
+        .map((id) => document.getElementById(id))
+        .filter(Boolean);
+      if (layouts.length) {
+        const mo = new MutationObserver(updateOffset);
+        layouts.forEach((node) => mo.observe(node, { attributes: true, attributeFilter: ['class', 'style'] }));
+      }
+
+      window.addEventListener('load', updateOffset, { once: true });
+      updateOffset();
+    })();
+  </script>
   <script type="module" src="assets/js/editor-boot.js"></script>
   <script type="module" src="assets/js/editor-main.js"></script>
   <script type="module" src="assets/js/composer.js"></script>


### PR DESCRIPTION
## Summary
- make the editor toolbar sticky with a matching background so it stays visible while scrolling
- compute and apply a dynamic offset for the editor tool controls so they stack correctly under the toolbar

## Testing
- python -m http.server 8000 (manual preview; stopped with Ctrl+C)


------
https://chatgpt.com/codex/tasks/task_e_68d61c9af4008328973e8b4585484edd