### PR TITLE
Increase spacing above composer inline meta summary

### DIFF
--- a/index_editor.html
+++ b/index_editor.html
@@ -1065,7 +1065,7 @@
     .composer-order-host .composer-order-main { grid-area: main; position: relative; z-index: 2; min-width: 0; }
     .composer-order-inline { grid-area: inline; display: flex; flex-direction: column; gap: .6rem; position: relative; z-index: 2; min-height: 0; }
     .composer-order-inline[hidden] { display: none !important; }
-    .composer-order-inline-meta { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: .6rem; margin-bottom: .4rem; }
+    .composer-order-inline-meta { display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: .6rem; margin: .75rem 0 .4rem; }
     .composer-order-inline-meta[hidden] { display: none !important; }
     .composer-order-inline,
     .composer-order-inline-meta {


### PR DESCRIPTION
## Summary
- add vertical margin above the inline change summary meta block in the composer view to create breathing room beneath the toolbar divider

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d62875467c832896849a77c17455e0