### PR TITLE
feat: redesign theme architecture

### DIFF
--- a/assets/js/theme-boot.js
+++ b/assets/js/theme-boot.js
@@ -16,7 +16,14 @@
   try {
     pack = String(pack || '').toLowerCase().trim().replace(/[^a-z0-9_-]/g, '') || 'native';
   } catch (_) { pack = 'native'; }
-  var href = 'assets/themes/' + encodeURIComponent(pack) + '/theme.css';
+  var primary = 'theme.css';
+  try {
+    var storedPrimary = localStorage.getItem('themePackPrimaryStyle');
+    if (storedPrimary) {
+      primary = String(storedPrimary || '').trim().replace(/[^a-zA-Z0-9_./-]/g, '') || 'theme.css';
+    }
+  } catch (_) { primary = 'theme.css'; }
+  var href = 'assets/themes/' + encodeURIComponent(pack) + '/' + encodeURIComponent(primary || 'theme.css');
   window.__themePackHref = href;
 
   // If the link tag exists already, set it; otherwise try briefly until it does

--- a/assets/js/theme-manager.js
+++ b/assets/js/theme-manager.js
@@ -1,0 +1,408 @@
+import { t, getLanguageLabel, getCurrentLang } from './i18n.js';
+
+const THEME_ROOT_ID = 'ns-app-root';
+const DEFAULT_TEMPLATE_ID = 'ns-default-layout';
+const PACK_LINK_ID = 'theme-pack';
+const EXTRA_STYLE_ATTR = 'data-theme-extra-style';
+const EXTRA_STYLE_PREFIX = 'theme-extra:';
+
+let activePack = null;
+let activeManifest = null;
+let activeHandlers = null;
+let themeContext = null;
+let lastSiteConfig = null;
+let applyToken = 0;
+const hydrators = new Set();
+let registryCache = null;
+
+export function sanitizePack(input) {
+  const s = String(input || '').toLowerCase().trim();
+  const clean = s.replace(/[^a-z0-9_-]/g, '');
+  return clean || 'native';
+}
+
+function sanitizeAssetPath(path) {
+  if (!path) return null;
+  const raw = String(path).trim();
+  if (!raw) return null;
+  if (raw.includes('..') || raw.includes('\\') || raw.startsWith('/')) return null;
+  const clean = raw.replace(/[^a-zA-Z0-9_./-]/g, '');
+  return clean || null;
+}
+
+function getThemeRoot() {
+  let el = document.getElementById(THEME_ROOT_ID);
+  if (!el) {
+    el = document.createElement('div');
+    el.id = THEME_ROOT_ID;
+    document.body.insertBefore(el, document.body.firstChild || null);
+  }
+  return el;
+}
+
+function getDefaultLayoutHtml() {
+  try {
+    const tpl = document.getElementById(DEFAULT_TEMPLATE_ID);
+    if (tpl && 'innerHTML' in tpl) {
+      const html = tpl.innerHTML.trim();
+      if (html) return html;
+    }
+  } catch (_) { /* ignore */ }
+  return `
+    <div class="container">
+      <div class="content">
+        <div class="box flex-split" id="mapview">
+          <nav class="tabs" id="tabsNav" aria-label="Sections"></nav>
+        </div>
+        <div class="box" id="mainview"></div>
+      </div>
+      <div class="sidebar">
+        <div class="box" id="searchbox">
+          <input id="searchInput" type="search">
+        </div>
+        <div class="box site-card">
+          <img class="avatar" alt="avatar" loading="lazy" decoding="async">
+          <h3 class="site-title"></h3>
+          <p class="site-subtitle"></p>
+          <hr class="site-hr">
+          <ul class="social-links"></ul>
+        </div>
+        <div class="box" id="tagview"></div>
+        <div class="box" id="tocview"></div>
+      </div>
+    </div>
+    <footer class="site-footer" role="contentinfo">
+      <div class="footer-inner">
+        <div class="footer-left">
+          <span class="footer-copy">© <span id="footerYear"></span> <span class="footer-site">NanoSite</span></span>
+          <span class="footer-sep">•</span>
+          <nav class="footer-nav" id="footerNav" aria-label="Footer"></nav>
+        </div>
+        <div class="footer-right">
+          <a href="#" class="top-link" id="footerTop">Top</a>
+        </div>
+      </div>
+    </footer>`;
+}
+
+async function loadThemeManifest(pack) {
+  const url = `assets/themes/${encodeURIComponent(pack)}/manifest.json`;
+  try {
+    const resp = await fetch(url, { cache: 'no-store' });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const data = await resp.json();
+    return normalizeManifest(data, pack);
+  } catch (err) {
+    console.warn(`[theme] Falling back to legacy manifest for pack "${pack}"`, err);
+    return {
+      name: pack,
+      version: 'legacy',
+      styles: ['theme.css'],
+      layout: null,
+      entry: null,
+      compatibilityMode: true
+    };
+  }
+}
+
+function normalizeManifest(manifest, pack) {
+  const result = { ...manifest };
+  if (!result || typeof result !== 'object') {
+    return {
+      name: pack,
+      version: 'legacy',
+      styles: ['theme.css'],
+      layout: null,
+      entry: null
+    };
+  }
+  if (!Array.isArray(result.styles)) {
+    const single = result.style || result.css || result.styles;
+    result.styles = single ? [single] : ['theme.css'];
+  }
+  result.styles = result.styles
+    .map(sanitizeAssetPath)
+    .filter(Boolean);
+  if (!result.styles.length) result.styles = ['theme.css'];
+  const layout = result.layout && typeof result.layout === 'object'
+    ? result.layout.template || result.layout.path || result.layout.file
+    : result.layout;
+  result.layout = sanitizeAssetPath(layout);
+  const entry = result.entry || result.module || result.script;
+  result.entry = sanitizeAssetPath(entry);
+  result.name = result.name || pack;
+  if (!result.version) result.version = '1.0.0';
+  return result;
+}
+
+function clearExtraStyleLinks() {
+  try {
+    const extras = document.querySelectorAll(`link[${EXTRA_STYLE_ATTR}]`);
+    extras.forEach(link => link.parentElement && link.parentElement.removeChild(link));
+  } catch (_) { /* noop */ }
+}
+
+function applyStyles(pack, manifest) {
+  const styles = Array.isArray(manifest.styles) && manifest.styles.length
+    ? manifest.styles.slice()
+    : ['theme.css'];
+  const [primary, ...rest] = styles;
+  const safePrimary = sanitizeAssetPath(primary) || 'theme.css';
+  const link = document.getElementById(PACK_LINK_ID);
+  const href = `assets/themes/${encodeURIComponent(pack)}/${encodeURIComponent(safePrimary)}`;
+  if (link) link.setAttribute('href', href);
+  clearExtraStyleLinks();
+  rest.forEach(path => {
+    const safe = sanitizeAssetPath(path);
+    if (!safe) return;
+    const extra = document.createElement('link');
+    extra.rel = 'stylesheet';
+    extra.href = `assets/themes/${encodeURIComponent(pack)}/${encodeURIComponent(safe)}`;
+    extra.setAttribute(EXTRA_STYLE_ATTR, `${EXTRA_STYLE_PREFIX}${pack}:${safe}`);
+    document.head.appendChild(extra);
+  });
+  try {
+    localStorage.setItem('themePackPrimaryStyle', safePrimary);
+  } catch (_) { /* ignore */ }
+}
+
+async function fetchLayoutHtml(pack, manifest) {
+  if (!manifest.layout) return getDefaultLayoutHtml();
+  const url = `assets/themes/${encodeURIComponent(pack)}/${manifest.layout}`;
+  try {
+    const resp = await fetch(url, { cache: 'no-store' });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    return await resp.text();
+  } catch (err) {
+    console.error(`[theme] Failed to load layout for pack "${pack}"`, err);
+    return getDefaultLayoutHtml();
+  }
+}
+
+function applyLayoutHtml(html) {
+  const root = getThemeRoot();
+  root.innerHTML = html;
+}
+
+function collectCoreElements(root) {
+  return {
+    container: root.querySelector('.container'),
+    content: root.querySelector('.content'),
+    sidebar: root.querySelector('.sidebar'),
+    mapview: root.querySelector('#mapview'),
+    tabsNav: root.querySelector('#tabsNav'),
+    mainview: root.querySelector('#mainview'),
+    searchbox: root.querySelector('#searchbox'),
+    searchInput: root.querySelector('#searchInput'),
+    siteCard: root.querySelector('.site-card'),
+    tagview: root.querySelector('#tagview'),
+    tocview: root.querySelector('#tocview'),
+    footer: document.querySelector('.site-footer')
+  };
+}
+
+function createContext(pack, manifest) {
+  const root = getThemeRoot();
+  const ctx = {
+    pack,
+    manifest,
+    root,
+    elements: {},
+    getSiteConfig: () => lastSiteConfig,
+    i18n: {
+      t,
+      getCurrentLang,
+      getLanguageLabel
+    }
+  };
+  return ctx;
+}
+
+function refreshContextElements(ctx) {
+  if (!ctx) return;
+  ctx.elements = collectCoreElements(ctx.root || getThemeRoot());
+}
+
+function safeInvoke(handler, payload) {
+  if (typeof handler !== 'function') return;
+  try {
+    const maybePromise = handler(payload, themeContext);
+    if (maybePromise && typeof maybePromise.then === 'function') {
+      maybePromise.catch(err => console.error('[theme] handler rejected', err));
+    }
+  } catch (err) {
+    console.error('[theme] handler error', err);
+  }
+}
+
+function runHydrators(ctx) {
+  hydrators.forEach(fn => {
+    try {
+      fn(ctx);
+    } catch (err) {
+      console.error('[theme] hydrator error', err);
+    }
+  });
+}
+
+async function setupThemeModule(pack, manifest, ctx) {
+  if (!manifest.entry) return null;
+  try {
+    const moduleUrl = new URL(`../themes/${pack}/${manifest.entry}`, import.meta.url);
+    moduleUrl.searchParams.set('v', manifest.version || Date.now().toString());
+    const mod = await import(moduleUrl.toString());
+    let handlers = {};
+    const candidate = mod && typeof mod.default !== 'undefined' ? mod.default : mod;
+    if (typeof candidate === 'function') {
+      const result = await candidate(ctx);
+      if (result && typeof result === 'object') handlers = { ...handlers, ...result };
+    } else if (candidate && typeof candidate === 'object') {
+      handlers = { ...candidate };
+    }
+    if (typeof mod.setup === 'function') {
+      const extra = await mod.setup(ctx);
+      if (extra && typeof extra === 'object') handlers = { ...handlers, ...extra };
+    }
+    const allowed = ['onReady', 'onSiteConfig', 'onRouteChange', 'onContentRendered', 'teardown'];
+    const normalized = {};
+    allowed.forEach(key => {
+      if (typeof handlers[key] === 'function') normalized[key] = handlers[key];
+      else if (typeof mod[key] === 'function') normalized[key] = mod[key];
+    });
+    return normalized;
+  } catch (err) {
+    console.error(`[theme] Failed to load enhancement script for pack "${pack}"`, err);
+    return null;
+  }
+}
+
+function cleanupActiveTheme() {
+  try {
+    safeInvoke(activeHandlers && activeHandlers.teardown, { pack: activePack });
+  } catch (_) { /* noop */ }
+  activeHandlers = null;
+  activeManifest = null;
+  activePack = null;
+  themeContext = null;
+}
+
+export function registerThemeHydrator(fn) {
+  if (typeof fn === 'function') hydrators.add(fn);
+}
+
+export function unregisterThemeHydrator(fn) {
+  if (hydrators.has(fn)) hydrators.delete(fn);
+}
+
+export async function applyThemePack(pack, options = {}) {
+  const sanitized = sanitizePack(pack);
+  const { persistSelection = false, force = false } = options;
+  if (persistSelection) {
+    try { localStorage.setItem('themePack', sanitized); } catch (_) { /* ignore */ }
+  }
+  if (!force && sanitized === activePack && themeContext) {
+    return themeContext;
+  }
+  const token = ++applyToken;
+  const manifest = await loadThemeManifest(sanitized);
+  if (token !== applyToken) return themeContext;
+  cleanupActiveTheme();
+  applyStyles(sanitized, manifest);
+  if (token !== applyToken) return themeContext;
+  const html = await fetchLayoutHtml(sanitized, manifest);
+  if (token !== applyToken) return themeContext;
+  applyLayoutHtml(html);
+  const ctx = createContext(sanitized, manifest);
+  document.body.setAttribute('data-theme-pack', sanitized);
+  ctx.root.dataset.themePack = sanitized;
+  refreshContextElements(ctx);
+  themeContext = ctx;
+  runHydrators(ctx);
+  refreshContextElements(ctx);
+  const handlers = await setupThemeModule(sanitized, manifest, ctx);
+  if (token !== applyToken) {
+    if (handlers && typeof handlers.teardown === 'function') {
+      try { handlers.teardown(ctx); } catch (_) { /* ignore */ }
+    }
+    return themeContext;
+  }
+  activePack = sanitized;
+  activeManifest = manifest;
+  activeHandlers = handlers;
+  if (handlers && typeof handlers.onReady === 'function') {
+    safeInvoke(handlers.onReady, { pack: sanitized, manifest });
+  }
+  return ctx;
+}
+
+export async function ensureInitialTheme(packHint) {
+  const saved = packHint ? sanitizePack(packHint) : getSavedThemePack();
+  const desired = saved || 'native';
+  return applyThemePack(desired, { persistSelection: false, force: true });
+}
+
+export function getSavedThemePack() {
+  try {
+    const stored = localStorage.getItem('themePack');
+    return sanitizePack(stored);
+  } catch (_) {
+    return 'native';
+  }
+}
+
+export function getActiveThemeInfo() {
+  return { pack: activePack, manifest: activeManifest, context: themeContext };
+}
+
+export function notifyThemeSiteConfig(cfg) {
+  lastSiteConfig = cfg || null;
+  if (activeHandlers && typeof activeHandlers.onSiteConfig === 'function') {
+    safeInvoke(activeHandlers.onSiteConfig, cfg);
+  }
+}
+
+export function notifyThemeRouteChange(route) {
+  if (activeHandlers && typeof activeHandlers.onRouteChange === 'function') {
+    safeInvoke(activeHandlers.onRouteChange, route);
+  }
+}
+
+export function notifyThemeContentRendered(payload) {
+  if (activeHandlers && typeof activeHandlers.onContentRendered === 'function') {
+    safeInvoke(activeHandlers.onContentRendered, payload);
+  }
+}
+
+export async function getThemeRegistry() {
+  if (registryCache) return registryCache;
+  try {
+    const resp = await fetch('assets/themes/packs.json', { cache: 'no-store' });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const data = await resp.json();
+    if (!Array.isArray(data)) throw new Error('Invalid registry payload');
+    registryCache = data.map(item => ({
+      value: sanitizePack(item && item.value),
+      label: (item && item.label) ? String(item.label) : sanitizePack(item && item.value),
+      description: item && item.description ? String(item.description) : ''
+    })).filter(entry => entry.value);
+  } catch (err) {
+    console.warn('[theme] Falling back to default registry', err);
+    registryCache = [
+      { value: 'native', label: 'Native', description: 'NanoSite minimal layout' },
+      { value: 'github', label: 'GitHub', description: 'GitHub-inspired presentation' }
+    ];
+  }
+  return registryCache;
+}
+
+export function resetThemeRegistryCache() {
+  registryCache = null;
+}
+
+export function getThemeContext() {
+  return themeContext;
+}
+
+export function getLastSiteConfig() {
+  return lastSiteConfig;
+}

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1198,6 +1198,7 @@ ul.collapsed, li > ul.collapsed { display: none; }
 /* Labeled tool items */
 #tools .tool-item { display:flex; flex-direction: column; gap: 0.375rem; min-width: 0; }
 #tools .tool-label { font-size: .78rem; color: var(--muted); letter-spacing: .02em; }
+#tools .tool-hint { font-size: .78rem; color: var(--muted); line-height: 1.45; margin: 0; }
 
 #tools .btn,
 #themeToggle.btn,

--- a/assets/themes/aurora/layout.html
+++ b/assets/themes/aurora/layout.html
@@ -1,0 +1,47 @@
+<div class="aurora-app container">
+  <header class="aurora-hero box">
+    <div class="aurora-identity site-card">
+      <div class="aurora-identity-main">
+        <img class="avatar" alt="avatar" loading="lazy" decoding="async">
+        <div class="aurora-identity-text">
+          <h3 class="site-title"></h3>
+          <p class="site-subtitle"></p>
+        </div>
+      </div>
+      <ul class="social-links"></ul>
+    </div>
+    <div class="aurora-hero-info">
+      <div class="aurora-status">
+        <span class="aurora-lang" data-lang-indicator></span>
+        <span class="aurora-route" data-route-label></span>
+      </div>
+      <div class="box aurora-search" id="searchbox">
+        <input id="searchInput" type="search">
+      </div>
+    </div>
+  </header>
+  <div class="box flex-split aurora-tabs" id="mapview">
+    <nav class="tabs" id="tabsNav" aria-label="Sections"></nav>
+  </div>
+  <div class="aurora-body">
+    <main class="content">
+      <div class="box" id="mainview"></div>
+    </main>
+    <aside class="sidebar aurora-sidebar">
+      <div class="box aurora-tags" id="tagview"></div>
+      <div class="box" id="tocview"></div>
+    </aside>
+  </div>
+</div>
+<footer class="site-footer" role="contentinfo">
+  <div class="footer-inner">
+    <div class="footer-left">
+      <span class="footer-copy">© <span id="footerYear"></span> <span class="footer-site">NanoSite</span></span>
+      <span class="footer-sep">•</span>
+      <nav class="footer-nav" id="footerNav" aria-label="Footer"></nav>
+    </div>
+    <div class="footer-right">
+      <a href="#" class="top-link" id="footerTop">Top</a>
+    </div>
+  </div>
+</footer>

--- a/assets/themes/aurora/manifest.json
+++ b/assets/themes/aurora/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Aurora",
+  "label": "Aurora",
+  "version": "1.0.0",
+  "styles": ["theme.css"],
+  "layout": "layout.html",
+  "entry": "theme.js",
+  "description": "Editorial layout with hero header and responsive sidebar"
+}

--- a/assets/themes/aurora/theme.css
+++ b/assets/themes/aurora/theme.css
@@ -1,0 +1,207 @@
+body[data-theme-pack="aurora"] {
+  background: radial-gradient(60rem 30rem at 20% -10%, rgba(129, 140, 248, 0.25), transparent 60%),
+    radial-gradient(40rem 20rem at 80% 0%, rgba(45, 212, 191, 0.2), transparent 70%),
+    var(--bg);
+}
+
+body[data-theme-pack="aurora"] .aurora-app.container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-width: 72rem;
+  padding-inline: 1.5rem;
+}
+
+body[data-theme-pack="aurora"] .aurora-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(16rem, 20rem);
+  gap: 1.5rem;
+  border: none;
+  color: #0f172a;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.15), rgba(16, 185, 129, 0.15));
+  box-shadow: 0 1.5rem 3.5rem -2rem rgba(37, 99, 235, 0.45);
+  border-radius: 1.5rem;
+}
+
+html[data-theme="dark"] body[data-theme-pack="aurora"] .aurora-hero {
+  color: #e2e8f0;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.35), rgba(16, 185, 129, 0.25));
+  box-shadow: 0 1.5rem 3.5rem -2rem rgba(14, 165, 233, 0.4);
+}
+
+body[data-theme-pack="aurora"] .aurora-identity {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+}
+
+body[data-theme-pack="aurora"] .aurora-identity-main {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+body[data-theme-pack="aurora"] .aurora-identity .avatar {
+  width: 4.5rem;
+  height: 4.5rem;
+  border-radius: 1.25rem;
+  box-shadow: 0 1rem 2.5rem -1.5rem rgba(15, 23, 42, 0.8);
+}
+
+body[data-theme-pack="aurora"] .aurora-identity-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+body[data-theme-pack="aurora"] .aurora-identity .site-title {
+  font-size: 1.65rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+body[data-theme-pack="aurora"] .aurora-identity .site-subtitle {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+html[data-theme="dark"] body[data-theme-pack="aurora"] .aurora-identity .site-subtitle {
+  color: rgba(226, 232, 240, 0.75);
+}
+
+body[data-theme-pack="aurora"] .aurora-identity .social-links {
+  margin-top: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding-left: 0;
+  list-style: none;
+}
+
+body[data-theme-pack="aurora"] .aurora-hero-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+body[data-theme-pack="aurora"] .aurora-status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+body[data-theme-pack="aurora"] .aurora-status span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  color: inherit;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
+}
+
+html[data-theme="dark"] body[data-theme-pack="aurora"] .aurora-status span {
+  background: rgba(226, 232, 240, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(226, 232, 240, 0.12);
+}
+
+body[data-theme-pack="aurora"] .aurora-search {
+  border: none;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 1rem 2.5rem -1.75rem rgba(15, 23, 42, 0.4);
+}
+
+html[data-theme="dark"] body[data-theme-pack="aurora"] .aurora-search {
+  background: rgba(15, 23, 42, 0.65);
+  box-shadow: 0 1rem 2.5rem -1.5rem rgba(15, 23, 42, 0.75);
+}
+
+body[data-theme-pack="aurora"] .aurora-search input {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1rem;
+}
+
+body[data-theme-pack="aurora"] .aurora-tabs {
+  border: none;
+  background: rgba(15, 23, 42, 0.04);
+  backdrop-filter: blur(18px);
+}
+
+html[data-theme="dark"] body[data-theme-pack="aurora"] .aurora-tabs {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+body[data-theme-pack="aurora"] .aurora-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(17rem, 20rem);
+  gap: 1.5rem;
+}
+
+body[data-theme-pack="aurora"] .aurora-sidebar {
+  display: flex;
+  flex-direction: column;
+}
+
+body[data-theme-pack="aurora"] .aurora-sidebar .box {
+  border-radius: 1.25rem;
+}
+
+body[data-theme-pack="aurora"] .aurora-tags {
+  order: -1;
+}
+
+body[data-theme-pack="aurora"] #mainview.aurora-pulse {
+  animation: auroraPulse 0.45s ease;
+}
+
+@keyframes auroraPulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.35);
+  }
+  100% {
+    box-shadow: 0 0 0 1.5rem rgba(59, 130, 246, 0);
+  }
+}
+
+body[data-theme-pack="aurora"] .site-footer {
+  margin-top: 3rem;
+  border-radius: 1.5rem;
+  box-shadow: 0 1.25rem 3rem -2rem rgba(15, 23, 42, 0.2);
+}
+
+html[data-theme="dark"] body[data-theme-pack="aurora"] .site-footer {
+  box-shadow: 0 1.25rem 3rem -2rem rgba(15, 23, 42, 0.5);
+}
+
+@media (max-width: 960px) {
+  body[data-theme-pack="aurora"] .aurora-hero {
+    grid-template-columns: 1fr;
+  }
+  body[data-theme-pack="aurora"] .aurora-body {
+    grid-template-columns: 1fr;
+  }
+  body[data-theme-pack="aurora"] .aurora-sidebar {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 640px) {
+  body[data-theme-pack="aurora"] .aurora-app.container {
+    padding-inline: 1rem;
+  }
+  body[data-theme-pack="aurora"] .aurora-status {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  body[data-theme-pack="aurora"] .aurora-search {
+    padding: 0.85rem;
+  }
+}

--- a/assets/themes/aurora/theme.js
+++ b/assets/themes/aurora/theme.js
@@ -1,0 +1,74 @@
+export default function registerAuroraTheme(context) {
+  const { root, i18n } = context || {};
+  const langBadge = root ? root.querySelector('[data-lang-indicator]') : null;
+  const routeBadge = root ? root.querySelector('[data-route-label]') : null;
+  const getLabel = (view) => {
+    const safeView = view || '';
+    const tryT = (key, fallback) => {
+      if (!i18n || typeof i18n.t !== 'function') return fallback;
+      try {
+        const val = i18n.t(key);
+        return (val && val !== key) ? val : fallback;
+      } catch (_) { return fallback; }
+    };
+    if (safeView === 'posts') return tryT('ui.allPosts', 'Posts');
+    if (safeView === 'post') return tryT('ui.article', 'Article');
+    if (safeView === 'tab') return tryT('ui.page', 'Page');
+    if (safeView === 'search') return tryT('ui.searchTab', 'Search');
+    return safeView;
+  };
+
+  const formatLang = () => {
+    if (!langBadge || !i18n) return;
+    const code = (i18n.getCurrentLang && i18n.getCurrentLang()) || 'en';
+    const label = (i18n.getLanguageLabel && i18n.getLanguageLabel(code)) || code.toUpperCase();
+    langBadge.textContent = label;
+  };
+
+  const formatRoute = (route) => {
+    if (!routeBadge) return;
+    if (!route || typeof route !== 'object') {
+      routeBadge.textContent = '';
+      return;
+    }
+    const view = route.view || 'posts';
+    const label = getLabel(view);
+    let extra = '';
+    if (view === 'tab' && route.title) extra = route.title;
+    if (view === 'post' && route.title) extra = route.title;
+    if (view === 'search' && route.q) extra = route.q;
+    routeBadge.textContent = extra ? `${label}: ${extra}` : label;
+    try {
+      root.dataset.routeView = view;
+    } catch (_) {}
+  };
+
+  const pulseMain = (payload) => {
+    try {
+      const el = payload && payload.element ? payload.element : document.getElementById('mainview');
+      if (!el) return;
+      el.classList.remove('aurora-pulse');
+      void el.offsetWidth;
+      el.classList.add('aurora-pulse');
+      setTimeout(() => el.classList.remove('aurora-pulse'), 400);
+    } catch (_) {}
+  };
+
+  return {
+    onReady() {
+      formatLang();
+    },
+    onSiteConfig() {
+      formatLang();
+    },
+    onRouteChange(route) {
+      formatRoute(route);
+    },
+    onContentRendered(payload) {
+      pulseMain(payload);
+      if (payload && payload.route) formatRoute(payload.route);
+      else if (payload && payload.view) formatRoute({ view: payload.view });
+      formatLang();
+    }
+  };
+}

--- a/assets/themes/github/layout.html
+++ b/assets/themes/github/layout.html
@@ -1,0 +1,34 @@
+<div class="container">
+  <div class="content">
+    <div class="box flex-split" id="mapview">
+      <nav class="tabs" id="tabsNav" aria-label="Sections"></nav>
+    </div>
+    <div class="box" id="mainview"></div>
+  </div>
+  <div class="sidebar">
+    <div class="box" id="searchbox">
+      <input id="searchInput" type="search">
+    </div>
+    <div class="box site-card">
+      <img class="avatar" alt="avatar" loading="lazy" decoding="async">
+      <h3 class="site-title"></h3>
+      <p class="site-subtitle"></p>
+      <hr class="site-hr">
+      <ul class="social-links"></ul>
+    </div>
+    <div class="box" id="tagview"></div>
+    <div class="box" id="tocview"></div>
+  </div>
+</div>
+<footer class="site-footer" role="contentinfo">
+  <div class="footer-inner">
+    <div class="footer-left">
+      <span class="footer-copy">© <span id="footerYear"></span> <span class="footer-site">NanoSite</span></span>
+      <span class="footer-sep">•</span>
+      <nav class="footer-nav" id="footerNav" aria-label="Footer"></nav>
+    </div>
+    <div class="footer-right">
+      <a href="#" class="top-link" id="footerTop">Top</a>
+    </div>
+  </div>
+</footer>

--- a/assets/themes/github/manifest.json
+++ b/assets/themes/github/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "GitHub",
+  "label": "GitHub",
+  "version": "1.1.0",
+  "styles": ["theme.css"],
+  "layout": "layout.html",
+  "description": "GitHub-inspired presentation"
+}

--- a/assets/themes/native/layout.html
+++ b/assets/themes/native/layout.html
@@ -1,0 +1,34 @@
+<div class="container">
+  <div class="content">
+    <div class="box flex-split" id="mapview">
+      <nav class="tabs" id="tabsNav" aria-label="Sections"></nav>
+    </div>
+    <div class="box" id="mainview"></div>
+  </div>
+  <div class="sidebar">
+    <div class="box" id="searchbox">
+      <input id="searchInput" type="search">
+    </div>
+    <div class="box site-card">
+      <img class="avatar" alt="avatar" loading="lazy" decoding="async">
+      <h3 class="site-title"></h3>
+      <p class="site-subtitle"></p>
+      <hr class="site-hr">
+      <ul class="social-links"></ul>
+    </div>
+    <div class="box" id="tagview"></div>
+    <div class="box" id="tocview"></div>
+  </div>
+</div>
+<footer class="site-footer" role="contentinfo">
+  <div class="footer-inner">
+    <div class="footer-left">
+      <span class="footer-copy">© <span id="footerYear"></span> <span class="footer-site">NanoSite</span></span>
+      <span class="footer-sep">•</span>
+      <nav class="footer-nav" id="footerNav" aria-label="Footer"></nav>
+    </div>
+    <div class="footer-right">
+      <a href="#" class="top-link" id="footerTop">Top</a>
+    </div>
+  </div>
+</footer>

--- a/assets/themes/native/manifest.json
+++ b/assets/themes/native/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "Native",
+  "label": "Native",
+  "version": "1.1.0",
+  "styles": ["theme.css"],
+  "layout": "layout.html",
+  "description": "NanoSite minimal layout"
+}

--- a/assets/themes/packs.json
+++ b/assets/themes/packs.json
@@ -1,4 +1,5 @@
 [
-  { "value": "native", "label": "Native" },
-  { "value": "github", "label": "GitHub" }
+  { "value": "native", "label": "Native", "description": "NanoSite minimal layout" },
+  { "value": "github", "label": "GitHub", "description": "GitHub-inspired presentation" },
+  { "value": "aurora", "label": "Aurora", "description": "Editorial layout with hero header" }
 ]

--- a/index.html
+++ b/index.html
@@ -21,58 +21,62 @@
 </head>
 
 <body>
-  <div class="container">
-    <div class="content">
-
-      <!-- Navigator Bar -->
-      <div class="box flex-split" id="mapview">
-        <nav class="tabs" id="tabsNav" aria-label="Sections"></nav>
-      </div>
-
-      <!-- Main content -->
-      <div class="box" id="mainview">
-      </div>
-    </div>
-    <div class="sidebar">
-
-      <!-- Search -->
-      <div class="box" id="searchbox">
-        <input id="searchInput" type="search">
-      </div>
-
-      <!-- Site Card -->
-      <div class="box site-card">
-        <img class="avatar" alt="avatar" loading="lazy" decoding="async">
-        <h3 class="site-title"></h3>
-        <p class="site-subtitle"></p>
-        <hr class="site-hr">
-        <ul class="social-links">
-        </ul>
-      </div>
-
-  <!-- Tags Filter -->
-  <div class="box" id="tagview"></div>
-
-      <!-- Tools box is rendered by JS (theme.js) -->
-
-      <!-- Page of Content for Posts -->
-      <div class="box" id="tocview"></div>
-    </div>
+  <div id="ns-app-root" data-theme-root>
+    <!-- The active theme will render its layout into this container. -->
   </div>
 
-  <!-- Site Footer -->
-  <footer class="site-footer" role="contentinfo">
-    <div class="footer-inner">
-      <div class="footer-left">
-        <span class="footer-copy">© <span id="footerYear"></span> <span class="footer-site">NanoSite</span></span>
-        <span class="footer-sep">•</span>
-        <nav class="footer-nav" id="footerNav" aria-label="Footer"></nav>
+  <template id="ns-default-layout">
+    <div class="container">
+      <div class="content">
+
+        <!-- Navigator Bar -->
+        <div class="box flex-split" id="mapview">
+          <nav class="tabs" id="tabsNav" aria-label="Sections"></nav>
+        </div>
+
+        <!-- Main content -->
+        <div class="box" id="mainview"></div>
       </div>
-      <div class="footer-right">
-        <a href="#" class="top-link" id="footerTop">Top</a>
+      <div class="sidebar">
+
+        <!-- Search -->
+        <div class="box" id="searchbox">
+          <input id="searchInput" type="search">
+        </div>
+
+        <!-- Site Card -->
+        <div class="box site-card">
+          <img class="avatar" alt="avatar" loading="lazy" decoding="async">
+          <h3 class="site-title"></h3>
+          <p class="site-subtitle"></p>
+          <hr class="site-hr">
+          <ul class="social-links"></ul>
+        </div>
+
+        <!-- Tags Filter -->
+        <div class="box" id="tagview"></div>
+
+        <!-- Tools box is rendered by JS (theme.js) -->
+
+        <!-- Page of Content for Posts -->
+        <div class="box" id="tocview"></div>
       </div>
     </div>
-  </footer>
+
+    <!-- Site Footer -->
+    <footer class="site-footer" role="contentinfo">
+      <div class="footer-inner">
+        <div class="footer-left">
+          <span class="footer-copy">© <span id="footerYear"></span> <span class="footer-site">NanoSite</span></span>
+          <span class="footer-sep">•</span>
+          <nav class="footer-nav" id="footerNav" aria-label="Footer"></nav>
+        </div>
+        <div class="footer-right">
+          <a href="#" class="top-link" id="footerTop">Top</a>
+        </div>
+      </div>
+    </footer>
+  </template>
 
   <script type="module" src="assets/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add a dedicated theme manager that loads manifests, layouts, styles and lifecycle hooks
- update the boot flow to await theme preparation, rehydrate sidebar controls and surface theme notifications
- ship manifests/layouts for existing packs and introduce the Aurora sample theme showcasing layout and scripting

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68d838f7391c8328bc2c2e6e11c3424c