### PR TITLE
Adjust system update release notes container layout

### DIFF
--- a/index_editor.html
+++ b/index_editor.html
@@ -79,6 +79,7 @@
     .updates-file-badge { flex:0 0 auto; font-size:.75rem; font-weight:700; text-transform:uppercase; letter-spacing:.04em; color: color-mix(in srgb, var(--primary) 90%, transparent); background: color-mix(in srgb, var(--primary) 14%, transparent); border-radius:999px; padding:.2rem .65rem; }
     .updates-notes { display:flex; flex-direction:column; gap:.55rem; }
     .updates-release-notes { border:1px solid color-mix(in srgb, var(--border) 80%, transparent); border-radius:14px; background: color-mix(in srgb, var(--card) 95%, transparent); padding:1rem 1.1rem; max-height:360px; overflow:auto; font-size:.95rem; color: color-mix(in srgb, var(--text) 88%, transparent); }
+    #systemUpdateReleaseNotes { max-height:none; overflow:visible; }
     .updates-release-notes h1,
     .updates-release-notes h2,
     .updates-release-notes h3,


### PR DESCRIPTION
## Summary
- allow the system update release notes container to expand with its content
- disable the internal scrollbar so the page scroll handles overflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7f4b33ee48328954f34c5dcd5ddc5