### PR TITLE
Add file previews to GitHub sync modal

### DIFF
--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -252,7 +252,8 @@ const translations = {
         noLocalChangesYet: 'No local changes yet.',
         dialogs: {
           cancel: 'Cancel',
-          confirm: 'Confirm'
+          confirm: 'Confirm',
+          close: 'Close'
         },
         statusMessages: {
           loadingConfig: 'Loading config…',
@@ -525,16 +526,25 @@ const translations = {
             title: 'Synchronize with GitHub',
             subtitle: 'Provide a Fine-grained Personal Access Token with repository contents access.',
             summaryTitle: 'The following files will be committed:',
+            summaryTextFilesTitle: 'Content files',
+            summaryAssetFilesTitle: 'Asset files',
+            summaryEmpty: 'No pending files to commit.',
             tokenLabel: 'Fine-grained Personal Access Token',
             helpHtml: 'Create a token at <a href="https://github.com/settings/tokens?type=beta" target="_blank" rel="noopener">github.com/settings/tokens</a> with access to the repository\'s contents. The token is stored for this browser session only.',
             forget: 'Forget token',
             submit: 'Commit changes',
             errorRequired: 'Enter a Fine-grained Personal Access Token to continue.'
+          },
+          preview: {
+            subtitle: 'Preview pending file before uploading to GitHub.',
+            unavailable: 'Preview unavailable for this file.',
+            untitled: 'Untitled file'
           }
         },
         dialogs: {
           cancel: 'Cancel',
-          confirm: 'Confirm'
+          confirm: 'Confirm',
+          close: 'Close'
         },
         addEntryPrompt: {
           hint: 'Use only English letters and numbers.',
@@ -881,7 +891,8 @@ const translations = {
         noLocalChangesYet: '暂时没有本地更改。',
         dialogs: {
           cancel: '取消',
-          confirm: '确认'
+          confirm: '确认',
+          close: '关闭'
         },
         statusMessages: {
           loadingConfig: '正在加载配置…',
@@ -1155,16 +1166,25 @@ const translations = {
             title: '与 GitHub 同步',
             subtitle: '请提供具备仓库内容访问权限的精细化个人访问令牌。',
             summaryTitle: '将提交以下文件：',
+            summaryTextFilesTitle: '内容文件',
+            summaryAssetFilesTitle: '资源文件',
+            summaryEmpty: '没有待提交的文件。',
             tokenLabel: '精细化个人访问令牌',
             helpHtml: '请在 <a href="https://github.com/settings/tokens?type=beta" target="_blank" rel="noopener">github.com/settings/tokens</a> 创建一个具有仓库内容访问权限的令牌。该令牌仅在当前浏览器会话中存储。',
             forget: '忘记令牌',
             submit: '提交更改',
             errorRequired: '请输入精细化个人访问令牌以继续。'
+          },
+          preview: {
+            subtitle: '上传至 GitHub 之前预览待提交的文件。',
+            unavailable: '无法预览此文件。',
+            untitled: '未命名文件'
           }
         },
         dialogs: {
           cancel: '取消',
-          confirm: '确认'
+          confirm: '确认',
+          close: '关闭'
         },
         addEntryPrompt: {
           hint: '仅使用英文字母和数字。',
@@ -1511,7 +1531,8 @@ const translations = {
         noLocalChangesYet: 'ローカルの変更はまだありません。',
         dialogs: {
           cancel: 'キャンセル',
-          confirm: '確認'
+          confirm: '確認',
+          close: '閉じる'
         },
         statusMessages: {
           loadingConfig: '設定を読み込み中…',
@@ -1785,16 +1806,25 @@ const translations = {
             title: 'GitHub と同期',
             subtitle: 'リポジトリの内容にアクセスできるファイングレインド Personal Access Token を入力してください。',
             summaryTitle: '以下のファイルがコミットされます:',
+            summaryTextFilesTitle: 'コンテンツファイル',
+            summaryAssetFilesTitle: 'アセットファイル',
+            summaryEmpty: 'コミット予定のファイルはありません。',
             tokenLabel: 'ファイングレインド Personal Access Token',
             helpHtml: '<a href="https://github.com/settings/tokens?type=beta" target="_blank" rel="noopener">github.com/settings/tokens</a> でリポジトリ内容にアクセスできるトークンを作成してください。このトークンはこのブラウザセッションにのみ保存されます。',
             forget: 'トークンを削除',
             submit: '変更をコミット',
             errorRequired: '続行するにはファイングレインド Personal Access Token を入力してください。'
+          },
+          preview: {
+            subtitle: 'GitHub にアップロードする前にファイルを確認できます。',
+            unavailable: 'このファイルはプレビューできません。',
+            untitled: '無題のファイル'
           }
         },
         dialogs: {
           cancel: 'キャンセル',
-          confirm: '確認'
+          confirm: '確認',
+          close: '閉じる'
         },
         addEntryPrompt: {
           hint: '英数字のみを使用してください。',

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1578,6 +1578,82 @@ ul.collapsed, li > ul.collapsed { display: none; }
 #mainview figure > img { display: block; width: 100%; height: auto; border-radius: 0.5rem; box-shadow: var(--shadow); }
 #mainview figcaption { margin-top: 0.4rem; color: var(--muted); text-align: center; }
 
+/* GitHub synchronization preview */
+.gh-sync-file-group { margin-top: 0.75rem; }
+.gh-sync-file-group-title {
+  font-weight: 600;
+  color: var(--text);
+  margin-bottom: 0.35rem;
+}
+.gh-sync-file-list { display: flex; flex-direction: column; gap: 0.35rem; }
+.gh-sync-file-entry {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--text);
+  border-radius: 0.65rem;
+  padding: 0.45rem 0.65rem;
+  text-align: left;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease, transform 0.1s ease;
+}
+.gh-sync-file-entry:hover,
+.gh-sync-file-entry:focus-visible {
+  outline: none;
+  border-color: color-mix(in srgb, var(--primary) 45%, var(--border));
+  background: color-mix(in srgb, var(--primary) 10%, var(--card));
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.15);
+}
+.gh-sync-file-entry:active { transform: translateY(1px); }
+
+.github-preview-dialog { max-width: min(90vw, 860px); }
+.github-preview-body {
+  padding: 0.25rem 0 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+.github-preview-path {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+.github-preview-content {
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--surface, var(--card)) 90%, transparent);
+  padding: 0.75rem;
+  max-height: 60vh;
+  overflow: auto;
+}
+.github-preview-code {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: var(--code-font, 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace);
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+.github-preview-image {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 0.5rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
+}
+.github-preview-empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+.github-preview-meta {
+  margin: -0.25rem 0 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
 /* Raw HTML media defaults (when not using auto-wrapped styles) */
 #mainview video:not(.post-video) { display: block; width: 100%; height: auto; border-radius: 0.5rem; box-shadow: var(--shadow); background: color-mix(in srgb, var(--text) 4%, transparent); margin: 0.75rem 0; }
 #mainview iframe { display: block; width: 100%; max-width: 100%; border: 0; border-radius: 0.5rem; box-shadow: var(--shadow); background: var(--card); margin: 0.75rem 0; }


### PR DESCRIPTION
## Summary
- list pending content and asset files individually in the GitHub sync modal
- add in-modal previews for text and image files
- localize new strings and style the GitHub preview UI
- fix the GitHub preview close button label so localized text renders correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d783d0342c83289b32af3df6e6d763