### PR TITLE
Add manifest-driven theme system

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@
 
 - ⚡ **Zero Build** – no bundlers, compilers, or environments required.  
 - 📝 **Markdown-first** – write posts like plain notes.  
-- 🌐 **GitHub Pages Ready** – simply push and host.  
-- 📊 **Performance Friendly** – passes [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) audits with great scores (see hero image above).  
-- 🎨 **Configurable** – customize your site using a simple `site.yaml`.  
+- 🌐 **GitHub Pages Ready** – simply push and host.
+- 📊 **Performance Friendly** – passes [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) audits with great scores (see hero image above).
+- 🎨 **Configurable** – customize your site using a simple `site.yaml`.
+- 🧩 **Manifest-driven Themes** – swap full theme packs, including layout and design tokens, without touching HTML.
 
 ## 🌍 Built with Nanosite
 

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,20 +1,464 @@
+
 import { t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage } from './i18n.js';
 
 const PACK_LINK_ID = 'theme-pack';
 
-// Restrict theme pack names to safe slug format and default to 'native'.
 function sanitizePack(input) {
   const s = String(input || '').toLowerCase().trim();
   const clean = s.replace(/[^a-z0-9_-]/g, '');
   return clean || 'native';
 }
 
-export function loadThemePack(name) {
+function sanitizeModuleKey(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function toClassArray(value) {
+  if (!value) return [];
+  const list = Array.isArray(value) ? value : String(value).split(/\s+/);
+  return list.map(v => String(v || '').trim()).filter(Boolean);
+}
+
+const DEFAULT_AREAS = [
+  { name: 'main', classes: ['content'], modules: ['tabs', 'main'] },
+  { name: 'sidebar', classes: ['sidebar'], modules: ['search', 'site-card', 'tags', 'tools', 'toc'] }
+];
+
+const SINGLE_COLUMN_AREAS = [
+  { name: 'main', classes: ['content'], modules: ['tabs', 'main', 'tags'] },
+  { name: 'support', classes: ['sidebar'], modules: ['search', 'site-card', 'tools', 'toc'] }
+];
+
+const BASE_MANIFEST = {
+  version: 1,
+  name: 'native',
+  label: 'Native Classic',
+  description: 'Classic two-column layout with a right sidebar.',
+  variables: {
+    '--ns-shell-gap': '1.5rem',
+    '--ns-shell-max-width': 'min(75rem, calc(100% - 2.5rem))'
+  },
+  shellClasses: ['container'],
+  bodyClasses: [],
+  layoutClasses: [],
+  layout: {
+    preset: 'two-column',
+    sidebarPosition: 'right',
+    variables: {
+      '--ns-sidebar-width': 'min(20rem, 100%)'
+    },
+    areas: DEFAULT_AREAS.map(area => ({
+      name: area.name,
+      classes: [...area.classes],
+      modules: [...area.modules],
+      as: 'div'
+    }))
+  }
+};
+
+const MODULE_REGISTRY = new Map();
+let modulesRegistered = false;
+const manifestCache = new Map();
+const appliedRootVars = new Set();
+const appliedShellVars = new Set();
+const appliedBodyClasses = new Set();
+const appliedShellClasses = new Set();
+let currentLayoutKey = '';
+let currentPackName = '';
+let currentLayoutOverride = null;
+
+const DEFAULT_THEME_MANIFEST = normalizeManifest(BASE_MANIFEST, 'native');
+
+function formatLabelFromPack(pack) {
+  const slug = String(pack || '').replace(/[_-]+/g, ' ').trim();
+  if (!slug) return 'Theme';
+  return slug.replace(/\b\w/g, ch => ch.toUpperCase());
+}
+
+function cloneArea(area) {
+  return {
+    name: area.name,
+    classes: Array.isArray(area.classes) ? [...area.classes] : toClassArray(area.classes),
+    modules: Array.isArray(area.modules) ? [...area.modules] : [],
+    as: area.as || 'div'
+  };
+}
+
+function normalizeArea(area) {
+  if (!area || typeof area !== 'object') return null;
+  const modules = Array.isArray(area.modules)
+    ? area.modules.map(sanitizeModuleKey).filter(Boolean)
+    : [];
+  const classes = toClassArray(area.classes || area.class);
+  const tag = (typeof area.as === 'string' && area.as.trim()) ? area.as.trim() : 'div';
+  const nameRaw = area.name != null ? String(area.name).trim() : '';
+  const name = nameRaw ? nameRaw.toLowerCase() : '';
+  return {
+    name,
+    classes,
+    modules,
+    as: tag
+  };
+}
+
+function mergeLayoutSpec(base, override) {
+  const baseLayout = base && typeof base === 'object' ? base : {};
+  const src = override && typeof override === 'object' ? override : {};
+  const preset = src.preset || baseLayout.preset || 'two-column';
+  const mergedClasses = toClassArray(src.classes || src.class);
+  const result = {
+    preset,
+    sidebarPosition: src.sidebarPosition || baseLayout.sidebarPosition || 'right',
+    classes: mergedClasses.length ? mergedClasses : toClassArray(baseLayout.classes),
+    variables: { ...(baseLayout.variables || {}) },
+    hiddenModules: Array.isArray(src.hiddenModules)
+      ? src.hiddenModules.map(sanitizeModuleKey).filter(Boolean)
+      : Array.isArray(baseLayout.hiddenModules)
+        ? baseLayout.hiddenModules.map(sanitizeModuleKey).filter(Boolean)
+        : []
+  };
+
+  if (src.variables && typeof src.variables === 'object') {
+    Object.assign(result.variables, src.variables);
+  }
+
+  if (src.maxWidth) result.maxWidth = String(src.maxWidth);
+  else if (baseLayout.maxWidth) result.maxWidth = baseLayout.maxWidth;
+
+  if (src.gap) result.gap = String(src.gap);
+  else if (baseLayout.gap) result.gap = baseLayout.gap;
+
+  const areasSource = Array.isArray(src.areas) && src.areas.length
+    ? src.areas
+    : (Array.isArray(baseLayout.areas) && baseLayout.areas.length
+      ? baseLayout.areas
+      : (preset === 'single-column' ? SINGLE_COLUMN_AREAS : DEFAULT_AREAS));
+
+  result.areas = areasSource.map(cloneArea).map(normalizeArea).filter(Boolean);
+  return result;
+}
+
+function normalizeManifest(raw, pack, base = BASE_MANIFEST) {
+  const src = raw && typeof raw === 'object' ? raw : {};
+  const baseManifest = base && typeof base === 'object' ? base : {};
+  const layout = mergeLayoutSpec(baseManifest.layout, src.layout);
+  const variables = { ...(baseManifest.variables || {}) };
+  if (src.variables && typeof src.variables === 'object') {
+    Object.entries(src.variables).forEach(([key, value]) => {
+      variables[String(key)] = value;
+    });
+  }
+
+  const shellClasses = toClassArray(src.shellClasses);
+  const bodyClasses = toClassArray(src.bodyClasses);
+  const layoutClasses = toClassArray(src.layoutClasses);
+
+  const name = src.name ? String(src.name) : (pack || baseManifest.name || 'theme');
+  const label = src.label
+    ? String(src.label)
+    : (src.name ? String(src.name) : (pack && pack !== 'native' ? formatLabelFromPack(pack) : (baseManifest.label || formatLabelFromPack(pack))));
+  const description = src.description != null ? String(src.description) : (baseManifest.description || '');
+
+  return {
+    version: src.version != null ? src.version : (baseManifest.version || 1),
+    name,
+    label,
+    description,
+    variables,
+    shellClasses: shellClasses.length ? shellClasses : toClassArray(baseManifest.shellClasses),
+    bodyClasses: bodyClasses.length ? bodyClasses : toClassArray(baseManifest.bodyClasses),
+    layoutClasses: layoutClasses.length ? layoutClasses : toClassArray(baseManifest.layoutClasses),
+    layout,
+    pack: pack || src.pack || baseManifest.pack || 'native'
+  };
+}
+
+function sanitizeLayoutOverride(value) {
+  if (!value || typeof value !== 'object') return null;
+  const override = { ...value };
+  if (override.areas && Array.isArray(override.areas)) {
+    override.areas = override.areas.map(normalizeArea).filter(Boolean);
+  }
+  if (override.hiddenModules && Array.isArray(override.hiddenModules)) {
+    override.hiddenModules = override.hiddenModules.map(sanitizeModuleKey).filter(Boolean);
+  }
+  if (override.variables && typeof override.variables === 'object') {
+    override.variables = { ...override.variables };
+  }
+  if (override.rootVariables && typeof override.rootVariables === 'object') {
+    override.rootVariables = { ...override.rootVariables };
+  }
+  if (override.shellClasses) override.shellClasses = toClassArray(override.shellClasses);
+  if (override.bodyClasses) override.bodyClasses = toClassArray(override.bodyClasses);
+  if (override.layoutClasses) override.layoutClasses = toClassArray(override.layoutClasses);
+  if (override.classes) override.classes = toClassArray(override.classes);
+  return override;
+}
+
+function buildFinalManifest(manifest, override) {
+  const base = manifest || DEFAULT_THEME_MANIFEST;
+  const layoutOverride = sanitizeLayoutOverride(override);
+  const result = {
+    version: base.version,
+    name: base.name,
+    label: base.label,
+    description: base.description,
+    variables: { ...(base.variables || {}) },
+    shellClasses: [...toClassArray(base.shellClasses)],
+    bodyClasses: [...toClassArray(base.bodyClasses)],
+    layoutClasses: [...toClassArray(base.layoutClasses)],
+    layout: mergeLayoutSpec(base.layout, layoutOverride),
+    pack: base.pack
+  };
+
+  if (layoutOverride) {
+    if (layoutOverride.rootVariables) Object.assign(result.variables, layoutOverride.rootVariables);
+    if (layoutOverride.shellClasses) result.shellClasses = [...layoutOverride.shellClasses];
+    if (layoutOverride.bodyClasses) result.bodyClasses = [...layoutOverride.bodyClasses];
+    if (layoutOverride.layoutClasses) result.layoutClasses = [...layoutOverride.layoutClasses];
+    if (layoutOverride.classes) result.layout.classes = layoutOverride.classes;
+  }
+
+  return result;
+}
+
+function computeLayoutKey(manifest, pack) {
+  try {
+    return JSON.stringify({
+      pack: pack || manifest.pack,
+      layout: manifest.layout,
+      variables: manifest.variables,
+      shellClasses: manifest.shellClasses,
+      bodyClasses: manifest.bodyClasses,
+      layoutClasses: manifest.layoutClasses
+    });
+  } catch (_) {
+    return `${pack || manifest.pack || 'theme'}::${Date.now()}`;
+  }
+}
+
+function getShellElement() {
+  return document.querySelector('[data-ns-shell]') || document.getElementById('ns-shell');
+}
+
+function ensureModulesRegistered() {
+  if (modulesRegistered) return;
+  modulesRegistered = true;
+  document.querySelectorAll('[data-ns-module]').forEach((el) => {
+    const key = sanitizeModuleKey(el.getAttribute('data-ns-module'));
+    if (!key) return;
+    MODULE_REGISTRY.set(key, el);
+    el.classList.add('ns-module', `ns-module-${key.replace(/[^a-z0-9]+/g, '-')}`);
+  });
+}
+
+function applyCssVariables(target, vars, tracker) {
+  if (!target) return;
+  const nextKeys = new Set();
+  if (vars && typeof vars === 'object') {
+    Object.entries(vars).forEach(([k, v]) => {
+      const name = String(k).startsWith('--') ? String(k) : `--${String(k)}`;
+      if (v == null) return;
+      target.style.setProperty(name, String(v));
+      nextKeys.add(name);
+    });
+  }
+  tracker.forEach((key) => {
+    if (!nextKeys.has(key)) target.style.removeProperty(key);
+  });
+  tracker.clear();
+  nextKeys.forEach(key => tracker.add(key));
+}
+
+function applyClassSet(target, base, extras, tracker) {
+  if (!target) return;
+  const next = new Set(Array.isArray(base) ? base.map(String) : []);
+  (Array.isArray(extras) ? extras : []).forEach(cls => {
+    const val = String(cls || '').trim();
+    if (val) next.add(val);
+  });
+  tracker.forEach(cls => {
+    if (!next.has(cls)) target.classList.remove(cls);
+  });
+  next.forEach(cls => target.classList.add(cls));
+  tracker.clear();
+  next.forEach(cls => tracker.add(cls));
+}
+
+function applyThemeManifest(manifest, { pack, force } = {}) {
+  ensureModulesRegistered();
+  const shell = getShellElement();
+  if (!shell) return manifest;
+
+  const manifestKey = computeLayoutKey(manifest, pack);
+  if (!force && manifestKey === currentLayoutKey) return manifest;
+  currentLayoutKey = manifestKey;
+
+  applyClassSet(document.body, ['ns-theme-ready'], manifest.bodyClasses, appliedBodyClasses);
+  applyClassSet(shell, ['ns-shell'], manifest.shellClasses, appliedShellClasses);
+
+  applyCssVariables(document.documentElement, manifest.variables, appliedRootVars);
+  const layoutVars = (manifest.layout && manifest.layout.variables) || {};
+  applyCssVariables(shell, layoutVars, appliedShellVars);
+
+  if (manifest.layout && manifest.layout.maxWidth) {
+    shell.style.setProperty('--ns-shell-max-width', manifest.layout.maxWidth);
+  } else {
+    shell.style.removeProperty('--ns-shell-max-width');
+  }
+  if (manifest.layout && manifest.layout.gap) {
+    shell.style.setProperty('--ns-shell-gap', manifest.layout.gap);
+  } else {
+    shell.style.removeProperty('--ns-shell-gap');
+  }
+
+  const layout = manifest.layout || {};
+  const preset = layout.preset || 'two-column';
+  const orientation = layout.sidebarPosition || 'right';
+
+  const layoutRoot = document.createElement('div');
+  const layoutClasses = new Set(['ns-layout', `ns-layout-${preset}`]);
+  layoutRoot.dataset.nsLayout = preset;
+  if (orientation === 'left') layoutClasses.add('ns-sidebar-left');
+  else layoutClasses.add('ns-sidebar-right');
+  toClassArray(layout.classes || layout.class).forEach(cls => layoutClasses.add(cls));
+  toClassArray(manifest.layoutClasses).forEach(cls => layoutClasses.add(cls));
+  layoutClasses.forEach(cls => layoutRoot.classList.add(cls));
+
+  shell.dataset.nsLayout = preset;
+  shell.dataset.nsPack = pack || manifest.pack || 'native';
+
+  const oldChildren = Array.from(shell.children);
+  shell.insertBefore(layoutRoot, shell.firstChild || null);
+
+  const hiddenSet = new Set((layout.hiddenModules || []).map(sanitizeModuleKey));
+  MODULE_REGISTRY.forEach((el, key) => {
+    if (hiddenSet.has(key)) {
+      el.dataset.nsSuppressed = 'true';
+      el.setAttribute('aria-hidden', 'true');
+      el.hidden = true;
+    } else {
+      el.removeAttribute('data-ns-suppressed');
+      el.removeAttribute('aria-hidden');
+      if (!el.hasAttribute('data-ns-keep-hidden')) {
+        el.hidden = false;
+      }
+    }
+  });
+
+  const assigned = new Set();
+  const areas = Array.isArray(layout.areas) && layout.areas.length
+    ? layout.areas
+    : (preset === 'single-column'
+      ? SINGLE_COLUMN_AREAS.map(cloneArea).map(normalizeArea)
+      : DEFAULT_AREAS.map(cloneArea).map(normalizeArea));
+
+  areas.forEach((area, index) => {
+    if (!area) return;
+    const areaEl = document.createElement(area.as || 'div');
+    areaEl.classList.add('ns-area');
+    const name = area.name || `area-${index}`;
+    areaEl.dataset.nsArea = name;
+    areaEl.classList.add(`ns-area-${name}`);
+    (area.classes || []).forEach(cls => areaEl.classList.add(cls));
+    layoutRoot.appendChild(areaEl);
+    (area.modules || []).forEach(mod => {
+      const key = sanitizeModuleKey(mod);
+      const moduleEl = MODULE_REGISTRY.get(key);
+      if (!moduleEl || hiddenSet.has(key)) return;
+      assigned.add(key);
+      areaEl.appendChild(moduleEl);
+    });
+  });
+
+  const overflow = [];
+  MODULE_REGISTRY.forEach((el, key) => {
+    if (!hiddenSet.has(key) && !assigned.has(key)) {
+      overflow.push({ key, el });
+    }
+  });
+
+  if (overflow.length) {
+    const extra = document.createElement('div');
+    extra.classList.add('ns-area', 'ns-area-overflow');
+    extra.dataset.nsArea = 'overflow';
+    overflow.forEach(({ el }) => extra.appendChild(el));
+    layoutRoot.appendChild(extra);
+  }
+
+  oldChildren.forEach(child => {
+    if (child.parentElement === shell && child !== layoutRoot) {
+      shell.removeChild(child);
+    }
+  });
+
+  return manifest;
+}
+
+function getThemeManifest(pack) {
+  const slug = sanitizePack(pack);
+  if (slug === 'native') return Promise.resolve(DEFAULT_THEME_MANIFEST);
+  if (manifestCache.has(slug)) return manifestCache.get(slug);
+  const promise = fetch(`assets/themes/${encodeURIComponent(slug)}/manifest.json`, { cache: 'no-store' })
+    .then(resp => resp.ok ? resp.json() : Promise.reject(new Error('manifest not found')))
+    .then(json => normalizeManifest(json, slug))
+    .catch(() => normalizeManifest({}, slug));
+  manifestCache.set(slug, promise);
+  return promise;
+}
+
+function applyThemeLayoutForPack(pack, options = {}) {
+  const override = options.override !== undefined ? options.override : currentLayoutOverride;
+  const force = !!options.force;
+  return getThemeManifest(pack)
+    .then(manifest => buildFinalManifest(manifest, override))
+    .then(finalManifest => applyThemeManifest(finalManifest, { pack, force }))
+    .catch(() => {
+      const fallback = buildFinalManifest(DEFAULT_THEME_MANIFEST, override);
+      applyThemeManifest(fallback, { pack: 'native', force: true });
+      return fallback;
+    });
+}
+
+function updateThemeMeta(manifest) {
+  const meta = document.getElementById('themePackMeta');
+  if (!meta) return;
+  if (!manifest) {
+    meta.textContent = '';
+    meta.setAttribute('hidden', 'hidden');
+    meta.removeAttribute('data-pack');
+    return;
+  }
+  const label = manifest.label || formatLabelFromPack(manifest.pack);
+  const desc = manifest.description ? String(manifest.description) : '';
+  const parts = desc ? [label, desc] : [label];
+  meta.textContent = parts.join(' — ');
+  meta.dataset.pack = manifest.pack || '';
+  if (meta.textContent.trim()) meta.removeAttribute('hidden');
+  else meta.setAttribute('hidden', 'hidden');
+}
+
+export function initThemeSystem() {
+  ensureModulesRegistered();
+  applyThemeManifest(DEFAULT_THEME_MANIFEST, { pack: 'native', force: true });
+  const saved = getSavedThemePack();
+  currentPackName = saved;
+  applyThemeLayoutForPack(saved, { force: true }).then(updateThemeMeta).catch(() => updateThemeMeta(null));
+}
+
+export function activateThemePack(name, options = {}) {
   const pack = sanitizePack(name);
-  try { localStorage.setItem('themePack', pack); } catch (_) {}
+  const persist = options.persist !== false;
+  if (persist) {
+    try { localStorage.setItem('themePack', pack); } catch (_) {}
+  }
   const link = document.getElementById(PACK_LINK_ID);
   const href = `assets/themes/${encodeURIComponent(pack)}/theme.css`;
-  if (link) link.setAttribute('href', href);
+  if (link && link.getAttribute('href') !== href) link.setAttribute('href', href);
+  currentPackName = pack;
+  return applyThemeLayoutForPack(pack, { force: options.force, override: options.override })
+    .then(manifest => { updateThemeMeta(manifest); return manifest; })
+    .catch(err => { updateThemeMeta(null); throw err; });
 }
 
 export function getSavedThemePack() {
@@ -30,17 +474,15 @@ export function applySavedTheme() {
       document.documentElement.setAttribute('data-theme', 'dark');
     }
   } catch (_) { /* ignore */ }
-  // Ensure pack is applied too
-  loadThemePack(getSavedThemePack());
+  activateThemePack(getSavedThemePack()).catch(() => {});
 }
 
-// Apply theme according to site config. When override = true, it forces the
-// site-defined values and updates localStorage to keep UI in sync.
 export function applyThemeConfig(siteConfig) {
   const cfg = siteConfig || {};
-  const override = cfg.themeOverride !== false; // default true
-  const mode = (cfg.themeMode || '').toLowerCase(); // 'dark' | 'light' | 'auto' | 'user'
-  const pack = sanitizePack(cfg.themePack);
+  currentLayoutOverride = sanitizeLayoutOverride(cfg.themeLayout || cfg.themeLayoutOverride);
+  const override = cfg.themeOverride !== false;
+  const mode = (cfg.themeMode || '').toLowerCase();
+  const configPack = sanitizePack(cfg.themePack);
 
   const setMode = (m) => {
     if (m === 'dark') {
@@ -49,8 +491,7 @@ export function applyThemeConfig(siteConfig) {
     } else if (m === 'light') {
       document.documentElement.removeAttribute('data-theme');
       try { localStorage.setItem('theme', 'light'); } catch (_) {}
-    } else { // auto
-      // Remove explicit choice to allow system preference to drive
+    } else if (m === 'auto') {
       try { localStorage.removeItem('theme'); } catch (_) {}
       if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
         document.documentElement.setAttribute('data-theme', 'dark');
@@ -62,26 +503,28 @@ export function applyThemeConfig(siteConfig) {
 
   if (override) {
     if (mode === 'dark' || mode === 'light' || mode === 'auto') setMode(mode);
-    else if (mode === 'user') {
-      // Respect user choice entirely; if none, fall back to system preference
-      applySavedTheme();
+    else if (mode === 'user') applySavedTheme();
+    if (configPack) {
+      try { localStorage.setItem('themePack', configPack); } catch (_) {}
+      activateThemePack(configPack, { force: true, override: currentLayoutOverride }).catch(() => {});
+      return;
     }
-    if (pack) {
-      // Force pack and persist
-      try { localStorage.setItem('themePack', pack); } catch (_) {}
-      loadThemePack(pack);
-    }
+    activateThemePack(getSavedThemePack(), { force: true, override: currentLayoutOverride }).catch(() => {});
+    return;
+  }
+
+  const hasUserTheme = (() => { try { return !!localStorage.getItem('theme'); } catch (_) { return false; } })();
+  const hasUserPack = (() => { try { return !!localStorage.getItem('themePack'); } catch (_) { return false; } })();
+
+  if (!hasUserTheme) {
+    if (mode === 'dark' || mode === 'light' || mode === 'auto') setMode(mode);
+    else if (mode === 'user') applySavedTheme();
+  }
+
+  if (!hasUserPack && configPack) {
+    activateThemePack(configPack, { force: true, override: currentLayoutOverride }).catch(() => {});
   } else {
-    // Respect user choice; but if site provides a default and no user choice exists,
-    // apply it once without persisting as an override
-    const hasUserTheme = (() => { try { return !!localStorage.getItem('theme'); } catch (_) { return false; } })();
-    const hasUserPack = (() => { try { return !!localStorage.getItem('themePack'); } catch (_) { return false; } })();
-    if (!hasUserTheme) {
-      if (mode === 'dark' || mode === 'light' || mode === 'auto') setMode(mode);
-      // When mode is 'user' and there's no saved user theme, do nothing here;
-      // the boot code/applySavedTheme already applied system preference as a soft default.
-    }
-    if (!hasUserPack && pack) loadThemePack(pack);
+    activateThemePack(getSavedThemePack(), { force: true, override: currentLayoutOverride }).catch(() => {});
   }
 }
 
@@ -108,34 +551,31 @@ export function bindPostEditor() {
 export function bindThemePackPicker() {
   const sel = document.getElementById('themePack');
   if (!sel) return;
-  // Initialize selection
   const saved = getSavedThemePack();
   sel.value = saved;
   sel.addEventListener('change', () => {
     const val = sanitizePack(sel.value) || 'native';
-    loadThemePack(val);
+    sel.value = val;
+    activateThemePack(val, { force: true }).catch(() => {});
   });
 }
 
-// Render theme tools UI (button + select) into the sidebar, before TOC.
-// Options are sourced from assets/themes/packs.json; falls back to defaults.
 export function mountThemeControls() {
-  // If already present, do nothing
-  if (document.getElementById('tools')) return;
-  const sidebar = document.querySelector('.sidebar');
-  if (!sidebar) return;
-
-  const wrapper = document.createElement('div');
-  wrapper.className = 'box';
+  const wrapper = document.querySelector('[data-ns-module="tools"]');
+  if (!wrapper) return;
   wrapper.id = 'tools';
+  wrapper.classList.add('box');
+  wrapper.hidden = false;
+  wrapper.removeAttribute('hidden');
+  wrapper.removeAttribute('data-ns-keep-hidden');
   wrapper.innerHTML = `
     <div class="section-title">${t('tools.sectionTitle')}</div>
     <div class="tools tools-panel">
       <div class="tool-item">
-        <button id="themeToggle" class="btn icon-btn" aria-label="Toggle light/dark" title="${t('tools.toggleTheme')}"><span class="icon">🌓</span><span class="btn-text">${t('tools.toggleTheme')}</span></button>
+        <button id="themeToggle" class="btn icon-btn" aria-label="${t('tools.toggleTheme')}" title="${t('tools.toggleTheme')}"><span class="icon">🌓</span><span class="btn-text">${t('tools.toggleTheme')}</span></button>
       </div>
       <div class="tool-item">
-        <button id="postEditor" class="btn icon-btn" aria-label="Open Markdown Editor" title="${t('tools.postEditor')}"><span class="icon">📝</span><span class="btn-text">${t('tools.postEditor')}</span></button>
+        <button id="postEditor" class="btn icon-btn" aria-label="${t('tools.postEditor')}" title="${t('tools.postEditor')}"><span class="icon">📝</span><span class="btn-text">${t('tools.postEditor')}</span></button>
       </div>
       <div class="tool-item">
         <label for="themePack" class="tool-label">${t('tools.themePack')}</label>
@@ -148,49 +588,39 @@ export function mountThemeControls() {
       <div class="tool-item">
         <button id="langReset" class="btn icon-btn" aria-label="${t('tools.resetLanguage')}" title="${t('tools.resetLanguage')}"><span class="icon">♻️</span><span class="btn-text">${t('tools.resetLanguage')}</span></button>
       </div>
-    </div>`;
+    </div>
+    <div class="tool-meta" id="themePackMeta" hidden></div>
+  `;
 
-  const toc = document.getElementById('tocview');
-  if (toc && toc.parentElement === sidebar) sidebar.insertBefore(wrapper, toc);
-  else sidebar.appendChild(wrapper);
-
-  // Populate theme packs
   const sel = wrapper.querySelector('#themePack');
   const saved = getSavedThemePack();
   const fallback = [
     { value: 'native', label: 'Native' },
     { value: 'github', label: 'GitHub' },
-    { value: 'apple', label: 'Apple' },
-    { value: 'openai', label: 'OpenAI' },
+    { value: 'magazine', label: 'Magazine' }
   ];
 
-  // Try to load from JSON; if it fails, use fallback
-  fetch('assets/themes/packs.json').then(r => r.ok ? r.json() : Promise.reject()).then(list => {
-    try {
-      sel.innerHTML = '';
-      (Array.isArray(list) ? list : []).forEach(p => {
-        const opt = document.createElement('option');
-        opt.value = sanitizePack(p.value);
-        opt.textContent = String(p.label || p.value || 'Theme');
-        sel.appendChild(opt);
-      });
-      if (!sel.options.length) throw new Error('empty options');
-    } catch (_) {
-      throw _;
-    }
-  }).catch(() => {
+  const populateOptions = (list) => {
+    if (!sel) return;
     sel.innerHTML = '';
-    fallback.forEach(p => {
+    list.forEach(p => {
       const opt = document.createElement('option');
-      opt.value = p.value;
-      opt.textContent = p.label;
+      opt.value = sanitizePack(p.value);
+      opt.textContent = String(p.label || p.value || 'Theme');
       sel.appendChild(opt);
     });
-  }).finally(() => {
     sel.value = saved;
-  });
+  };
 
-  // Populate language selector
+  fetch('assets/themes/packs.json')
+    .then(r => r.ok ? r.json() : Promise.reject())
+    .then(list => Array.isArray(list) && list.length ? populateOptions(list) : populateOptions(fallback))
+    .catch(() => populateOptions(fallback))
+    .finally(() => {
+      const pack = currentPackName || saved;
+      getThemeManifest(pack).then(updateThemeMeta).catch(() => updateThemeMeta(null));
+    });
+
   const langSel = wrapper.querySelector('#langSelect');
   if (langSel) {
     const langs = getAvailableLangs();
@@ -208,15 +638,16 @@ export function mountThemeControls() {
     });
   }
 
-  // Bind language reset button
   const resetBtn = wrapper.querySelector('#langReset');
   if (resetBtn) {
     resetBtn.addEventListener('click', () => {
-      // Clear saved language and drop URL param, then soft-reset without full reload
       try { localStorage.removeItem('lang'); } catch (_) {}
-      try { const url = new URL(window.location.href); url.searchParams.delete('lang'); history.replaceState(history.state, document.title, url.toString()); } catch (_) {}
-      try { (window.__ns_softResetLang && window.__ns_softResetLang()); } catch (_) { /* fall through */ }
-      // If soft reset isn't available for some reason, fall back to reload
+      try {
+        const url = new URL(window.location.href);
+        url.searchParams.delete('lang');
+        history.replaceState(history.state, document.title, url.toString());
+      } catch (_) {}
+      try { (window.__ns_softResetLang && window.__ns_softResetLang()); } catch (_) {}
       if (!window.__ns_softResetLang) {
         try { window.location.reload(); } catch (_) {}
       }
@@ -224,7 +655,6 @@ export function mountThemeControls() {
   }
 }
 
-// Rebuild language selector options based on current available content langs
 export function refreshLanguageSelector() {
   const sel = document.getElementById('langSelect');
   if (!sel) return;

--- a/assets/main.js
+++ b/assets/main.js
@@ -1,6 +1,6 @@
 import { mdParse } from './js/markdown.js';
 import { setupAnchors, setupTOC } from './js/toc.js';
-import { applySavedTheme, bindThemeToggle, bindThemePackPicker, mountThemeControls, refreshLanguageSelector, applyThemeConfig, bindPostEditor } from './js/theme.js';
+import { initThemeSystem, applySavedTheme, bindThemeToggle, bindThemePackPicker, mountThemeControls, refreshLanguageSelector, applyThemeConfig, bindPostEditor } from './js/theme.js';
 import { setupSearch } from './js/search.js';
 import { extractExcerpt, computeReadTime } from './js/content.js';
 import { getQueryVariable, setDocTitle, setBaseSiteTitle, cardImageSrc, fallbackCover, renderTags, slugifyTab, escapeHtml, formatDisplayDate, formatBytes, renderSkeletonArticle, isModifiedClick, getContentRoot, sanitizeImageUrl, sanitizeUrl } from './js/utils.js';
@@ -38,6 +38,15 @@ let PAGE_SIZE = 8;
 let __activePostRequestId = 0;
 // Track last route to harmonize scroll behavior on back/forward
 let __lastRouteKey = '';
+
+const getLayoutArea = (name, fallbackSelector) => {
+  return document.querySelector(`[data-ns-area="${name}"]`) || (fallbackSelector ? document.querySelector(fallbackSelector) : null);
+};
+
+const getMainAreaEl = () => getLayoutArea('main', '.content');
+const getSidebarAreaEl = () => getLayoutArea('sidebar', '.sidebar') || getLayoutArea('support', '.sidebar');
+
+initThemeSystem();
 
 // --- UI helpers: smooth show/hide (height + opacity) ---
 
@@ -935,8 +944,8 @@ function displayPost(postname) {
   // Bump request token to invalidate any in-flight older renders
   const reqId = (++__activePostRequestId);
   // Add loading-state classes to keep layout stable
-  const contentEl = document.querySelector('.content');
-  const sidebarEl = document.querySelector('.sidebar');
+  const contentEl = getMainAreaEl();
+  const sidebarEl = getSidebarAreaEl();
   const mainviewContainer = document.getElementById('mainview')?.closest('.box');
   
   if (contentEl) contentEl.classList.add('loading', 'layout-stable');
@@ -1448,8 +1457,8 @@ function displayStaticTab(slug) {
   if (!tab) return displayIndex({});
   
   // Add loading state class to maintain layout stability
-  const contentEl = document.querySelector('.content');
-  const sidebarEl = document.querySelector('.sidebar');
+  const contentEl = getMainAreaEl();
+  const sidebarEl = getSidebarAreaEl();
   const mainviewContainer = document.getElementById('mainview')?.closest('.box');
   
   if (contentEl) contentEl.classList.add('loading', 'layout-stable');

--- a/assets/schema/site.json
+++ b/assets/schema/site.json
@@ -90,6 +90,10 @@
       "type": "boolean",
       "description": "Allow theme override via UI or config."
     },
+    "themeLayout": {
+      "$ref": "#/$defs/themeLayout",
+      "description": "Optional layout overrides merged with the active theme manifest."
+    },
     "cardCoverFallback": {
       "type": "boolean",
       "description": "Use card cover image as fallback when missing."
@@ -208,6 +212,51 @@
           }
         }
       ]
+    },
+    "stringArray": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "stringMap": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "themeLayoutArea": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "classes": { "$ref": "#/$defs/stringArray" },
+        "class": { "type": "string" },
+        "modules": { "$ref": "#/$defs/stringArray" },
+        "as": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "themeLayout": {
+      "type": "object",
+      "properties": {
+        "preset": {
+          "type": "string",
+          "enum": ["two-column", "single-column", "stacked"]
+        },
+        "sidebarPosition": {
+          "type": "string",
+          "enum": ["left", "right"]
+        },
+        "areas": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/themeLayoutArea" }
+        },
+        "hiddenModules": { "$ref": "#/$defs/stringArray" },
+        "variables": { "$ref": "#/$defs/stringMap" },
+        "rootVariables": { "$ref": "#/$defs/stringMap" },
+        "shellClasses": { "$ref": "#/$defs/stringArray" },
+        "bodyClasses": { "$ref": "#/$defs/stringArray" },
+        "layoutClasses": { "$ref": "#/$defs/stringArray" },
+        "gap": { "type": "string" },
+        "maxWidth": { "type": "string" }
+      },
+      "additionalProperties": true
     }
   }
 }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -12,6 +12,9 @@
   --code-text: #e5e7eb;
   --hr: #e5e7eb;
   --shadow: 0 0.0625rem 0.1875rem rgba(0, 0, 0, 0.06), 0 0.0625rem 0.125rem rgba(0, 0, 0, 0.04);
+  --ns-shell-gap: 1.5rem;
+  --ns-shell-max-width: min(75rem, calc(100% - 2.5rem));
+  --ns-sidebar-width: min(20rem, 100%);
   /* Serif stack for article-like body text (theme packs may override) */
   --article-serif-stack: Georgia, "Times New Roman", Times, "Noto Serif CJK SC", "Source Han Serif SC", "Noto Serif", "STSong", serif;
   /* Callout palette */
@@ -66,11 +69,73 @@ body {
   max-width: 100vw;
   box-sizing: border-box;
 }
-html { 
-  scroll-behavior: smooth; 
+html {
+  scroll-behavior: smooth;
   /* Prevent horizontal scroll on mobile */
   overflow-x: clip;
   max-width: 100vw;
+}
+
+/* Layout shell rebuilt dynamically by the theme system */
+#ns-shell {
+  width: 100%;
+}
+
+.ns-shell {
+  box-sizing: border-box;
+  margin: 0 auto;
+  width: min(var(--ns-shell-max-width), 100%);
+  padding: 0 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ns-shell-gap);
+}
+
+.ns-layout {
+  display: grid;
+  gap: var(--ns-shell-gap);
+  align-items: start;
+  width: 100%;
+}
+
+.ns-layout.ns-layout-two-column {
+  grid-template-columns: minmax(0, 1fr) minmax(0, var(--ns-sidebar-width));
+}
+
+.ns-layout.ns-sidebar-left {
+  grid-template-columns: minmax(0, var(--ns-sidebar-width)) minmax(0, 1fr);
+}
+
+.ns-layout.ns-layout-single-column {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.ns-area {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-width: 0;
+}
+
+.ns-area > .box {
+  margin-bottom: 0;
+}
+
+.ns-area-main,
+.content {
+  min-height: 70vh;
+  overflow: visible;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.ns-area-sidebar,
+.sidebar {
+  min-width: 0;
+}
+
+.ns-area-support {
+  min-width: 0;
 }
 
 /* Link style */
@@ -848,11 +913,14 @@ ul.collapsed, li > ul.collapsed { display: none; }
 }
 
 /* Container stability during loading */
-.content.loading #mainview {
+.content.loading #mainview,
+.ns-area-main.loading #mainview {
   min-height: 37.5rem; /* Ensure stable height while loading */
 }
 
-.sidebar.loading #tocview {
+.sidebar.loading #tocview,
+.ns-area-sidebar.loading #tocview,
+.ns-area-support.loading #tocview {
   min-height: 12.5rem; /* Ensure stable height for TOC while loading */
 }
 
@@ -1123,14 +1191,11 @@ ul.collapsed, li > ul.collapsed { display: none; }
 }
 
 .container {
-  display: grid;
-  grid-template-columns: 45rem 18.75rem; /* Fixed column widths to prevent collapse */
-  justify-content: center; /* Center align */
   margin: 0 auto;
-  max-width: 75rem;
-  gap: 1.5rem;
+  width: min(var(--ns-shell-max-width), 100%);
+  max-width: 100%;
   padding: 0 1.25rem;
-  /* Prevent grid container distortion when content changes */
+  box-sizing: border-box;
 }
 
 /* Compact tabs mode: when nav collapses due to small width */
@@ -1198,6 +1263,8 @@ ul.collapsed, li > ul.collapsed { display: none; }
 /* Labeled tool items */
 #tools .tool-item { display:flex; flex-direction: column; gap: 0.375rem; min-width: 0; }
 #tools .tool-label { font-size: .78rem; color: var(--muted); letter-spacing: .02em; }
+#tools .tool-meta { font-size: .8rem; color: var(--muted); line-height: 1.4; margin-top: 0.5rem; }
+#tools .tool-meta[hidden] { display: none; }
 
 #tools .btn,
 #themeToggle.btn,
@@ -1272,173 +1339,153 @@ ul.collapsed, li > ul.collapsed { display: none; }
 
 /* Large screens (>1400px) */
 @media (min-width: 87.5rem) {
-  .container {
-    max-width: 87.5rem;
-    gap: 2rem;
-    grid-template-columns: 50rem 20rem; /* Wider layout on large screens */
+  .ns-shell {
+    width: min(var(--ns-shell-max-width), 87.5rem);
   }
-  
+
+  .ns-layout.ns-layout-two-column {
+    gap: max(var(--ns-shell-gap), 2rem);
+    grid-template-columns: minmax(0, 1fr) minmax(0, max(var(--ns-sidebar-width), 20rem));
+  }
+
   .index {
     grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
-  column-gap: 1.5rem;
-  row-gap: 0;
+    column-gap: 1.5rem;
+    row-gap: 0;
   }
 }
 
 /* Tablet landscape (769px - 1024px) */
 @media (max-width: 64rem) and (min-width: 48.0625rem) {
-  .container {
-    max-width: 100%;
+  .ns-shell {
+    width: 100%;
     padding: 0 1rem;
-    gap: 1.25rem;
-    grid-template-columns: 37.5rem 16.25rem; /* Grid layout for medium screens */
   }
-  
-  .index {
-    grid-template-columns: repeat(auto-fill, minmax(15.625rem, 1fr));
-  column-gap: 1rem;
-  row-gap: 0;
-  }
-}
 
-/* Tablet devices (769px - 1024px) */
-@media (max-width: 64rem) and (min-width: 48.0625rem) {
-  .container {
-    max-width: 100%;
-    padding: 0 1rem;
+  .ns-layout.ns-layout-two-column {
     gap: 1.25rem;
-    grid-template-columns: 37.5rem 16.25rem; /* Grid layout for medium screens */
+    grid-template-columns: minmax(0, 1fr) minmax(0, clamp(16.25rem, 24vw, 18rem));
   }
-  
+
   .index {
     grid-template-columns: repeat(auto-fill, minmax(15.625rem, 1fr));
-  column-gap: 1rem;
-  row-gap: 0;
+    column-gap: 1rem;
+    row-gap: 0;
   }
 }
 
 /* Mobile (≤768px) — comprehensive mobile optimizations */
 @media (max-width: 48rem) {
-  /* Global mobile settings */
   html {
-    -webkit-text-size-adjust: 100%; /* Prevent iOS auto text-size adjustment */
+    -webkit-text-size-adjust: 100%;
   }
-  
+
   body {
-    padding: 1rem 0 1.5rem; /* Reduce padding on mobile */
+    padding: 1rem 0 1.5rem;
   }
-  
-  .container {
-    display: flex !important; /* Force flex layout on mobile */
-    flex-direction: column;
-    margin: 0;
-    padding: 0.5rem; /* Reduce container padding */
-    gap: 1rem; /* Reduce spacing */
+
+  .ns-shell {
+    padding: 0.5rem;
     width: 100%;
-    max-width: 100vw; /* Use viewport width */
-    min-width: 0; /* Allow minimum shrink */
-    overflow-x: hidden; /* Prevent horizontal overflow */
-    box-sizing: border-box;
+    max-width: 100vw;
+    gap: 1rem;
   }
 
-  .content {
-    flex: 1 1 auto;
-    width: 100%; /* Ensure full width */
-    max-width: 100%;
-    min-width: 0; /* Allow shrink */
-    overflow: hidden; /* Prevent content overflow */
-    min-height: 40vh; /* Smaller min-height on mobile */
-    /* Reset desktop fixed-width settings */
-    box-sizing: border-box;
-    order: 1; /* Place content above */
+  .ns-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
   }
 
+  .ns-area,
+  .content,
   .sidebar {
-    flex: 0 0 auto; /* No stretch; size to content */
-    width: 100%; /* Ensure full width */
+    width: 100%;
     max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
+  }
+
+  .ns-area-main,
+  .content {
+    min-height: 40vh;
+  }
+
+  .ns-area-sidebar,
+  .ns-area-support,
+  .sidebar {
     margin-top: 0;
     margin-left: 0;
-    order: 2; /* Move sidebar below content */
-    box-sizing: border-box;
+    padding: 0;
+    background: transparent;
+    border: none;
+    box-shadow: none;
   }
-  
+
   .index {
-    grid-template-columns: 1fr; /* Single-column layout */
-  column-gap: 0.75rem; /* horizontal spacing */
-  row-gap: 0; /* remove vertical spacing on mobile too */
+    grid-template-columns: 1fr;
+    column-gap: 0.75rem;
+    row-gap: 0;
   }
-  
+
   #tools .tools {
-    grid-template-columns: 1fr; /* Single-column toolbar */
-    gap: 0.5rem; /* Reduce spacing */
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
   }
-  
+
   .site-footer .footer-inner {
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.5rem; /* Reduce spacing */
-    padding: 0.75rem 0; /* Reduce padding */
+    gap: 0.5rem;
+    padding: 0.75rem 0;
     max-width: 100%;
   }
-  
+
   .footer-nav {
     flex-direction: column;
-    gap: 0.375rem; /* Reduce spacing */
+    gap: 0.375rem;
     width: 100%;
   }
-  
-  /* Mobile TOC optimizations */
+
   #tocview {
-    position: static !important; /* Force non-sticky positioning on mobile */
+    position: static !important;
     max-height: none;
     overflow: visible;
-    min-height: 6.25rem; /* Reduce min-height */
+    min-height: 6.25rem;
     width: 100%;
-    box-sizing: border-box;
   }
-  
-  /* Mobile main content area adjustments */
+
   #mainview {
-    min-height: 15.625rem; /* Reduce min-height */
+    min-height: 15.625rem;
     width: 100%;
     max-width: 100%;
-    /* Allow long tokens to wrap, but prefer hyphenation over arbitrary breaks */
-    overflow-wrap: break-word; /* Allow long-word wrap when necessary */
-    word-break: normal; /* Do not force arbitrary breaks */
-    hyphens: auto; /* Enable hyphenation */
+    overflow-wrap: break-word;
+    word-break: normal;
+    hyphens: auto;
     -webkit-hyphens: auto;
     -ms-hyphens: auto;
-    box-sizing: border-box;
+    font-size: 0.95rem;
+    line-height: 1.6;
   }
-  
-  /* Mobile font size adjustments */
-  #mainview {
-    font-size: 0.95rem; /* Slightly smaller font */
-    line-height: 1.6; /* Tighter line-height */
-  }
-  
-  /* Mobile buttons and inputs optimizations */
+
   #tools .btn,
   #searchbox input[type="search"] {
-    padding: .5rem .6rem; /* Reduce padding */
-    height: 2.625rem; /* Touch-friendly height */
-    width: 100%; /* Ensure buttons span full width */
+    padding: .5rem .6rem;
+    height: 2.625rem;
+    width: 100%;
     box-sizing: border-box;
-    font-size: 0.95rem; /* Slightly smaller font */
+    font-size: 0.95rem;
   }
-  
-  /* Mobile box optimizations */
+
   .box {
-    margin-bottom: 0.75rem; /* Reduce spacing */
-    padding: 0.75rem; /* Reduce padding */
+    margin-bottom: 0.75rem;
+    padding: 0.75rem;
     width: 100%;
     max-width: 100%;
     box-sizing: border-box;
-    overflow: hidden; /* Prevent content overflow */
+    overflow: hidden;
   }
-  
-  /* Mobile image handling */
+
   #mainview img,
   .index img {
     max-width: 100% !important;
@@ -1446,55 +1493,50 @@ ul.collapsed, li > ul.collapsed { display: none; }
     width: auto !important;
     box-sizing: border-box;
   }
-  
-  /* Mobile table handling */
+
   .table-wrap {
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     max-width: 100%;
   }
-  
+
   table {
     min-width: 100%;
-    font-size: 0.9rem; /* Smaller font for tables */
+    font-size: 0.9rem;
   }
-  
-  /* Mobile code block handling */
+
   pre {
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
     max-width: 100%;
-    padding: 0.8rem; /* Reduce padding */
-    font-size: 0.85rem; /* Smaller font for code */
-    margin: 0.75rem 0; /* Keep consistent spacing between blocks */
+    padding: 0.8rem;
+    font-size: 0.85rem;
+    margin: 0.75rem 0;
   }
-  
-  /* Ensure the nav bar renders correctly on mobile */
+
   .tabs {
     flex-wrap: wrap;
-    gap: 0.1875rem; /* Reduce spacing */
-    padding: 0.25rem; /* Reduce padding */
+    gap: 0.1875rem;
+    padding: 0.25rem;
   }
-  
+
   .tab {
-    padding: .3rem .45rem; /* Reduce padding */
-    font-size: 0.85rem; /* Smaller font */
+    padding: .3rem .45rem;
+    font-size: 0.85rem;
   }
-  
-  /* Mobile heading adjustments */
-  h1 { font-size: 1.6rem; } /* 减小标题字体 */
+
+  h1 { font-size: 1.6rem; }
   h2 { font-size: 1.4rem; }
   h3 { font-size: 1.2rem; }
-  
-  /* Mobile list adjustments */
-  #mainview ul, #mainview ol { 
-    margin: .6rem 0 .6rem 1rem; /* Reduce margins */
+
+  #mainview ul,
+  #mainview ol {
+    margin: .6rem 0 .6rem 1rem;
   }
-  
-  /* Mobile blockquote adjustments */
-  blockquote { 
-    margin: .8rem 0; /* Reduce margins */
-    padding: .4rem .8rem; /* Reduce padding */
+
+  blockquote {
+    margin: .8rem 0;
+    padding: .4rem .8rem;
   }
 }
 

--- a/assets/themes/github/manifest.json
+++ b/assets/themes/github/manifest.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "name": "github",
+  "label": "GitHub Primer",
+  "description": "GitHub-inspired palette with a compact document column and flat surfaces.",
+  "variables": {
+    "--ns-shell-gap": "1.5rem",
+    "--ns-shell-max-width": "min(61.25rem, calc(100% - 2.5rem))"
+  },
+  "layout": {
+    "preset": "two-column",
+    "sidebarPosition": "right",
+    "variables": {
+      "--ns-sidebar-width": "15rem"
+    },
+    "areas": [
+      { "name": "main", "classes": ["content"], "modules": ["tabs", "main"] },
+      { "name": "sidebar", "classes": ["sidebar"], "modules": ["search", "site-card", "tags", "tools", "toc"] }
+    ]
+  }
+}

--- a/assets/themes/magazine/manifest.json
+++ b/assets/themes/magazine/manifest.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "name": "magazine",
+  "label": "Magazine Focus",
+  "description": "A single-column magazine layout with generous spacing and stacked utilities.",
+  "variables": {
+    "--ns-shell-gap": "2.25rem",
+    "--ns-shell-max-width": "min(48rem, calc(100% - 2rem))"
+  },
+  "layout": {
+    "preset": "single-column",
+    "sidebarPosition": "right",
+    "variables": {
+      "--ns-sidebar-width": "100%"
+    },
+    "areas": [
+      { "name": "main", "classes": ["content", "magazine-main"], "modules": ["tabs", "main"] },
+      { "name": "support", "classes": ["sidebar", "magazine-support"], "modules": ["search", "site-card", "tags", "tools", "toc"] }
+    ]
+  }
+}

--- a/assets/themes/magazine/theme.css
+++ b/assets/themes/magazine/theme.css
@@ -1,0 +1,181 @@
+/* Magazine-inspired theme */
+:root {
+  --bg: #fdfbf6;
+  --text: #2b2118;
+  --muted: #7c6f62;
+  --primary: #d97706;
+  --primary-hover: #f97316;
+  --card: rgba(255, 255, 255, 0.92);
+  --border: rgba(226, 209, 189, 0.7);
+  --code-bg: #f6efe6;
+  --code-text: #2b2118;
+  --hr: rgba(226, 209, 189, 0.8);
+  --shadow: 0 1.25rem 3rem rgba(122, 74, 18, 0.08);
+}
+
+[data-theme="dark"] {
+  --bg: #1f1710;
+  --text: #f1ede7;
+  --muted: #c7b9a5;
+  --primary: #f8b26a;
+  --primary-hover: #f9c087;
+  --card: rgba(35, 25, 18, 0.92);
+  --border: rgba(122, 90, 58, 0.4);
+  --code-bg: #241c15;
+  --code-text: #f1ede7;
+  --hr: rgba(122, 90, 58, 0.4);
+  --shadow: 0 1.25rem 3.5rem rgba(0, 0, 0, 0.35);
+}
+
+body {
+  font-family: "Playfair Display", "Georgia", "Times New Roman", serif;
+  background: radial-gradient(circle at top left, rgba(217, 119, 6, 0.12), transparent 55%),
+              radial-gradient(circle at bottom right, rgba(234, 179, 8, 0.12), transparent 50%),
+              var(--bg) !important;
+  color: var(--text);
+}
+
+.ns-shell {
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 1.5rem;
+  padding: 2rem clamp(1.5rem, 2vw, 2.5rem);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4), var(--shadow);
+  backdrop-filter: blur(14px);
+}
+
+.ns-layout.ns-layout-single-column {
+  gap: 2.5rem;
+}
+
+.ns-area-main .box,
+.ns-area-support .box {
+  border-radius: 1.25rem;
+  border-color: var(--border);
+  background: var(--card);
+  box-shadow: var(--shadow);
+}
+
+#mapview .tabs {
+  border: none;
+  background: transparent;
+  padding: 0;
+  gap: 0.75rem;
+}
+
+#mapview .tab {
+  font-family: "Playfair Display", "Georgia", serif;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(217, 119, 6, 0.25);
+  background: rgba(217, 119, 6, 0.08);
+  color: var(--primary);
+}
+
+#mapview .tab.active {
+  background: var(--primary);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 0.75rem 2rem rgba(217, 119, 6, 0.25);
+}
+
+#mapview .tab:hover { background: color-mix(in srgb, var(--primary) 20%, transparent); }
+
+#mainview h1,
+#mainview h2,
+#mainview h3 {
+  font-family: "Playfair Display", "Georgia", serif;
+  letter-spacing: 0.04em;
+}
+
+#mainview p,
+#mainview li {
+  font-size: 1.08rem;
+  line-height: 1.9;
+}
+
+.ns-area-support {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: 1.5rem;
+}
+
+.ns-area-support #searchbox,
+.ns-area-support #tagview,
+.ns-area-support #tools,
+.ns-area-support .site-card,
+.ns-area-support #tocview {
+  height: 100%;
+}
+
+.site-card .avatar {
+  width: 6rem;
+  height: 6rem;
+  border-radius: 50%;
+  border: 0.25rem solid rgba(217, 119, 6, 0.25);
+  margin-bottom: 1rem;
+}
+
+.site-card .site-title {
+  font-family: "Playfair Display", serif;
+  font-size: 1.4rem;
+}
+
+.site-card .site-subtitle {
+  color: var(--muted);
+  font-size: 1rem;
+}
+
+#tools .btn,
+#tools select {
+  border-radius: 999px;
+  border: 1px solid rgba(217, 119, 6, 0.2);
+  background: rgba(217, 119, 6, 0.08);
+  color: var(--primary);
+}
+
+#tools .btn:hover,
+#tools select:hover {
+  background: color-mix(in srgb, var(--primary) 22%, transparent);
+  color: #fff;
+}
+
+#tools .tool-label { text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.7rem; }
+
+.index .card-title {
+  font-family: "Playfair Display", serif;
+}
+
+.index a {
+  border-radius: 1.25rem !important;
+  border: none !important;
+  background: rgba(255, 255, 255, 0.85) !important;
+  box-shadow: var(--shadow) !important;
+}
+
+.index a:hover {
+  transform: translateY(-0.2rem) !important;
+  box-shadow: 0 1.5rem 3rem rgba(217, 119, 6, 0.2) !important;
+}
+
+#tocview .toc-header { font-family: "Playfair Display", serif; letter-spacing: 0.08em; text-transform: uppercase; }
+
+#tagview .section-title { font-family: "Playfair Display", serif; letter-spacing: 0.08em; }
+
+[data-theme="dark"] .ns-shell {
+  background: rgba(24, 17, 12, 0.8);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), var(--shadow);
+}
+
+[data-theme="dark"] #tools .btn,
+[data-theme="dark"] #tools select {
+  color: var(--text);
+  background: rgba(248, 178, 106, 0.12);
+  border-color: rgba(248, 178, 106, 0.35);
+}
+
+[data-theme="dark"] .index a {
+  background: rgba(35, 25, 18, 0.95) !important;
+}

--- a/assets/themes/native/manifest.json
+++ b/assets/themes/native/manifest.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "name": "native",
+  "label": "Native Classic",
+  "description": "Default NanoSite layout with a right sidebar and balanced spacing.",
+  "variables": {
+    "--ns-shell-gap": "1.5rem",
+    "--ns-shell-max-width": "min(75rem, calc(100% - 2.5rem))"
+  },
+  "layout": {
+    "preset": "two-column",
+    "sidebarPosition": "right",
+    "variables": {
+      "--ns-sidebar-width": "min(20rem, 100%)"
+    },
+    "areas": [
+      { "name": "main", "classes": ["content"], "modules": ["tabs", "main"] },
+      { "name": "sidebar", "classes": ["sidebar"], "modules": ["search", "site-card", "tags", "tools", "toc"] }
+    ]
+  }
+}

--- a/assets/themes/packs.json
+++ b/assets/themes/packs.json
@@ -1,4 +1,5 @@
 [
   { "value": "native", "label": "Native" },
-  { "value": "github", "label": "GitHub" }
+  { "value": "github", "label": "GitHub" },
+  { "value": "magazine", "label": "Magazine" }
 ]

--- a/docs/theme-system.md
+++ b/docs/theme-system.md
@@ -1,0 +1,77 @@
+# Theme System Architecture Plan
+
+## 1. Current State and Limitations
+- Theme packs are limited to CSS files located under `assets/themes/<pack>/theme.css`.
+- Layout of the application is hard-coded in `index.html` with a fixed `.content` + `.sidebar` structure.
+- JavaScript modules assume a specific DOM hierarchy, preventing major layout changes.
+- End users cannot express theme capabilities (metadata, tokens, layout) without editing source files.
+
+## 2. Goals for the New System
+- Allow themes to declare metadata, design tokens, and layout behaviour via a manifest.
+- Support multiple layout presets (e.g., classic two-column, single-column, sidebar-left) and custom area definitions.
+- Maintain backwards compatibility with existing themes through sensible defaults.
+- Enable site owners to override parts of the theme layout in `site.yaml`.
+- Keep runtime lightweight (no build step) and avoid blocking initial paint.
+
+## 3. Theme Pack Manifest
+Each theme pack now includes a `manifest.json` file alongside `theme.css`.
+
+Key fields (subject to validation but flexible for future versions):
+- `name`, `label`, `description`, `version`: metadata shown in UI.
+- `layout`: object describing the shell (see §4 for structure).
+- `variables`: map of CSS custom properties applied to `:root` for design tokens.
+- `bodyClasses`, `shellClasses`, `layoutClasses`: arrays of classes applied to `<body>`, the layout shell, and layout root.
+- `assets`: reserved for additional resources (future use, defaults to CSS already loaded via link).
+
+If `manifest.json` is missing, the runtime falls back to the built-in `native` manifest that mimics the current layout.
+
+## 4. Layout Specification
+A layout manifest describes how logical modules are arranged.
+
+Terminology:
+- **Module**: a semantic block of UI with a `data-ns-module` attribute. Core modules include `tabs`, `main`, `search`, `site-card`, `tags`, `tools`, and `toc`.
+- **Area**: container created by the layout engine, typically corresponding to visual regions such as the main column or sidebar.
+
+`layout` fields:
+- `preset`: named preset used for defaults (`two-column`, `single-column`, etc.).
+- `sidebarPosition`: optional hint (`left` / `right`) for two-column presets.
+- `areas`: array of area definitions, each containing:
+  - `name`: identifier used for attributes/classes (`ns-area-${name}`).
+  - `modules`: ordered list of module keys placed inside the area.
+  - `class`: optional extra classes (e.g., `content`, `sidebar`).
+  - `as`: optional tag name for the container (default `div`).
+- `hiddenModules`: modules to hide entirely (useful for minimal layouts).
+- `variables`: CSS custom properties attached to the shell for layout sizing (e.g., `--ns-shell-max-width`).
+
+Areas not listed fall back to the default preset definition. Any modules not assigned to an area are appended to a hidden overflow area unless explicitly hidden.
+
+## 5. Runtime Flow
+1. On boot (`initThemeSystem()`), the runtime collects all DOM nodes marked with `data-ns-module`.
+2. The default manifest (classic two-column) is applied immediately to avoid layout flashes.
+3. The active pack is resolved (`localStorage`, site config) and its manifest is fetched asynchronously.
+4. Once loaded, the layout engine rebuilds the shell according to the manifest and applies design tokens/body classes.
+5. Changing the pack via UI or config re-runs step 4. Overrides from `site.yaml` (`themeLayout`) are merged before application.
+6. Theme controls UI reuses the existing `#tools` module so modules remain relocatable.
+
+## 6. Site Configuration Overrides
+`site.yaml` gains an optional `themeLayout` object using the same structure as the manifest `layout`. This lets site owners reorder modules or tweak layout settings without duplicating a theme pack.
+
+Override precedence:
+1. Theme manifest provides defaults.
+2. `site.yaml` `themeLayout` merges on top.
+3. Runtime ensures requested modules exist and ignores unknown keys gracefully.
+
+## 7. Sample Theme Deliverable
+- Introduce a new `assets/themes/magazine` pack showcasing a single-column “magazine” layout. It pushes auxiliary modules below the content and uses wider spacing.
+- Update `packs.json` so it surfaces in the picker with metadata.
+- Ensure existing `native` and `github` packs ship manifests compatible with the new system.
+
+## 8. Compatibility Notes
+- `index.html` modules receive `data-ns-module` attributes, plus a reusable empty Tools container.
+- JavaScript selectors are updated to prefer `data-ns-area` markers with fallbacks to legacy classes to avoid regressions.
+- CSS updates provide base styles for the new `.ns-shell`, `.ns-layout`, and `.ns-area-*` classes while keeping legacy selectors working.
+
+## 9. Testing Strategy
+- Manual verification by switching between theme packs (native, GitHub, magazine) ensuring layout adjustments and persisted choice.
+- Smoke-test main flows: load posts, open static tab, toggle dark/light, verify TOC/search still works.
+

--- a/index.html
+++ b/index.html
@@ -21,27 +21,27 @@
 </head>
 
 <body>
-  <div class="container">
-    <div class="content">
+  <div class="container" id="ns-shell" data-ns-shell>
+    <div class="content" data-ns-area-root="main">
 
       <!-- Navigator Bar -->
-      <div class="box flex-split" id="mapview">
+      <div class="box flex-split" id="mapview" data-ns-module="tabs">
         <nav class="tabs" id="tabsNav" aria-label="Sections"></nav>
       </div>
 
       <!-- Main content -->
-      <div class="box" id="mainview">
+      <div class="box" id="mainview" data-ns-module="main">
       </div>
     </div>
-    <div class="sidebar">
+    <div class="sidebar" data-ns-area-root="sidebar">
 
       <!-- Search -->
-      <div class="box" id="searchbox">
+      <div class="box" id="searchbox" data-ns-module="search">
         <input id="searchInput" type="search">
       </div>
 
       <!-- Site Card -->
-      <div class="box site-card">
+      <div class="box site-card" data-ns-module="site-card">
         <img class="avatar" alt="avatar" loading="lazy" decoding="async">
         <h3 class="site-title"></h3>
         <p class="site-subtitle"></p>
@@ -50,13 +50,16 @@
         </ul>
       </div>
 
-  <!-- Tags Filter -->
-  <div class="box" id="tagview"></div>
+      <!-- Tags Filter -->
+      <div class="box" id="tagview" data-ns-module="tags"></div>
 
-      <!-- Tools box is rendered by JS (theme.js) -->
+      <!-- Theme / tools placeholder (populated via JS) -->
+      <div class="box" id="tools" data-ns-module="tools" data-ns-keep-hidden="true" hidden></div>
+
+      <!-- Tools module is hydrated by JS (theme.js) -->
 
       <!-- Page of Content for Posts -->
-      <div class="box" id="tocview"></div>
+      <div class="box" id="tocview" data-ns-module="toc"></div>
     </div>
   </div>
 

--- a/site.yaml
+++ b/site.yaml
@@ -43,6 +43,13 @@ contentRoot: wwwroot      # Root directory for content files
 themeMode: user
 themePack: native
 themeOverride: true
+# themeLayout:
+#   preset: two-column
+#   areas:
+#     - name: main
+#       modules: [tabs, main]
+#     - name: sidebar
+#       modules: [search, site-card, tags, tools, toc]
 
 # Repository information used for internal linking of "report issue" etc.
 # repo:


### PR DESCRIPTION
## Summary
- document a manifest-driven theme architecture and update the runtime to build layouts from manifests
- convert the HTML shell and base styles to data-ns hooks so themes can swap layouts safely
- add manifests for native/github packs plus a new magazine theme and expose layout overrides in the site schema

## Testing
- No automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d8316a15408328b8781eb5eaa1082f