### PR TITLE
Add SEO tooling mode to editor

### DIFF
--- a/assets/js/editor-seo.js
+++ b/assets/js/editor-seo.js
@@ -1,0 +1,336 @@
+import './seo-tool-state.js';
+import {
+  generateSitemap,
+  generateRobots,
+  generateMetaTags,
+  validateSitemap,
+  validateRobots,
+  validateMeta,
+  copySitemap,
+  copyRobots,
+  copyMetaTags,
+  downloadSitemap,
+  downloadRobots,
+  downloadMetaTags
+} from './seo-tool-generators.js?v=2';
+import { initSeoEditors, getEditorValue, setEditorValue } from './hieditor.js';
+
+const SEO_FILES = {
+  sitemap: {
+    path: 'sitemap.xml',
+    label: 'sitemap.xml',
+    outputId: 'sitemapOutput',
+    previewId: 'sitemapPreview',
+    statusId: 'seoStatus-sitemap',
+    loadBtn: 'seoLoadSitemap',
+    generateBtn: 'seoGenerateSitemap',
+    validateBtn: 'seoValidateSitemap',
+    copyBtn: 'seoCopySitemap',
+    downloadBtn: 'seoDownloadSitemap',
+    resetBtn: 'seoResetSitemap',
+    generator: generateSitemap,
+    validator: validateSitemap,
+    copier: copySitemap,
+    downloader: downloadSitemap,
+    loaded: false,
+    loading: null,
+    cachedContent: ''
+  },
+  robots: {
+    path: 'robots.txt',
+    label: 'robots.txt',
+    outputId: 'robotsOutput',
+    previewId: 'robotsPreview',
+    statusId: 'seoStatus-robots',
+    loadBtn: 'seoLoadRobots',
+    generateBtn: 'seoGenerateRobots',
+    validateBtn: 'seoValidateRobots',
+    copyBtn: 'seoCopyRobots',
+    downloadBtn: 'seoDownloadRobots',
+    resetBtn: 'seoResetRobots',
+    generator: generateRobots,
+    validator: validateRobots,
+    copier: copyRobots,
+    downloader: downloadRobots,
+    loaded: false,
+    loading: null,
+    cachedContent: ''
+  },
+  meta: {
+    path: 'meta-tags.html',
+    label: 'meta-tags.html',
+    outputId: 'metaOutput',
+    previewId: 'metaPreview',
+    statusId: 'seoStatus-meta',
+    loadBtn: 'seoLoadMeta',
+    generateBtn: 'seoGenerateMeta',
+    validateBtn: 'seoValidateMeta',
+    copyBtn: 'seoCopyMeta',
+    downloadBtn: 'seoDownloadMeta',
+    resetBtn: 'seoResetMeta',
+    generator: generateMetaTags,
+    validator: validateMeta,
+    copier: copyMetaTags,
+    downloader: downloadMetaTags,
+    loaded: false,
+    loading: null,
+    cachedContent: ''
+  }
+};
+
+let seoModeInitialized = false;
+
+function composerApi() {
+  try {
+    return window.__nsSeoDraftApi || {};
+  } catch (_) {
+    return {};
+  }
+}
+
+function setBaseline(kind, text, meta) {
+  const api = composerApi();
+  if (typeof api.setBaseline === 'function') api.setBaseline(kind, text, meta);
+}
+
+function setContent(kind, text, meta) {
+  const api = composerApi();
+  if (typeof api.setContent === 'function') api.setContent(kind, text, meta);
+}
+
+function resetDraft(kind) {
+  const api = composerApi();
+  if (typeof api.reset === 'function') api.reset(kind);
+}
+
+function getDraft(kind) {
+  const api = composerApi();
+  if (typeof api.get === 'function') return api.get(kind);
+  return null;
+}
+
+function updateStatus(kind, message, state) {
+  const info = SEO_FILES[kind];
+  if (!info) return;
+  const el = document.getElementById(info.statusId);
+  if (!el) return;
+  if (message != null) el.textContent = message;
+  if (state) el.dataset.state = state;
+}
+
+function refreshStatus(kind) {
+  const info = SEO_FILES[kind];
+  if (!info) return;
+  const entry = getDraft(kind);
+  if (!entry) {
+    updateStatus(kind, 'Load current file to begin.', 'idle');
+    return;
+  }
+  if (entry.dirty) {
+    const msg = entry.exists ? 'Ready to sync (updated)' : 'Ready to sync (new file)';
+    updateStatus(kind, msg, 'dirty');
+    return;
+  }
+  if (info.loaded) {
+    if (entry.exists && entry.original) {
+      updateStatus(kind, 'In sync with GitHub', 'clean');
+    } else {
+      updateStatus(kind, 'Not published yet', 'empty');
+    }
+  } else {
+    updateStatus(kind, 'Load current file to begin.', 'idle');
+  }
+}
+
+function refreshAllStatuses() {
+  Object.keys(SEO_FILES).forEach((kind) => refreshStatus(kind));
+}
+
+async function loadExisting(kind, options = {}) {
+  const info = SEO_FILES[kind];
+  if (!info) return '';
+  if (info.loading) return info.loading;
+  if (info.loaded && !options.force) return info.cachedContent;
+
+  updateStatus(kind, 'Loading current file…', 'loading');
+  const loader = (async () => {
+    let content = '';
+    let exists = false;
+    try {
+      const response = await fetch(info.path, { cache: 'no-store' });
+      if (response.status === 404) {
+        content = '';
+        exists = false;
+      } else if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      } else {
+        content = await response.text();
+        exists = true;
+      }
+    } catch (err) {
+      updateStatus(kind, `Failed to load (${err.message || 'error'})`, 'error');
+      info.loaded = false;
+      throw err;
+    }
+
+    setBaseline(kind, content, { exists, path: info.path, label: info.label });
+
+    const textarea = document.getElementById(info.outputId);
+    if (textarea) textarea.value = content;
+    try { setEditorValue(info.outputId, content); } catch (_) {}
+
+    info.loaded = true;
+    info.cachedContent = content;
+    refreshStatus(kind);
+    return content;
+  })().finally(() => {
+    info.loading = null;
+  });
+
+  info.loading = loader;
+  return loader;
+}
+
+function handleTextareaInput(kind) {
+  const info = SEO_FILES[kind];
+  if (!info) return;
+  const textarea = document.getElementById(info.outputId);
+  if (!textarea) return;
+  textarea.addEventListener('input', () => {
+    const value = textarea.value || '';
+    setContent(kind, value, { path: info.path, label: info.label });
+    refreshStatus(kind);
+  });
+}
+
+function ensureEditorsInitialized() {
+  try { initSeoEditors(); } catch (_) {}
+}
+
+function extractEditorValue(kind) {
+  const info = SEO_FILES[kind];
+  if (!info) return '';
+  let value = '';
+  try { value = getEditorValue(info.outputId) || ''; }
+  catch (_) { value = ''; }
+  if (!value) {
+    const textarea = document.getElementById(info.outputId);
+    if (textarea) value = textarea.value || '';
+  }
+  return value;
+}
+
+function attachButtonHandlers(kind) {
+  const info = SEO_FILES[kind];
+  if (!info) return;
+
+  const loadBtn = document.getElementById(info.loadBtn);
+  if (loadBtn) {
+    loadBtn.addEventListener('click', () => {
+      loadExisting(kind, { force: true }).catch(() => {});
+    });
+  }
+
+  const generateBtn = document.getElementById(info.generateBtn);
+  if (generateBtn) {
+    generateBtn.addEventListener('click', async () => {
+      if (!info.loaded) {
+        try { await loadExisting(kind); }
+        catch (_) { /* swallow load errors; generation may still proceed */ }
+      }
+      updateStatus(kind, 'Generating…', 'loading');
+      try {
+        await info.generator();
+      } catch (err) {
+        updateStatus(kind, `Generation failed (${err && err.message ? err.message : 'error'})`, 'error');
+        return;
+      }
+      const value = extractEditorValue(kind);
+      setContent(kind, value, { path: info.path, label: info.label });
+      info.cachedContent = value;
+      refreshStatus(kind);
+    });
+  }
+
+  const validateBtn = document.getElementById(info.validateBtn);
+  if (validateBtn) {
+    validateBtn.addEventListener('click', () => {
+      try { info.validator(); }
+      catch (_) {}
+      refreshStatus(kind);
+    });
+  }
+
+  const copyBtn = document.getElementById(info.copyBtn);
+  if (copyBtn) {
+    copyBtn.addEventListener('click', () => {
+      try { info.copier(); }
+      catch (_) {}
+    });
+  }
+
+  const downloadBtn = document.getElementById(info.downloadBtn);
+  if (downloadBtn) {
+    downloadBtn.addEventListener('click', () => {
+      try { info.downloader(); }
+      catch (_) {}
+    });
+  }
+
+  const resetBtn = document.getElementById(info.resetBtn);
+  if (resetBtn) {
+    resetBtn.addEventListener('click', () => {
+      const entryBefore = getDraft(kind);
+      resetDraft(kind);
+      const entryAfter = getDraft(kind) || entryBefore;
+      const original = entryAfter ? entryAfter.original || '' : '';
+      try { setEditorValue(info.outputId, original); } catch (_) {}
+      const textarea = document.getElementById(info.outputId);
+      if (textarea) textarea.value = original;
+      info.cachedContent = original;
+      updateStatus(kind, 'Reverted to loaded version', entryAfter && entryAfter.exists ? 'clean' : 'empty');
+      refreshStatus(kind);
+    });
+  }
+}
+
+async function initializeSeoMode() {
+  if (seoModeInitialized) {
+    refreshAllStatuses();
+    return;
+  }
+  seoModeInitialized = true;
+  ensureEditorsInitialized();
+  Object.keys(SEO_FILES).forEach((kind) => {
+    handleTextareaInput(kind);
+    attachButtonHandlers(kind);
+  });
+  refreshAllStatuses();
+  await Promise.all(Object.keys(SEO_FILES).map((kind) => loadExisting(kind).catch(() => {})));
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const activeTab = document.querySelector('.mode-tab.is-active');
+  if (activeTab && activeTab.dataset.mode === 'seo') {
+    initializeSeoMode().catch(() => {});
+  } else {
+    refreshAllStatuses();
+  }
+});
+
+document.addEventListener('ns:mode-changed', (event) => {
+  const detail = event && event.detail;
+  if (!detail) return;
+  if (detail.mode === 'seo') {
+    initializeSeoMode().catch(() => {});
+  }
+});
+
+document.addEventListener('ns:seo-draft-change', (event) => {
+  const detail = event && event.detail;
+  if (!detail || !detail.kind) {
+    refreshAllStatuses();
+    return;
+  }
+  refreshStatus(detail.kind);
+});

--- a/assets/js/seo-tool-generators.js
+++ b/assets/js/seo-tool-generators.js
@@ -1192,3 +1192,18 @@ window.__seoToolState = state;
 window.__seoUpdatePreview = function(id){
   try { const ta = document.getElementById(id); const val = ta ? (ta.value || '') : ''; setEditorValue(id, val); } catch (_) {}
 }
+
+export {
+  generateSitemap,
+  generateRobots,
+  generateMetaTags,
+  validateSitemap,
+  validateRobots,
+  validateMeta,
+  copySitemap,
+  copyRobots,
+  copyMetaTags,
+  downloadSitemap,
+  downloadRobots,
+  downloadMetaTags
+};

--- a/index_editor.html
+++ b/index_editor.html
@@ -1231,6 +1231,35 @@
     [data-init-cfile="site"] #composerSite { display: block !important; }
     [data-init-cfile="site"] #composerIndex,
     [data-init-cfile="site"] #composerTabs { display: none !important; }
+
+    /* SEO mode */
+    #mode-seo { display: none; }
+    .seo-mode { display: flex; flex-direction: column; gap: 1.5rem; }
+    .seo-mode .seo-intro { display: flex; flex-direction: column; gap: .5rem; }
+    .seo-mode .seo-intro h2 { margin: 0; font-size: 1.5rem; font-weight: 700; color: var(--text); }
+    .seo-mode .seo-intro p { margin: 0; color: var(--muted); font-size: .98rem; line-height: 1.6; }
+    .seo-grid { display: grid; gap: 1.5rem; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); align-items: stretch; }
+    .seo-card { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 1.25rem; display: flex; flex-direction: column; gap: 1rem; box-shadow: var(--shadow); min-width: 0; }
+    .seo-card-header { display: flex; align-items: center; justify-content: space-between; gap: .75rem; }
+    .seo-card-header h3 { margin: 0; font-size: 1.15rem; font-weight: 700; color: var(--text); }
+    .seo-status { font-size: .9rem; color: var(--muted); display: inline-flex; align-items: center; gap: .45rem; }
+    .seo-status[data-state="dirty"] { color: var(--primary); font-weight: 600; }
+    .seo-status[data-state="error"] { color: #dc2626; }
+    .seo-status[data-state="loading"] { color: var(--muted); font-style: italic; }
+    .seo-status[data-state="clean"] { color: #15803d; }
+    .seo-status[data-state="empty"] { color: #92400e; }
+    .seo-actions { display: flex; flex-wrap: wrap; gap: .5rem; align-items: center; }
+    .seo-actions button { display: inline-flex; align-items: center; justify-content: center; gap: .35rem; }
+    .seo-actions .btn-tertiary { border-style: dashed; }
+    .seo-preview { border: 1px solid color-mix(in srgb, var(--border) 80%, transparent); border-radius: 12px; padding: 1rem; background: color-mix(in srgb, var(--card) 94%, transparent); max-height: 320px; overflow: auto; font-size: .9rem; line-height: 1.5; }
+    .seo-editor-wrap { position: relative; display: flex; flex-direction: column; gap: .75rem; }
+    .seo-editor-wrap textarea { min-height: 220px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Ubuntu Mono", monospace; font-size: .85rem; }
+    .seo-card-footer { display: flex; align-items: center; justify-content: flex-end; gap: .5rem; }
+    .seo-mode .hi-editor { max-height: 320px; }
+    .seo-mode .hi-editor .code-scroll { min-height: 220px; }
+    @media (max-width: 720px) {
+      .seo-grid { grid-template-columns: 1fr; }
+    }
   </style>
 </head>
 <body>
@@ -1247,6 +1276,10 @@
         </button>
         <button class="mode-tab" data-mode="editor" data-tab-label="Editor" data-i18n-data-tab-label="editor.modes.editor" role="tab" aria-controls="mode-editor" aria-selected="false" aria-label="Editor" data-i18n-aria-label="editor.modes.editor">
           <span class="mode-tab-text" data-i18n="editor.modes.editor">Editor</span>
+          <span class="mode-tab-badge" aria-hidden="true" hidden></span>
+        </button>
+        <button class="mode-tab" data-mode="seo" data-tab-label="SEO" role="tab" aria-controls="mode-seo" aria-selected="false" aria-label="SEO">
+          <span class="mode-tab-text">SEO</span>
           <span class="mode-tab-badge" aria-hidden="true" hidden></span>
         </button>
       </nav>
@@ -1359,6 +1392,71 @@
         </div>
       </div>
     </div>
+
+    <!-- SEO Mode -->
+    <section class="box seo-mode" id="mode-seo" style="display:none;">
+      <div class="seo-intro">
+        <h2>SEO tools</h2>
+        <p>Generate sitemap, robots.txt, and HTML meta tags directly from your site configuration and content. Any changes appear in the status panel and can be synchronized to GitHub with the existing workflow.</p>
+      </div>
+      <div class="seo-grid">
+        <article class="seo-card" data-seo-kind="sitemap">
+          <div class="seo-card-header">
+            <h3>sitemap.xml</h3>
+            <span class="seo-status" id="seoStatus-sitemap" data-state="idle" role="status" aria-live="polite">Load current sitemap to begin.</span>
+          </div>
+          <div class="seo-actions">
+            <button type="button" class="btn-tertiary" id="seoLoadSitemap">Load current</button>
+            <button type="button" class="btn-primary" id="seoGenerateSitemap">Generate</button>
+            <button type="button" class="btn-secondary" id="seoValidateSitemap">Validate</button>
+            <button type="button" class="btn-secondary" id="seoCopySitemap">Copy</button>
+            <button type="button" class="btn-secondary" id="seoDownloadSitemap">Download</button>
+            <button type="button" class="btn-tertiary" id="seoResetSitemap">Revert</button>
+          </div>
+          <div class="seo-preview" id="sitemapPreview" aria-live="polite"></div>
+          <div class="seo-editor-wrap">
+            <textarea id="sitemapOutput" data-seo-kind="sitemap" spellcheck="false"></textarea>
+          </div>
+        </article>
+        <article class="seo-card" data-seo-kind="robots">
+          <div class="seo-card-header">
+            <h3>robots.txt</h3>
+            <span class="seo-status" id="seoStatus-robots" data-state="idle" role="status" aria-live="polite">Load current robots.txt to begin.</span>
+          </div>
+          <div class="seo-actions">
+            <button type="button" class="btn-tertiary" id="seoLoadRobots">Load current</button>
+            <button type="button" class="btn-primary" id="seoGenerateRobots">Generate</button>
+            <button type="button" class="btn-secondary" id="seoValidateRobots">Validate</button>
+            <button type="button" class="btn-secondary" id="seoCopyRobots">Copy</button>
+            <button type="button" class="btn-secondary" id="seoDownloadRobots">Download</button>
+            <button type="button" class="btn-tertiary" id="seoResetRobots">Revert</button>
+          </div>
+          <div class="seo-preview" id="robotsPreview" aria-live="polite"></div>
+          <div class="seo-editor-wrap">
+            <textarea id="robotsOutput" data-seo-kind="robots" spellcheck="false"></textarea>
+          </div>
+        </article>
+        <article class="seo-card" data-seo-kind="meta">
+          <div class="seo-card-header">
+            <h3>meta-tags.html</h3>
+            <span class="seo-status" id="seoStatus-meta" data-state="idle" role="status" aria-live="polite">Load current meta tags to begin.</span>
+          </div>
+          <div class="seo-actions">
+            <button type="button" class="btn-tertiary" id="seoLoadMeta">Load current</button>
+            <button type="button" class="btn-primary" id="seoGenerateMeta">Generate</button>
+            <button type="button" class="btn-secondary" id="seoValidateMeta">Validate</button>
+            <button type="button" class="btn-secondary" id="seoCopyMeta">Copy</button>
+            <button type="button" class="btn-secondary" id="seoDownloadMeta">Download</button>
+            <button type="button" class="btn-tertiary" id="seoResetMeta">Revert</button>
+          </div>
+          <div class="seo-preview" id="metaPreview" aria-live="polite"></div>
+          <div class="seo-editor-wrap">
+            <textarea id="metaOutput" data-seo-kind="meta" spellcheck="false"></textarea>
+          </div>
+        </article>
+      </div>
+      <textarea id="configOutput" hidden></textarea>
+    </section>
 
     <!-- Composer Mode -->
     <div class="editor-layout" id="mode-composer" style="display:none;">
@@ -1473,6 +1571,7 @@
   <script type="module" src="assets/js/editor-boot.js"></script>
   <script type="module" src="assets/js/editor-main.js"></script>
   <script type="module" src="assets/js/composer.js"></script>
+  <script type="module" src="assets/js/editor-seo.js"></script>
   <script type="module" src="assets/js/editor-github.js"></script>
   <!-- Back to top button -->
   <button id="backToTop" class="back-to-top" aria-label="返回顶部" title="返回顶部" type="button" hidden>


### PR DESCRIPTION
## Summary
- add a dedicated SEO mode to the editor that can load, generate, and preview sitemap.xml, robots.txt, and meta-tags.html
- integrate the generated SEO files with the existing status stack and GitHub sync pipeline so changes appear alongside other drafts
- expose reusable SEO generator helpers and hook up a new editor-seo module to orchestrate UI events and composer interactions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6e2ba3ba88328aefe627b33ca3c0b