### PR TITLE
Add theme manifest-driven layout system

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@
 
 ## ✨ Features
 
-- ⚡ **Zero Build** – no bundlers, compilers, or environments required.  
-- 📝 **Markdown-first** – write posts like plain notes.  
-- 🌐 **GitHub Pages Ready** – simply push and host.  
-- 📊 **Performance Friendly** – passes [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) audits with great scores (see hero image above).  
-- 🎨 **Configurable** – customize your site using a simple `site.yaml`.  
+- ⚡ **Zero Build** – no bundlers, compilers, or environments required.
+- 📝 **Markdown-first** – write posts like plain notes.
+- 🌐 **GitHub Pages Ready** – simply push and host.
+- 📊 **Performance Friendly** – passes [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) audits with great scores (see hero image above).
+- 🎨 **Configurable** – customize your site using a simple `site.yaml`.
+- 🧩 **Composable Themes** – theme packs can ship manifests with layout presets, custom assets, and optional behavior.
 
 ## 🌍 Built with Nanosite
 

--- a/assets/js/layouts.js
+++ b/assets/js/layouts.js
@@ -1,0 +1,411 @@
+const LAYOUT_PRESETS = new Map();
+const COMPONENT_REGISTRY = new Map();
+const DEFAULT_PRESET = 'sidebar-right';
+let currentPresetName = null;
+let activeBodyClasses = [];
+let activeRootClasses = [];
+
+const IDENT_RE = /[^a-z0-9_-]/g;
+
+function sanitizeKey(value) {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim().toLowerCase();
+  const clean = trimmed.replace(IDENT_RE, '');
+  return clean;
+}
+
+function sanitizePresetName(value) {
+  const key = sanitizeKey(value);
+  return key || DEFAULT_PRESET;
+}
+
+function sanitizeZoneName(value) {
+  const key = sanitizeKey(value);
+  return key || '';
+}
+
+function isElement(node) {
+  return !!(node && typeof node === 'object' && node.nodeType === 1);
+}
+
+function toArray(input) {
+  if (Array.isArray(input)) return input;
+  if (input === undefined || input === null) return [];
+  return [input];
+}
+
+function sanitizeComponentKey(value) {
+  const key = sanitizeKey(value);
+  return key;
+}
+
+function sanitizeZoneEntries(input) {
+  const arr = toArray(input);
+  const out = [];
+  for (const value of arr) {
+    const key = sanitizeComponentKey(value);
+    if (key) out.push(key);
+  }
+  return out;
+}
+
+function normalizeZoneObject(zones) {
+  const result = {};
+  if (!zones || typeof zones !== 'object') return result;
+  for (const [zoneName, entries] of Object.entries(zones)) {
+    const name = sanitizeZoneName(zoneName);
+    if (!name) continue;
+    const normalized = sanitizeZoneEntries(entries);
+    if (normalized.length || (Array.isArray(entries) && entries.length === 0)) {
+      result[name] = normalized;
+    }
+  }
+  return result;
+}
+
+function classListFrom(input) {
+  const out = [];
+  if (!input) return out;
+  if (typeof input === 'string') {
+    input.split(/\s+/g).forEach(token => {
+      const cls = sanitizeKey(token);
+      if (cls) out.push(cls);
+    });
+    return out;
+  }
+  if (Array.isArray(input)) {
+    input.forEach(token => {
+      const cls = sanitizeKey(token);
+      if (cls) out.push(cls);
+    });
+  } else if (typeof input === 'object') {
+    for (const token of Object.keys(input)) {
+      if (!Object.prototype.hasOwnProperty.call(input, token)) continue;
+      const enabled = input[token];
+      if (!enabled) continue;
+      const cls = sanitizeKey(token);
+      if (cls) out.push(cls);
+    }
+  }
+  return out;
+}
+
+function ensureLayoutRoot() {
+  const root = document.querySelector('[data-layout-root]');
+  if (!root) return null;
+  return root;
+}
+
+function collectComponents() {
+  const nodes = {};
+  for (const [key, resolver] of COMPONENT_REGISTRY.entries()) {
+    if (typeof resolver !== 'function') continue;
+    try {
+      const node = resolver();
+      if (isElement(node)) nodes[key] = node;
+    } catch (_) {
+      // ignore resolver errors to avoid breaking layout apply
+    }
+  }
+  return nodes;
+}
+
+function takeNode(key, nodes, used) {
+  if (!nodes || !Object.prototype.hasOwnProperty.call(nodes, key)) return null;
+  const node = nodes[key];
+  if (!isElement(node) || used.has(key)) return null;
+  used.add(key);
+  if (node.parentNode) node.parentNode.removeChild(node);
+  return node;
+}
+
+function appendZoneElements(element, zoneName, nodes, used, zones) {
+  if (!element) return;
+  const keys = (zones && Array.isArray(zones[zoneName])) ? zones[zoneName] : [];
+  for (const key of keys) {
+    const node = takeNode(key, nodes, used);
+    if (node) element.appendChild(node);
+  }
+}
+
+function mergeZones(baseZones, overrideZones) {
+  const result = {};
+  const names = new Set();
+  if (baseZones && typeof baseZones === 'object') {
+    Object.keys(baseZones).forEach(name => names.add(name));
+  }
+  if (overrideZones && typeof overrideZones === 'object') {
+    Object.keys(overrideZones).forEach(name => names.add(name));
+  }
+  for (const name of names) {
+    if (overrideZones && Object.prototype.hasOwnProperty.call(overrideZones, name)) {
+      result[name] = Array.isArray(overrideZones[name]) ? [...overrideZones[name]] : [];
+    } else if (baseZones && Object.prototype.hasOwnProperty.call(baseZones, name)) {
+      result[name] = Array.isArray(baseZones[name]) ? [...baseZones[name]] : [];
+    } else {
+      result[name] = [];
+    }
+  }
+  return result;
+}
+
+function setBodyLayoutState(presetName, additionalClasses) {
+  const body = document.body;
+  if (!body) return;
+  const classesToRemove = Array.isArray(activeBodyClasses) ? activeBodyClasses : [];
+  classesToRemove.forEach(cls => body.classList.remove(cls));
+  const classes = [];
+  if (presetName) {
+    classes.push(`layout-${presetName}`);
+    body.setAttribute('data-layout', presetName);
+    body.setAttribute('data-layout-preset', presetName);
+  } else {
+    body.removeAttribute('data-layout');
+    body.removeAttribute('data-layout-preset');
+  }
+  if (Array.isArray(additionalClasses)) {
+    additionalClasses.forEach(cls => {
+      if (!cls) return;
+      if (!classes.includes(cls)) classes.push(cls);
+    });
+  }
+  classes.forEach(cls => body.classList.add(cls));
+  activeBodyClasses = classes;
+}
+
+function setRootLayoutState(root, presetName, classes) {
+  if (!root) return;
+  const prev = Array.isArray(activeRootClasses) ? activeRootClasses : [];
+  prev.forEach(cls => root.classList.remove(cls));
+  const applied = new Set();
+  root.classList.add('layout-host');
+  if (presetName) {
+    const presetClass = `layout-host-${presetName}`;
+    root.classList.add(presetClass);
+    applied.add(presetClass);
+    root.setAttribute('data-layout-preset', presetName);
+  } else {
+    root.removeAttribute('data-layout-preset');
+  }
+  if (Array.isArray(classes)) {
+    classes.forEach(cls => {
+      if (!cls) return;
+      root.classList.add(cls);
+      applied.add(cls);
+    });
+  }
+  activeRootClasses = Array.from(applied);
+}
+
+function normalizeLayoutConfig(input) {
+  if (typeof input === 'string') {
+    return {
+      preset: sanitizePresetName(input),
+      zones: {},
+      bodyClasses: [],
+      rootClasses: [],
+      fallbackZone: 'sidebar',
+    };
+  }
+  const obj = (input && typeof input === 'object') ? input : {};
+  const presetName = sanitizePresetName(obj.preset);
+  const zones = normalizeZoneObject(obj.zones);
+  const bodyClasses = classListFrom(obj.bodyClass || obj.bodyClasses);
+  const rootClasses = classListFrom(obj.rootClass || obj.rootClasses);
+  const fallbackZone = sanitizeZoneName(obj.fallbackZone) || 'sidebar';
+  return { preset: presetName, zones, bodyClasses, rootClasses, fallbackZone };
+}
+
+export function registerLayoutComponent(name, resolver) {
+  const key = sanitizeComponentKey(name);
+  if (!key || typeof resolver !== 'function') return;
+  COMPONENT_REGISTRY.set(key, resolver);
+}
+
+export function registerLayoutPreset(name, preset) {
+  const presetName = sanitizePresetName(name);
+  if (!presetName || !preset || typeof preset !== 'object') return;
+  const build = typeof preset.build === 'function' ? preset.build : null;
+  if (!build) return;
+  const zones = normalizeZoneObject(preset.zones || {});
+  const fallbackZone = sanitizeZoneName(preset.fallbackZone) || 'sidebar';
+  const bodyClasses = classListFrom(preset.bodyClass || preset.bodyClasses);
+  const rootClasses = classListFrom(preset.rootClass || preset.rootClasses);
+  LAYOUT_PRESETS.set(presetName, {
+    name: presetName,
+    build,
+    zones,
+    fallbackZone,
+    bodyClasses,
+    rootClasses,
+  });
+}
+
+function getPreset(name) {
+  return LAYOUT_PRESETS.get(sanitizePresetName(name));
+}
+
+export function getRegisteredLayoutPresets() {
+  return Array.from(LAYOUT_PRESETS.keys());
+}
+
+export function getCurrentLayoutPreset() {
+  return currentPresetName;
+}
+
+export function applyLayoutConfig(config) {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return { preset: null };
+  const root = ensureLayoutRoot();
+  if (!root) return { preset: null };
+  const normalized = normalizeLayoutConfig(config);
+  const preset = getPreset(normalized.preset) || getPreset(DEFAULT_PRESET);
+  if (!preset) return { preset: null };
+  const nodes = collectComponents();
+  const used = new Set();
+  const zones = mergeZones(preset.zones, normalized.zones);
+
+  // Clear existing layout content but retain root element and tracked classes
+  while (root.firstChild) root.removeChild(root.firstChild);
+
+  const appendZone = (element, zoneName) => appendZoneElements(element, zoneName, nodes, used, zones);
+  const context = {
+    root,
+    zones,
+    config: normalized,
+    preset: preset.name,
+    appendZone,
+    takeNode: (key) => takeNode(key, nodes, used),
+    getNode: (key) => (nodes && Object.prototype.hasOwnProperty.call(nodes, key) ? nodes[key] : null),
+  };
+
+  let zoneElements = {};
+  try {
+    const built = preset.build(context) || {};
+    if (built && typeof built === 'object') {
+      for (const [zoneName, element] of Object.entries(built)) {
+        if (!zoneName || !isElement(element)) continue;
+        zoneElements[zoneName] = element;
+      }
+    }
+  } catch (err) {
+    console.error('[layout] Failed to build layout preset:', preset.name, err);
+  }
+
+  const fallbackZoneName = sanitizeZoneName(normalized.fallbackZone) || preset.fallbackZone || 'sidebar';
+  const fallbackTarget = zoneElements[fallbackZoneName] || zoneElements.sidebar || zoneElements.content || root;
+  if (fallbackTarget) {
+    for (const [key, node] of Object.entries(nodes)) {
+      if (!isElement(node) || used.has(key)) continue;
+      const taken = takeNode(key, nodes, used);
+      if (taken) fallbackTarget.appendChild(taken);
+    }
+  }
+
+  currentPresetName = preset.name;
+  const bodyClasses = [...new Set([...(preset.bodyClasses || []), ...(normalized.bodyClasses || [])])];
+  setBodyLayoutState(currentPresetName, bodyClasses);
+  const rootClasses = [...new Set([...(preset.rootClasses || []), ...(normalized.rootClasses || [])])];
+  setRootLayoutState(root, currentPresetName, rootClasses);
+
+  return {
+    preset: currentPresetName,
+    zones,
+    fallbackZone: fallbackZoneName,
+  };
+}
+
+// --- Default component registry ---
+registerLayoutComponent('map', () => document.getElementById('mapview'));
+registerLayoutComponent('main', () => document.getElementById('mainview'));
+registerLayoutComponent('search', () => document.getElementById('searchbox'));
+registerLayoutComponent('site', () => document.getElementById('sitecard'));
+registerLayoutComponent('tags', () => document.getElementById('tagview'));
+registerLayoutComponent('toc', () => document.getElementById('tocview'));
+registerLayoutComponent('tools', () => document.getElementById('tools'));
+
+// --- Built-in presets ---
+registerLayoutPreset('sidebar-right', {
+  zones: {
+    content: ['map', 'main'],
+    sidebar: ['search', 'site', 'tags', 'tools', 'toc'],
+  },
+  fallbackZone: 'sidebar',
+  build({ root, appendZone }) {
+    const container = document.createElement('div');
+    container.className = 'container layout-two-column layout-sidebar-right';
+
+    const content = document.createElement('div');
+    content.className = 'content';
+    appendZone(content, 'content');
+
+    const sidebar = document.createElement('aside');
+    sidebar.className = 'sidebar';
+    appendZone(sidebar, 'sidebar');
+
+    container.appendChild(content);
+    container.appendChild(sidebar);
+    root.appendChild(container);
+
+    return { container, content, sidebar };
+  },
+});
+
+registerLayoutPreset('sidebar-left', {
+  zones: {
+    content: ['map', 'main'],
+    sidebar: ['search', 'site', 'tags', 'tools', 'toc'],
+  },
+  fallbackZone: 'sidebar',
+  build({ root, appendZone }) {
+    const container = document.createElement('div');
+    container.className = 'container layout-two-column layout-sidebar-left';
+
+    const sidebar = document.createElement('aside');
+    sidebar.className = 'sidebar';
+    appendZone(sidebar, 'sidebar');
+
+    const content = document.createElement('div');
+    content.className = 'content';
+    appendZone(content, 'content');
+
+    container.appendChild(sidebar);
+    container.appendChild(content);
+    root.appendChild(container);
+
+    return { container, content, sidebar };
+  },
+});
+
+registerLayoutPreset('single-column', {
+  zones: {
+    content: ['map', 'main'],
+    sidebar: ['search', 'site', 'tags', 'tools', 'toc'],
+  },
+  fallbackZone: 'content',
+  build({ root, appendZone }) {
+    const container = document.createElement('div');
+    container.className = 'container layout-single-column';
+
+    const content = document.createElement('div');
+    content.className = 'content';
+    appendZone(content, 'content');
+
+    const sidebar = document.createElement('aside');
+    sidebar.className = 'sidebar sidebar-stack';
+    appendZone(sidebar, 'sidebar');
+
+    container.appendChild(content);
+    container.appendChild(sidebar);
+    root.appendChild(container);
+
+    return { container, content, sidebar };
+  },
+});
+
+export default {
+  applyLayoutConfig,
+  registerLayoutPreset,
+  registerLayoutComponent,
+  getRegisteredLayoutPresets,
+  getCurrentLayoutPreset,
+};

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -142,11 +142,20 @@ async function loadLayoutModules(pack, layoutConfig) {
     const safePath = sanitizeResourcePath(path);
     if (!safePath) continue;
     const url = buildThemeResourceUrl(pack, safePath);
+    const base = (typeof document !== 'undefined' && document.baseURI) ? document.baseURI : (typeof window !== 'undefined' ? window.location.href : '');
+    let importUrl = url;
+    if (base) {
+      try {
+        importUrl = new URL(url, base).href;
+      } catch (_) {
+        importUrl = url;
+      }
+    }
     try {
-      const mod = await import(url);
+      const mod = await import(/* @vite-ignore */ importUrl);
       if (mod) modules.push(mod);
     } catch (err) {
-      console.error(`[theme] Failed to load layout module ${url}:`, err);
+      console.error(`[theme] Failed to load layout module ${importUrl}:`, err);
     }
   }
   return modules;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -66,6 +66,12 @@ body {
   max-width: 100vw;
   box-sizing: border-box;
 }
+
+[data-layout-root] {
+  flex: 1 0 auto;
+  width: 100%;
+  display: block;
+}
 html { 
   scroll-behavior: smooth; 
   /* Prevent horizontal scroll on mobile */
@@ -1123,14 +1129,48 @@ ul.collapsed, li > ul.collapsed { display: none; }
 }
 
 .container {
-  display: grid;
-  grid-template-columns: 45rem 18.75rem; /* Fixed column widths to prevent collapse */
-  justify-content: center; /* Center align */
+  width: 100%;
   margin: 0 auto;
   max-width: 75rem;
-  gap: 1.5rem;
   padding: 0 1.25rem;
-  /* Prevent grid container distortion when content changes */
+  box-sizing: border-box;
+}
+
+.container.layout-two-column {
+  display: grid;
+  grid-template-columns: 45rem 18.75rem; /* Fixed column widths to prevent collapse */
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+.container.layout-two-column.layout-sidebar-left {
+  grid-template-columns: 18.75rem 45rem;
+}
+
+.container.layout-two-column .content,
+.container.layout-two-column .sidebar {
+  min-width: 0;
+}
+
+.container.layout-single-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-width: min(60rem, 92vw);
+}
+
+.container.layout-single-column .content > * {
+  width: 100%;
+}
+
+.container.layout-single-column .sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.container.layout-single-column .sidebar > * {
+  width: 100%;
 }
 
 /* Compact tabs mode: when nav collapses due to small width */
@@ -1272,7 +1312,7 @@ ul.collapsed, li > ul.collapsed { display: none; }
 
 /* Large screens (>1400px) */
 @media (min-width: 87.5rem) {
-  .container {
+  .container.layout-two-column {
     max-width: 87.5rem;
     gap: 2rem;
     grid-template-columns: 50rem 20rem; /* Wider layout on large screens */
@@ -1287,7 +1327,7 @@ ul.collapsed, li > ul.collapsed { display: none; }
 
 /* Tablet landscape (769px - 1024px) */
 @media (max-width: 64rem) and (min-width: 48.0625rem) {
-  .container {
+  .container.layout-two-column {
     max-width: 100%;
     padding: 0 1rem;
     gap: 1.25rem;
@@ -1303,7 +1343,7 @@ ul.collapsed, li > ul.collapsed { display: none; }
 
 /* Tablet devices (769px - 1024px) */
 @media (max-width: 64rem) and (min-width: 48.0625rem) {
-  .container {
+  .container.layout-two-column {
     max-width: 100%;
     padding: 0 1rem;
     gap: 1.25rem;
@@ -1329,7 +1369,7 @@ ul.collapsed, li > ul.collapsed { display: none; }
   }
   
   .container {
-    display: flex !important; /* Force flex layout on mobile */
+    display: flex; /* Force vertical stacking on mobile */
     flex-direction: column;
     margin: 0;
     padding: 0.5rem; /* Reduce container padding */
@@ -1339,6 +1379,10 @@ ul.collapsed, li > ul.collapsed { display: none; }
     min-width: 0; /* Allow minimum shrink */
     overflow-x: hidden; /* Prevent horizontal overflow */
     box-sizing: border-box;
+  }
+  .container.layout-two-column,
+  .container.layout-single-column {
+    gap: 1rem;
   }
 
   .content {

--- a/assets/themes/aurora/layout.js
+++ b/assets/themes/aurora/layout.js
@@ -1,0 +1,64 @@
+const HERO_EMPTY_CLASS = 'aurora-hero-empty';
+
+export function registerLayouts({ registerLayoutPreset }) {
+  registerLayoutPreset('aurora-split', {
+    zones: {
+      hero: ['site'],
+      content: ['map', 'main'],
+      aside: ['search', 'tags', 'tools', 'toc']
+    },
+    fallbackZone: 'aside',
+    bodyClasses: ['layout-aurora'],
+    rootClasses: ['aurora-root'],
+    build({ root, appendZone }) {
+      const shell = document.createElement('div');
+      shell.className = 'aurora-shell';
+
+      const hero = document.createElement('header');
+      hero.className = 'aurora-hero';
+      appendZone(hero, 'hero');
+
+      const main = document.createElement('div');
+      main.className = 'aurora-body';
+
+      const content = document.createElement('main');
+      content.className = 'aurora-content';
+      appendZone(content, 'content');
+
+      const aside = document.createElement('aside');
+      aside.className = 'aurora-aside';
+      appendZone(aside, 'aside');
+
+      main.appendChild(content);
+      main.appendChild(aside);
+
+      shell.appendChild(hero);
+      shell.appendChild(main);
+
+      root.appendChild(shell);
+
+      return {
+        container: shell,
+        hero,
+        content,
+        aside
+      };
+    }
+  });
+}
+
+export function afterLayout({ root }) {
+  if (!root) return;
+  const hero = root.querySelector('.aurora-hero');
+  if (hero) {
+    if (!hero.children.length) {
+      hero.classList.add(HERO_EMPTY_CLASS);
+    } else {
+      hero.classList.remove(HERO_EMPTY_CLASS);
+    }
+  }
+}
+
+export function cleanup() {
+  // Nothing persistent to clean right now, but keep hook for parity with other packs
+}

--- a/assets/themes/aurora/manifest.json
+++ b/assets/themes/aurora/manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "Aurora Glass",
+  "version": 1,
+  "description": "Glassmorphism layout with aurora gradients and a hero spotlight for the site card.",
+  "assets": {
+    "styles": [
+      {
+        "href": "theme.css",
+        "rel": "stylesheet"
+      }
+    ]
+  },
+  "layout": {
+    "preset": "aurora-split",
+    "module": "layout.js",
+    "fallbackZone": "aside",
+    "zones": {
+      "hero": ["site"],
+      "content": ["map", "main"],
+      "aside": ["search", "tags", "tools", "toc"]
+    }
+  }
+}

--- a/assets/themes/aurora/theme.css
+++ b/assets/themes/aurora/theme.css
@@ -1,0 +1,433 @@
+/* Aurora Glass theme */
+
+body.layout-aurora {
+  --bg: #e8f1ff;
+  --text: #11253a;
+  --muted: #4d6178;
+  --primary: #5b4bff;
+  --primary-hover: #4035d8;
+  --card: rgba(255, 255, 255, 0.82);
+  --border: rgba(255, 255, 255, 0.45);
+  --code-bg: rgba(16, 26, 44, 0.75);
+  --code-text: #f1f5ff;
+  --hr: rgba(17, 37, 58, 0.18);
+  --shadow: 0 1.75rem 4rem rgba(38, 57, 111, 0.18);
+  background:
+    radial-gradient(40rem 40rem at 20% -5%, rgba(91, 75, 255, 0.25), transparent 65%),
+    radial-gradient(35rem 35rem at 75% 0%, rgba(33, 202, 255, 0.2), transparent 70%),
+    linear-gradient(180deg, rgba(234, 244, 255, 0.7) 0%, rgba(224, 238, 255, 0.85) 35%, rgba(214, 238, 255, 1) 100%);
+  color: var(--text);
+  font-family: "Poppins", "Segoe UI", Roboto, "Noto Sans", "PingFang SC", sans-serif;
+}
+
+html[data-theme="dark"] body.layout-aurora {
+  --bg: #050c1f;
+  --text: #e7f0ff;
+  --muted: #a1b8d9;
+  --primary: #8fb8ff;
+  --primary-hover: #c5ddff;
+  --card: rgba(12, 22, 46, 0.72);
+  --border: rgba(143, 184, 255, 0.22);
+  --code-bg: rgba(9, 17, 35, 0.85);
+  --code-text: #f6fbff;
+  --hr: rgba(143, 184, 255, 0.18);
+  --shadow: 0 2rem 4.5rem rgba(0, 12, 48, 0.55);
+  background:
+    radial-gradient(45rem 45rem at 20% -10%, rgba(90, 78, 255, 0.32), transparent 68%),
+    radial-gradient(40rem 40rem at 85% 5%, rgba(33, 202, 255, 0.25), transparent 70%),
+    linear-gradient(185deg, rgba(3, 11, 31, 0.95) 0%, rgba(3, 18, 45, 0.97) 45%, rgba(4, 20, 48, 1) 100%);
+}
+
+body.layout-aurora::before,
+body.layout-aurora::after {
+  content: "";
+  position: fixed;
+  inset: 10% auto auto 55%;
+  width: 30rem;
+  height: 30rem;
+  pointer-events: none;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.22), transparent 60%);
+  filter: blur(80px);
+  opacity: 0.6;
+  transform: translateZ(0);
+  z-index: -1;
+}
+
+body.layout-aurora::after {
+  inset: auto auto -5% 15%;
+  width: 26rem;
+  height: 26rem;
+  background: radial-gradient(circle, rgba(123, 239, 255, 0.28), transparent 65%);
+  filter: blur(110px);
+  opacity: 0.55;
+}
+
+body.layout-aurora .site-footer {
+  background: rgba(10, 26, 49, 0.1);
+  border-top: 1px solid color-mix(in srgb, var(--primary) 18%, transparent);
+  backdrop-filter: blur(18px);
+}
+
+.aurora-root {
+  position: relative;
+}
+
+.aurora-shell {
+  position: relative;
+  width: min(74rem, 100%);
+  margin: 0 auto;
+  padding: clamp(3rem, 6vw, 4.5rem) clamp(1.4rem, 4vw, 2.25rem) clamp(3.5rem, 7vw, 5rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 5vw, 3rem);
+}
+
+.aurora-shell::before,
+.aurora-shell::after {
+  content: "";
+  position: absolute;
+  inset: -15% auto auto -20%;
+  width: clamp(22rem, 40vw, 32rem);
+  height: clamp(22rem, 40vw, 32rem);
+  background: radial-gradient(circle at 35% 35%, rgba(255, 255, 255, 0.5), transparent 60%);
+  filter: blur(120px);
+  opacity: 0.65;
+  z-index: -1;
+}
+
+.aurora-shell::after {
+  inset: auto -10% -20% auto;
+  background: radial-gradient(circle at 65% 65%, rgba(135, 206, 255, 0.4), transparent 65%);
+  opacity: 0.55;
+}
+
+.aurora-hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: clamp(1.4rem, 3vw, 2rem);
+  padding: clamp(2.2rem, 4vw, 3rem);
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(12rem, 18rem);
+  align-items: center;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+  background: linear-gradient(135deg, rgba(91, 75, 255, 0.86), rgba(56, 204, 255, 0.72));
+  color: #fefeff;
+  box-shadow: 0 2.5rem 5rem rgba(61, 83, 190, 0.35);
+}
+
+.aurora-hero::before {
+  content: "";
+  position: absolute;
+  inset: -40% 40% auto -30%;
+  width: clamp(25rem, 45vw, 35rem);
+  height: clamp(25rem, 45vw, 35rem);
+  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.35), transparent 60%);
+  filter: blur(80px);
+  opacity: 0.75;
+  transform: rotate(8deg);
+  z-index: 0;
+}
+
+.aurora-hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.aurora-hero-empty {
+  display: none;
+}
+
+.layout-aurora .aurora-hero .box,
+.layout-aurora .aurora-hero #sitecard {
+  background: transparent;
+  box-shadow: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: inherit;
+}
+
+.layout-aurora #sitecard {
+  display: grid;
+  grid-template-columns: clamp(4.25rem, 10vw, 5.25rem) minmax(0, 1fr);
+  gap: 1.25rem;
+  align-items: center;
+}
+
+.layout-aurora #sitecard .avatar {
+  width: clamp(4rem, 10vw, 5rem);
+  height: clamp(4rem, 10vw, 5rem);
+  border-radius: 1.5rem;
+  box-shadow: inset 0 0 0 0.125rem rgba(255, 255, 255, 0.6);
+}
+
+.layout-aurora #sitecard .site-title {
+  font-size: clamp(1.8rem, 4vw, 2.35rem);
+  font-weight: 700;
+  line-height: 1.2;
+  color: inherit;
+}
+
+.layout-aurora #sitecard .site-subtitle {
+  font-size: clamp(1rem, 2.4vw, 1.15rem);
+  margin-top: 0.35rem;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.layout-aurora #sitecard .site-hr {
+  display: none;
+}
+
+.layout-aurora #sitecard .social-links {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.layout-aurora #sitecard .social-links a {
+  color: rgba(255, 255, 255, 0.9);
+  padding: 0.45rem 0.85rem;
+  background: rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+  backdrop-filter: blur(10px);
+  transition: background 0.25s ease, transform 0.25s ease;
+}
+
+.layout-aurora #sitecard .social-links a:hover {
+  background: rgba(255, 255, 255, 0.28);
+  transform: translateY(-2px);
+}
+
+.layout-aurora #sitecard .social-links li {
+  list-style: none;
+  margin: 0;
+}
+
+.aurora-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(16rem, 22rem);
+  gap: clamp(1.75rem, 4vw, 2.75rem);
+}
+
+.aurora-content,
+.aurora-aside {
+  backdrop-filter: blur(20px);
+  border-radius: clamp(1.2rem, 2.5vw, 1.65rem);
+  background: color-mix(in srgb, var(--card) 90%, transparent);
+  border: 1px solid color-mix(in srgb, var(--primary) 20%, var(--border));
+  box-shadow: 0 1.5rem 3rem rgba(30, 58, 138, 0.15);
+  padding: clamp(1.5rem, 3.5vw, 2.25rem);
+}
+
+.layout-aurora .aurora-content .box,
+.layout-aurora .aurora-content #mapview,
+.layout-aurora .aurora-content #mainview {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  margin: 0;
+}
+
+.layout-aurora .aurora-content #mapview {
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--primary) 16%, transparent);
+  margin-bottom: 1.25rem;
+}
+
+.layout-aurora .aurora-content #tabsNav {
+  border-radius: 999px;
+  padding: 0.35rem;
+  background: rgba(255, 255, 255, 0.28);
+  backdrop-filter: blur(14px);
+  gap: 0.35rem;
+}
+
+.layout-aurora .aurora-content .tab {
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.55);
+  box-shadow: none;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+html[data-theme="dark"] .layout-aurora .aurora-content .tab {
+  background: rgba(12, 22, 46, 0.75);
+  color: rgba(231, 240, 255, 0.92);
+}
+
+.layout-aurora .aurora-content .tab:hover,
+.layout-aurora .aurora-content .tab.active {
+  background: rgba(91, 75, 255, 0.2);
+  transform: translateY(-1px);
+}
+
+.layout-aurora .aurora-content #mainview {
+  margin-top: 1.5rem;
+}
+
+.layout-aurora .aurora-content #mainview img {
+  box-shadow: 0 1.25rem 2.5rem rgba(30, 58, 138, 0.2);
+  border-radius: 1.25rem;
+}
+
+.layout-aurora .aurora-aside .box {
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid color-mix(in srgb, var(--primary) 25%, transparent);
+  box-shadow: none;
+  padding: clamp(1.1rem, 2.5vw, 1.4rem);
+}
+
+html[data-theme="dark"] .layout-aurora .aurora-aside .box {
+  background: rgba(9, 18, 36, 0.65);
+}
+
+.layout-aurora #searchbox {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.layout-aurora #searchInput {
+  width: 100%;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  padding: 0.65rem 1rem;
+  color: var(--text);
+  font-size: 0.95rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+html[data-theme="dark"] .layout-aurora #searchInput {
+  background: rgba(16, 26, 44, 0.85);
+  border-color: rgba(143, 184, 255, 0.4);
+}
+
+.layout-aurora #searchInput:focus {
+  outline: none;
+  border-color: rgba(91, 75, 255, 0.6);
+  box-shadow: 0 0 0 0.25rem rgba(91, 75, 255, 0.12);
+}
+
+.layout-aurora #tagview .tag-cloud,
+.layout-aurora #tagview ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.layout-aurora #tagview .tag,
+.layout-aurora #tagview li,
+.layout-aurora #tagview a {
+  list-style: none;
+  background: rgba(255, 255, 255, 0.22);
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+html[data-theme="dark"] .layout-aurora #tagview .tag,
+html[data-theme="dark"] .layout-aurora #tagview li,
+html[data-theme="dark"] .layout-aurora #tagview a {
+  background: rgba(12, 22, 46, 0.72);
+  color: rgba(231, 240, 255, 0.92);
+}
+
+.layout-aurora #tools {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 1.25rem;
+  border: 1px solid color-mix(in srgb, var(--primary) 15%, transparent);
+  padding: 1.25rem;
+}
+
+html[data-theme="dark"] .layout-aurora #tools {
+  background: rgba(9, 18, 36, 0.55);
+}
+
+.layout-aurora #tools .btn,
+.layout-aurora #tools select {
+  border-radius: 0.75rem;
+  border-color: rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.65);
+}
+
+html[data-theme="dark"] .layout-aurora #tools .btn,
+html[data-theme="dark"] .layout-aurora #tools select {
+  background: rgba(16, 26, 44, 0.85);
+  border-color: rgba(143, 184, 255, 0.35);
+  color: rgba(231, 240, 255, 0.9);
+}
+
+.layout-aurora #tools .btn:hover,
+.layout-aurora #tools select:hover {
+  background: color-mix(in srgb, var(--primary) 22%, rgba(255, 255, 255, 0.5));
+  border-color: color-mix(in srgb, var(--primary) 40%, var(--border));
+}
+
+.layout-aurora .sidebar .box + .box {
+  margin-top: 1rem;
+}
+
+.layout-aurora #tocview {
+  max-height: clamp(20rem, 55vh, 28rem);
+  overflow: auto;
+  scrollbar-width: thin;
+}
+
+.layout-aurora #tocview::-webkit-scrollbar {
+  width: 0.5rem;
+}
+
+.layout-aurora #tocview::-webkit-scrollbar-thumb {
+  background: rgba(91, 75, 255, 0.35);
+  border-radius: 999px;
+}
+
+@media (max-width: 1080px) {
+  .aurora-hero {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+
+  .layout-aurora #sitecard {
+    justify-items: center;
+    grid-template-columns: 1fr;
+  }
+
+  .layout-aurora #sitecard .social-links {
+    justify-content: center;
+  }
+
+  .aurora-body {
+    grid-template-columns: 1fr;
+  }
+
+  .aurora-aside {
+    order: 3;
+  }
+}
+
+@media (max-width: 680px) {
+  .aurora-shell {
+    padding: 2.5rem 1.25rem 3.5rem;
+  }
+
+  .aurora-hero {
+    padding: 2rem 1.5rem;
+  }
+
+  body.layout-aurora {
+    padding: 1.75rem 0 2rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .layout-aurora * {
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
+  }
+}

--- a/assets/themes/github/manifest.json
+++ b/assets/themes/github/manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "GitHub",
+  "version": 1,
+  "assets": {
+    "styles": [
+      {
+        "href": "theme.css",
+        "rel": "stylesheet"
+      }
+    ]
+  },
+  "layout": {
+    "preset": "sidebar-right",
+    "zones": {
+      "content": ["map", "main"],
+      "sidebar": ["search", "site", "tags", "tools", "toc"]
+    }
+  }
+}

--- a/assets/themes/native/manifest.json
+++ b/assets/themes/native/manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "Native",
+  "version": 1,
+  "assets": {
+    "styles": [
+      {
+        "href": "theme.css",
+        "rel": "stylesheet"
+      }
+    ]
+  },
+  "layout": {
+    "preset": "sidebar-right",
+    "zones": {
+      "content": ["map", "main"],
+      "sidebar": ["search", "site", "tags", "tools", "toc"]
+    }
+  }
+}

--- a/assets/themes/packs.json
+++ b/assets/themes/packs.json
@@ -1,4 +1,5 @@
 [
   { "value": "native", "label": "Native" },
-  { "value": "github", "label": "GitHub" }
+  { "value": "github", "label": "GitHub" },
+  { "value": "aurora", "label": "Aurora Glass" }
 ]

--- a/index.html
+++ b/index.html
@@ -21,44 +21,44 @@
 </head>
 
 <body>
-  <div class="container">
-    <div class="content">
+  <main id="layoutRoot" data-layout-root>
+    <div class="container layout-two-column">
+      <div class="content">
+        <!-- Navigator Bar -->
+        <div class="box flex-split" id="mapview">
+          <nav class="tabs" id="tabsNav" aria-label="Sections"></nav>
+        </div>
 
-      <!-- Navigator Bar -->
-      <div class="box flex-split" id="mapview">
-        <nav class="tabs" id="tabsNav" aria-label="Sections"></nav>
+        <!-- Main content -->
+        <div class="box" id="mainview">
+        </div>
       </div>
+      <aside class="sidebar">
+        <!-- Search -->
+        <div class="box" id="searchbox">
+          <input id="searchInput" type="search">
+        </div>
 
-      <!-- Main content -->
-      <div class="box" id="mainview">
-      </div>
+        <!-- Site Card -->
+        <div class="box site-card" id="sitecard">
+          <img class="avatar" alt="avatar" loading="lazy" decoding="async">
+          <h3 class="site-title"></h3>
+          <p class="site-subtitle"></p>
+          <hr class="site-hr">
+          <ul class="social-links">
+          </ul>
+        </div>
+
+        <!-- Tags Filter -->
+        <div class="box" id="tagview"></div>
+
+        <!-- Tools box is rendered by JS (theme.js) -->
+
+        <!-- Page of Content for Posts -->
+        <div class="box" id="tocview"></div>
+      </aside>
     </div>
-    <div class="sidebar">
-
-      <!-- Search -->
-      <div class="box" id="searchbox">
-        <input id="searchInput" type="search">
-      </div>
-
-      <!-- Site Card -->
-      <div class="box site-card">
-        <img class="avatar" alt="avatar" loading="lazy" decoding="async">
-        <h3 class="site-title"></h3>
-        <p class="site-subtitle"></p>
-        <hr class="site-hr">
-        <ul class="social-links">
-        </ul>
-      </div>
-
-  <!-- Tags Filter -->
-  <div class="box" id="tagview"></div>
-
-      <!-- Tools box is rendered by JS (theme.js) -->
-
-      <!-- Page of Content for Posts -->
-      <div class="box" id="tocview"></div>
-    </div>
-  </div>
+  </main>
 
   <!-- Site Footer -->
   <footer class="site-footer" role="contentinfo">

--- a/site.yaml
+++ b/site.yaml
@@ -41,7 +41,7 @@ contentRoot: wwwroot      # Root directory for content files
 
 # Theme override configurations
 themeMode: user
-themePack: native
+themePack: aurora
 themeOverride: true
 # themeLayout: sidebar-right
 # themeLayout:

--- a/site.yaml
+++ b/site.yaml
@@ -43,6 +43,13 @@ contentRoot: wwwroot      # Root directory for content files
 themeMode: user
 themePack: native
 themeOverride: true
+# themeLayout: sidebar-right
+# themeLayout:
+#   preset: single-column
+#   zones:
+#     sidebar:
+#       - search
+#       - site
 
 # Repository information used for internal linking of "report issue" etc.
 # repo:


### PR DESCRIPTION
## Summary
- load theme pack manifests to manage styles, optional modules, and layout overrides
- add a reusable layout manager with built-in presets and component registry
- update markup, styles, sample manifests, and docs to support layout-aware themes

## Testing
- Not run (static project)


------
https://chatgpt.com/codex/tasks/task_e_68d8278e8e4083288430e3603fbc8c54