### PR TITLE
Improve site language selector

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -11323,7 +11323,7 @@ function rebuildSiteUI() {
   .ci-ver-item input.ci-path{flex:1 1 auto;min-width:0;height:2rem;border:1px solid var(--border);border-radius:6px;background:var(--card);color:var(--text);padding:.25rem .4rem;transition:border-color .18s ease, background-color .18s ease}
   .ci-ver-actions button:disabled{opacity:.5;cursor:not-allowed}
   /* Add Language row: compact button, keep menu aligned to trigger width */
-  .ci-add-lang,.ct-add-lang{display:inline-flex;align-items:center;gap:.5rem;margin-top:.5rem;position:relative}
+  .ci-add-lang,.ct-add-lang,.cs-add-lang{display:inline-flex;align-items:center;gap:.5rem;margin-top:.5rem;position:relative;flex:0 0 auto}
   .ci-add-lang .btn-secondary,.ct-add-lang .btn-secondary{justify-content:center;border-bottom:0 !important}
   .ci-add-lang input,.ct-add-lang input{height:2rem;border:1px solid var(--border);border-radius:6px;background:var(--card);color:var(--text);padding:.25rem .4rem}
   .ci-add-lang select,.ct-add-lang select{height:2rem;border:1px solid var(--border);border-radius:6px;background:var(--card);color:var(--text);padding:.25rem .4rem}
@@ -11332,7 +11332,7 @@ function rebuildSiteUI() {
   /* Button when open looks attached to menu */
   .ci-add-lang .btn-secondary.is-open,.ct-add-lang .btn-secondary.is-open{border-bottom-left-radius:0;border-bottom-right-radius:0;background:color-mix(in srgb, var(--text) 5%, var(--card));border-color:color-mix(in srgb, var(--primary) 45%, var(--border));border-bottom:0 !important}
   /* Custom menu popup */
-  .ns-menu{position:absolute;top:calc(100% - 1px);left:0;right:auto;z-index:101;border:1px solid var(--border);background:var(--card);box-shadow:var(--shadow);width:100%;min-width:0;border-top:none;border-bottom-left-radius:8px;border-bottom-right-radius:8px;border-top-left-radius:0;border-top-right-radius:0;transform-origin: top left;}
+  .ns-menu{position:absolute;top:calc(100% - 1px);left:0;right:auto;z-index:101;border:1px solid var(--border);background:var(--card);box-shadow:var(--shadow);width:max-content;min-width:100%;max-width:min(320px,calc(100vw - 3rem));border-top:none;border-bottom-left-radius:8px;border-bottom-right-radius:8px;border-top-left-radius:0;border-top-right-radius:0;transform-origin: top left;}
   .has-menu.is-open > .ns-menu{animation: ns-menu-in 160ms ease-out both}
   @keyframes ns-menu-in{from{opacity:0; transform: translateY(-4px) scale(0.98);} to{opacity:1; transform: translateY(0) scale(1);} }
   /* Closing animation */

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -10409,11 +10409,14 @@ function buildSiteUI(root, state) {
       if (!available.length) {
         addBtn.setAttribute('disabled', '');
         addWrap.classList.add('is-disabled');
+        addWrap.hidden = true;
         if (!menu.hidden) closeMenu();
-      } else {
-        addBtn.removeAttribute('disabled');
-        addWrap.classList.remove('is-disabled');
+        return;
       }
+
+      addBtn.removeAttribute('disabled');
+      addWrap.classList.remove('is-disabled');
+      addWrap.hidden = false;
     };
 
     const closeMenu = () => {
@@ -10439,7 +10442,7 @@ function buildSiteUI(root, state) {
 
     const openMenu = () => {
       refreshMenu();
-      if (!menu.innerHTML.trim()) return;
+      if (!menu.innerHTML.trim() || addWrap.hidden) return;
       if (!menu.hidden) return;
       menu.hidden = false;
       try { menu.classList.remove('is-closing'); } catch (_) {}


### PR DESCRIPTION
## Summary
- replace the Site settings language prompt with a dropdown menu of available languages
- reuse the composer language menu styling and update options dynamically based on configured languages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d66b5910e88328a22deff48506069d