### PR TITLE
Refactor theme system and add Nocturne layout

### DIFF
--- a/assets/js/theme-boot.js
+++ b/assets/js/theme-boot.js
@@ -17,6 +17,7 @@
     pack = String(pack || '').toLowerCase().trim().replace(/[^a-z0-9_-]/g, '') || 'native';
   } catch (_) { pack = 'native'; }
   var href = 'assets/themes/' + encodeURIComponent(pack) + '/theme.css';
+  try { document.documentElement.setAttribute('data-theme-pack', pack); } catch (_) {}
   window.__themePackHref = href;
 
   // If the link tag exists already, set it; otherwise try briefly until it does

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -2,11 +2,273 @@ import { t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage 
 
 const PACK_LINK_ID = 'theme-pack';
 
+let themeEventTarget;
+try {
+  themeEventTarget = window.__ns_themeEvents || new EventTarget();
+  window.__ns_themeEvents = themeEventTarget;
+} catch (_) {
+  themeEventTarget = new EventTarget();
+}
+
+const manifestCache = new Map();
+let activeThemeRuntime = null;
+let activeSiteConfig = null;
+let activePackToken = 0;
+
 // Restrict theme pack names to safe slug format and default to 'native'.
 function sanitizePack(input) {
   const s = String(input || '').toLowerCase().trim();
   const clean = s.replace(/[^a-z0-9_-]/g, '');
   return clean || 'native';
+}
+
+function createCleanupStack() {
+  const stack = [];
+  return {
+    push(fn) {
+      if (typeof fn === 'function') stack.push(fn);
+    },
+    run() {
+      while (stack.length) {
+        const fn = stack.pop();
+        try { fn(); } catch (_) { /* noop */ }
+      }
+    }
+  };
+}
+
+function rememberPlacement(el) {
+  if (!el || !el.parentNode) return null;
+  return { el, parent: el.parentNode, next: el.nextSibling };
+}
+
+function restorePlacement(record) {
+  if (!record || !record.parent) return;
+  const { parent, next, el } = record;
+  if (!parent) return;
+  if (next && next.parentNode === parent) parent.insertBefore(el, next);
+  else parent.appendChild(el);
+}
+
+function createLayoutHelper(stack) {
+  return {
+    move(el, target, { position = 'append' } = {}) {
+      if (!el || !target) return;
+      const placement = rememberPlacement(el);
+      if (!placement || !placement.parent) return;
+      stack.push(() => restorePlacement(placement));
+      if (position === 'prepend') target.insertBefore(el, target.firstChild);
+      else target.appendChild(el);
+    },
+    before(el, reference) {
+      if (!el || !reference || !reference.parentNode) return;
+      const placement = rememberPlacement(el);
+      if (!placement || !placement.parent) return;
+      stack.push(() => restorePlacement(placement));
+      reference.parentNode.insertBefore(el, reference);
+    },
+    after(el, reference) {
+      if (!el || !reference || !reference.parentNode) return;
+      const placement = rememberPlacement(el);
+      if (!placement || !placement.parent) return;
+      stack.push(() => restorePlacement(placement));
+      reference.parentNode.insertBefore(el, reference.nextSibling);
+    },
+    wrap(el, wrapper) {
+      if (!el || !wrapper) return null;
+      const placement = rememberPlacement(el);
+      if (!placement || !placement.parent) return null;
+      const parent = placement.parent;
+      stack.push(() => {
+        restorePlacement(placement);
+        if (wrapper.parentNode) wrapper.parentNode.removeChild(wrapper);
+      });
+      parent.insertBefore(wrapper, placement.next);
+      wrapper.appendChild(el);
+      return wrapper;
+    }
+  };
+}
+
+function getLocalizedValue(value, fallback = '') {
+  if (value == null) return fallback;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'object') {
+    try {
+      const lang = getCurrentLang && getCurrentLang();
+      if (lang && Object.prototype.hasOwnProperty.call(value, lang)) {
+        const v = value[lang];
+        if (typeof v === 'string') return v;
+      }
+      if (Object.prototype.hasOwnProperty.call(value, 'default')) {
+        const dv = value.default;
+        if (typeof dv === 'string') return dv;
+      }
+      const keys = Object.keys(value);
+      for (let i = 0; i < keys.length; i += 1) {
+        const k = keys[i];
+        const v = value[k];
+        if (typeof v === 'string') return v;
+      }
+    } catch (_) {
+      return fallback;
+    }
+  }
+  return fallback;
+}
+
+function createThemeContext(pack, manifest) {
+  const stack = createCleanupStack();
+  const doc = (typeof document !== 'undefined') ? document : null;
+  const root = doc ? doc.documentElement : null;
+  const body = doc ? doc.body : null;
+  const container = doc ? doc.querySelector('.container') : null;
+  const context = {
+    pack,
+    manifest,
+    document: doc,
+    window: (typeof window !== 'undefined') ? window : null,
+    root,
+    body,
+    container,
+    content: container ? container.querySelector('.content') : (doc ? doc.querySelector('.content') : null),
+    sidebar: container ? container.querySelector('.sidebar') : (doc ? doc.querySelector('.sidebar') : null),
+    main: doc ? doc.getElementById('mainview') : null,
+    nav: doc ? doc.getElementById('tabsNav') : null,
+    toc: doc ? doc.getElementById('tocview') : null,
+    tags: doc ? doc.getElementById('tagview') : null,
+    tools: doc ? doc.getElementById('tools') : null,
+    registerCleanup(fn) { stack.push(fn); },
+    addBodyClass(cls) {
+      if (body && cls) {
+        body.classList.add(cls);
+        stack.push(() => body.classList.remove(cls));
+      }
+    },
+    addRootClass(cls) {
+      if (root && cls) {
+        root.classList.add(cls);
+        stack.push(() => root.classList.remove(cls));
+      }
+    },
+    setRootAttribute(name, value) {
+      if (!root || !name) return;
+      const prev = root.getAttribute(name);
+      if (value === null || value === undefined) root.removeAttribute(name);
+      else root.setAttribute(name, String(value));
+      stack.push(() => {
+        if (prev === null || prev === undefined) root.removeAttribute(name);
+        else root.setAttribute(name, prev);
+      });
+    },
+    layout: createLayoutHelper(stack),
+    events: {
+      on(eventName, handler, options) {
+        if (!eventName || typeof handler !== 'function') return;
+        const listener = (evt) => {
+          try { handler(evt?.detail, evt); } catch (_) { /* swallow */ }
+        };
+        themeEventTarget.addEventListener(eventName, listener, options);
+        stack.push(() => themeEventTarget.removeEventListener(eventName, listener, options));
+      },
+      emit(eventName, detail) {
+        if (!eventName) return;
+        try { themeEventTarget.dispatchEvent(new CustomEvent(eventName, { detail })); } catch (_) { /* noop */ }
+      }
+    },
+    getLocalized(value, fallback = '') {
+      return getLocalizedValue(value, fallback);
+    },
+    site: {
+      getConfig: () => activeSiteConfig
+    }
+  };
+  return { context, cleanup: () => stack.run() };
+}
+
+function cleanupRuntime(runtime) {
+  if (!runtime) return;
+  try {
+    if (runtime.controller && typeof runtime.controller.deactivate === 'function') {
+      runtime.controller.deactivate();
+    }
+  } catch (_) { /* ignore deactivate errors */ }
+  try { if (typeof runtime.cleanup === 'function') runtime.cleanup(); } catch (_) { /* ignore cleanup errors */ }
+}
+
+async function fetchManifest(pack) {
+  if (!pack) return null;
+  if (manifestCache.has(pack)) return manifestCache.get(pack);
+  const url = `assets/themes/${encodeURIComponent(pack)}/manifest.json`;
+  const resp = await fetch(url, { cache: 'no-store' });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  const json = await resp.json();
+  manifestCache.set(pack, json);
+  return json;
+}
+
+async function activateRuntime(pack) {
+  const manifest = await fetchManifest(pack).catch(() => null);
+  const { context, cleanup } = createThemeContext(pack, manifest || {});
+  let controller = null;
+  if (manifest && manifest.entry) {
+    const base = `../themes/${encodeURIComponent(pack)}/${manifest.entry}`;
+    const cacheBust = manifest.version ? `?v=${encodeURIComponent(manifest.version)}` : `?v=${Date.now()}`;
+    try {
+      const module = await import(`${base}${cacheBust}`);
+      const activator = (module && module.activate)
+        || (module && module.default && typeof module.default === 'function' ? module.default : null)
+        || (module && module.default && typeof module.default.activate === 'function' ? module.default.activate : null);
+      if (typeof activator === 'function') {
+        const result = await activator(context);
+        if (result && typeof result === 'object') controller = result;
+      }
+    } catch (err) {
+      console.warn('[NanoSite] Failed to initialize theme runtime', err);
+      themeEventTarget.dispatchEvent(new CustomEvent('theme:error', { detail: { pack, error: err } }));
+    }
+  }
+  return { pack, manifest, context, controller, cleanup };
+}
+
+function applySiteConfigToRuntime(runtime, cfg) {
+  if (!runtime || !runtime.controller || typeof runtime.controller.applySiteConfig !== 'function') return;
+  try { runtime.controller.applySiteConfig(cfg); } catch (_) { /* ignore */ }
+}
+
+function setActiveSiteConfig(cfg) {
+  activeSiteConfig = cfg || null;
+  applySiteConfigToRuntime(activeThemeRuntime, activeSiteConfig);
+  notifyThemeRuntime('site:config', activeSiteConfig);
+}
+
+function enrichThemeOptions(selectEl) {
+  if (!selectEl) return;
+  const options = Array.from(selectEl.options || []);
+  options.forEach((opt) => {
+    const pack = sanitizePack(opt.value);
+    fetchManifest(pack).then((manifest) => {
+      if (!manifest) return;
+      try {
+        if (manifest.name && typeof manifest.name === 'string') {
+          const name = manifest.name.trim();
+          if (name) opt.textContent = name;
+        }
+        if (manifest.description && typeof manifest.description === 'string') {
+          const desc = manifest.description.trim();
+          if (desc) opt.setAttribute('title', desc);
+        }
+      } catch (_) { /* ignore option enrich errors */ }
+    }).catch(() => {});
+  });
+}
+
+export function notifyThemeRuntime(eventName, detail) {
+  if (!eventName) return;
+  try { themeEventTarget.dispatchEvent(new CustomEvent(eventName, { detail })); } catch (_) { /* ignore */ }
+  const runtime = activeThemeRuntime;
+  if (!runtime || !runtime.controller || typeof runtime.controller.handleEvent !== 'function') return;
+  try { runtime.controller.handleEvent(eventName, detail); } catch (_) { /* ignore handler errors */ }
 }
 
 export function loadThemePack(name) {
@@ -15,6 +277,28 @@ export function loadThemePack(name) {
   const link = document.getElementById(PACK_LINK_ID);
   const href = `assets/themes/${encodeURIComponent(pack)}/theme.css`;
   if (link) link.setAttribute('href', href);
+  try { document.documentElement.setAttribute('data-theme-pack', pack); } catch (_) { /* ignore */ }
+
+  const token = ++activePackToken;
+  const previous = activeThemeRuntime ? activeThemeRuntime.pack : null;
+  notifyThemeRuntime('theme:will-activate', { next: pack, previous });
+  cleanupRuntime(activeThemeRuntime);
+  activeThemeRuntime = null;
+
+  const promise = activateRuntime(pack).then((runtime) => {
+    if (token !== activePackToken) {
+      cleanupRuntime(runtime);
+      return;
+    }
+    activeThemeRuntime = runtime;
+    applySiteConfigToRuntime(activeThemeRuntime, activeSiteConfig);
+    notifyThemeRuntime('theme:activated', { pack, manifest: runtime ? runtime.manifest : null });
+  }).catch((err) => {
+    console.warn('[NanoSite] Failed to load theme pack', err);
+    notifyThemeRuntime('theme:error', { pack, error: err });
+  });
+
+  return promise;
 }
 
 export function getSavedThemePack() {
@@ -83,6 +367,8 @@ export function applyThemeConfig(siteConfig) {
     }
     if (!hasUserPack && pack) loadThemePack(pack);
   }
+
+  setActiveSiteConfig(cfg);
 }
 
 export function bindThemeToggle() {
@@ -111,8 +397,10 @@ export function bindThemePackPicker() {
   // Initialize selection
   const saved = getSavedThemePack();
   sel.value = saved;
+  enrichThemeOptions(sel);
   sel.addEventListener('change', () => {
     const val = sanitizePack(sel.value) || 'native';
+    sel.value = val;
     loadThemePack(val);
   });
 }
@@ -188,6 +476,7 @@ export function mountThemeControls() {
     });
   }).finally(() => {
     sel.value = saved;
+    enrichThemeOptions(sel);
   });
 
   // Populate language selector

--- a/assets/themes/native/manifest.json
+++ b/assets/themes/native/manifest.json
@@ -1,0 +1,7 @@
+{
+  "id": "native",
+  "name": "Native Classic",
+  "description": "Original NanoSite two-column layout with balanced cards and serif reading experience.",
+  "version": "1.0.0",
+  "entry": "runtime.js"
+}

--- a/assets/themes/native/runtime.js
+++ b/assets/themes/native/runtime.js
@@ -1,0 +1,18 @@
+export function activate(context) {
+  if (!context) return {};
+  const { addBodyClass, registerCleanup, root } = context;
+  addBodyClass('theme-native-active');
+  if (root) {
+    root.setAttribute('data-theme-shell', 'two-column');
+    registerCleanup(() => {
+      if (root.getAttribute('data-theme-shell') === 'two-column') {
+        root.removeAttribute('data-theme-shell');
+      }
+    });
+  }
+
+  return {
+    applySiteConfig() {},
+    deactivate() {}
+  };
+}

--- a/assets/themes/nocturne/manifest.json
+++ b/assets/themes/nocturne/manifest.json
@@ -1,0 +1,7 @@
+{
+  "id": "nocturne",
+  "name": "Nocturne Atelier",
+  "description": "Moody night-owl layout with immersive hero, left rail navigation, and golden accents inspired by mcyoun's blog style.",
+  "version": "1.0.0",
+  "entry": "runtime.js"
+}

--- a/assets/themes/nocturne/runtime.js
+++ b/assets/themes/nocturne/runtime.js
@@ -1,0 +1,113 @@
+function firstCharacter(text, fallback = 'N') {
+  if (!text) return fallback;
+  try {
+    const chars = Array.from(String(text).trim());
+    if (chars.length) return chars[0].toUpperCase();
+  } catch (_) { /* ignore */ }
+  return fallback;
+}
+
+function describeRoute(detail) {
+  if (!detail) return { type: 'OVERVIEW', label: 'All content' };
+  const type = (detail.type || detail.view || '').toString().trim().toUpperCase() || 'VIEW';
+  let label = '';
+  if (detail.type === 'post' || detail.view === 'post') {
+    label = detail.title || (detail.metadata && detail.metadata.title) || (detail.metadata && detail.metadata.location) || 'Post';
+  } else if (detail.type === 'search' || detail.view === 'search') {
+    if (detail.tag) label = `Tag · ${detail.tag}`;
+    else if (detail.query) label = `Search · ${detail.query}`;
+    else label = 'Search results';
+  } else if (detail.type === 'index' || detail.view === 'posts') {
+    label = detail.title || 'All posts';
+  } else if (detail.type === 'tab' || detail.view === 'tab') {
+    label = detail.title || detail.slug || 'Page';
+  } else if (detail.type === 'error') {
+    label = detail.label || 'Something went wrong';
+  }
+  return { type, label: label || type.charAt(0) + type.slice(1).toLowerCase() };
+}
+
+export function activate(context) {
+  if (!context) return {};
+  const { addBodyClass, registerCleanup, container, sidebar, content, layout, root } = context;
+  addBodyClass('theme-nocturne');
+  if (root) {
+    root.setAttribute('data-theme-shell', 'nocturne');
+    registerCleanup(() => {
+      if (root.getAttribute('data-theme-shell') === 'nocturne') root.removeAttribute('data-theme-shell');
+    });
+  }
+
+  const hero = document.createElement('header');
+  hero.className = 'nocturne-hero';
+  hero.innerHTML = `
+    <div class="nocturne-brand">
+      <div class="nocturne-brand-mark" aria-hidden="true"></div>
+      <div class="nocturne-brand-copy">
+        <div class="nocturne-brand-title"></div>
+        <div class="nocturne-brand-subtitle"></div>
+      </div>
+    </div>
+    <div class="nocturne-route">
+      <span class="nocturne-route-type"></span>
+      <span class="nocturne-route-label"></span>
+    </div>`;
+  const parent = container && container.parentNode;
+  if (parent) parent.insertBefore(hero, container);
+  registerCleanup(() => { hero.remove(); });
+
+  const grid = document.createElement('div');
+  grid.className = 'nocturne-grid';
+  if (container) container.appendChild(grid);
+  registerCleanup(() => { grid.remove(); });
+
+  const asideShell = document.createElement('aside');
+  asideShell.className = 'nocturne-aside';
+  const mainShell = document.createElement('div');
+  mainShell.className = 'nocturne-main';
+  grid.appendChild(asideShell);
+  grid.appendChild(mainShell);
+
+  if (sidebar) layout.move(sidebar, asideShell);
+  if (content) layout.move(content, mainShell);
+
+  const brandMark = hero.querySelector('.nocturne-brand-mark');
+  const brandTitle = hero.querySelector('.nocturne-brand-title');
+  const brandSubtitle = hero.querySelector('.nocturne-brand-subtitle');
+  const routeType = hero.querySelector('.nocturne-route-type');
+  const routeLabel = hero.querySelector('.nocturne-route-label');
+
+  const applySite = (cfg) => {
+    const title = context.getLocalized(cfg && cfg.siteTitle, 'NanoSite');
+    const subtitle = context.getLocalized(cfg && cfg.siteDescription, 'A zero-build publishing system.');
+    if (brandTitle) brandTitle.textContent = title || 'NanoSite';
+    if (brandSubtitle) brandSubtitle.textContent = subtitle;
+    if (brandMark) brandMark.textContent = firstCharacter(title, 'N');
+  };
+
+  const applyRoute = (detail) => {
+    const { type, label } = describeRoute(detail || {});
+    if (routeType) routeType.textContent = type;
+    if (routeLabel) routeLabel.textContent = label;
+  };
+
+  applySite(context.site && typeof context.site.getConfig === 'function' ? context.site.getConfig() : null);
+  applyRoute(null);
+
+  return {
+    applySiteConfig: applySite,
+    handleEvent(eventName, detail) {
+      if (eventName === 'content:rendered') {
+        applyRoute(detail);
+      } else if (eventName === 'content:error') {
+        applyRoute({ type: 'error', label: 'Unavailable' });
+      } else if (eventName === 'route:change') {
+        applyRoute(detail);
+      }
+    },
+    deactivate() {
+      if (routeType) routeType.textContent = '';
+      if (routeLabel) routeLabel.textContent = '';
+    }
+  };
+}

--- a/assets/themes/nocturne/theme.css
+++ b/assets/themes/nocturne/theme.css
@@ -1,0 +1,381 @@
+:root {
+  --bg: #0b0d14;
+  --bg-accent: rgba(245, 209, 113, 0.12);
+  --text: #f3f5ff;
+  --muted: #8b90a8;
+  --primary: #f5d171;
+  --primary-hover: #f8e6a0;
+  --card: rgba(16, 18, 27, 0.92);
+  --border: rgba(255, 255, 255, 0.08);
+  --code-bg: #0b0e17;
+  --code-text: #f7faff;
+  --shadow: 0 28px 64px rgba(4, 6, 12, 0.5);
+  --article-serif-stack: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Palatino, "Noto Serif", serif;
+}
+
+[data-theme="dark"] {
+  --bg: #06070c;
+  --bg-accent: rgba(245, 209, 113, 0.18);
+  --text: #f6f7ff;
+  --muted: #9ba2bf;
+  --primary: #f7d97e;
+  --primary-hover: #fde8aa;
+  --card: rgba(12, 14, 22, 0.92);
+  --border: rgba(255, 255, 255, 0.1);
+  --code-bg: #05060d;
+  --code-text: #f6f8ff;
+  --shadow: 0 30px 70px rgba(2, 3, 8, 0.62);
+}
+
+body {
+  color: var(--text);
+  background: radial-gradient(900px 500px at 0% 0%, var(--bg-accent), transparent),
+              radial-gradient(1200px 700px at 100% 0%, rgba(120, 155, 255, 0.08), transparent),
+              var(--bg);
+  font-family: "Inter", "SF Pro Display", "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Noto Sans", sans-serif;
+  letter-spacing: 0.01em;
+}
+
+.container {
+  max-width: 76rem;
+  padding: 0 2rem 4rem;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.nocturne-hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 3.25rem 2rem 2.25rem;
+  margin: 0 auto 1.5rem;
+  max-width: 76rem;
+  color: var(--text);
+}
+
+.nocturne-brand {
+  display: flex;
+  gap: 1.75rem;
+  align-items: center;
+}
+
+.nocturne-brand-mark {
+  width: 4.75rem;
+  height: 4.75rem;
+  border-radius: 1.35rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.35rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, rgba(245, 209, 113, 0.86), rgba(252, 242, 200, 0.9));
+  color: #201a0a;
+  box-shadow: 0 18px 42px rgba(245, 209, 113, 0.35);
+  letter-spacing: 0.05em;
+}
+
+.nocturne-brand-title {
+  font-size: 2.4rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.nocturne-brand-subtitle {
+  margin-top: 0.4rem;
+  font-size: 1rem;
+  color: var(--muted);
+  max-width: 28rem;
+  line-height: 1.6;
+}
+
+.nocturne-route {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.65rem;
+  text-align: right;
+}
+
+.nocturne-route-type {
+  font-size: 0.75rem;
+  letter-spacing: 0.32em;
+  font-weight: 600;
+  color: rgba(245, 209, 113, 0.85);
+}
+
+.nocturne-route-label {
+  font-size: 1.05rem;
+  color: var(--muted);
+  max-width: 18rem;
+  line-height: 1.5;
+}
+
+.nocturne-grid {
+  display: grid;
+  grid-template-columns: minmax(15rem, 18.75rem) minmax(0, 1fr);
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.nocturne-aside {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  position: sticky;
+  top: 6.5rem;
+}
+
+.nocturne-main {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.box {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 1.2rem;
+  box-shadow: var(--shadow);
+  padding: 1.75rem;
+}
+
+.box .section-title {
+  color: var(--muted);
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+}
+
+#mapview.box {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+}
+
+#mapview .tabs {
+  width: 100%;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 999px;
+  padding: 0.4rem 0.6rem;
+  display: flex;
+  gap: 0.25rem;
+  position: relative;
+}
+
+#mapview .tab {
+  flex: 1;
+  text-align: center;
+  padding: 0.55rem 0.75rem;
+  font-size: 0.92rem;
+  font-weight: 500;
+  color: var(--muted);
+  border-radius: 999px;
+  transition: all 0.2s ease;
+}
+
+#mapview .tab.active {
+  color: var(--text);
+  background: rgba(245, 209, 113, 0.18);
+  box-shadow: 0 12px 28px rgba(245, 209, 113, 0.16);
+}
+
+#mapview .tab:hover {
+  color: var(--text);
+  background: rgba(245, 209, 113, 0.12);
+}
+
+.sidebar .box {
+  backdrop-filter: blur(20px);
+}
+
+.site-card {
+  text-align: left;
+  background: rgba(18, 20, 29, 0.88);
+  border-radius: 1.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.site-card .avatar {
+  border-radius: 1rem;
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.35);
+}
+
+.site-card .site-title {
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.site-card .site-subtitle {
+  color: var(--muted);
+  margin-top: 0.4rem;
+}
+
+#searchbox {
+  background: rgba(18, 20, 29, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+#searchInput {
+  background: rgba(8, 9, 15, 0.68);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  padding: 0.65rem 1.2rem;
+  color: var(--text);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+#searchInput:focus {
+  outline: none;
+  border-color: rgba(245, 209, 113, 0.6);
+  box-shadow: 0 0 0 3px rgba(245, 209, 113, 0.18);
+}
+
+#index, .index {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.index a {
+  display: block;
+  background: rgba(13, 15, 24, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  color: var(--text);
+  text-decoration: none;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.index a:hover {
+  transform: translateY(-6px);
+  border-color: rgba(245, 209, 113, 0.45);
+  box-shadow: 0 18px 45px rgba(245, 209, 113, 0.18);
+}
+
+.card-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.card-meta {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.card-sep {
+  color: rgba(255, 255, 255, 0.25);
+  margin: 0 0.35rem;
+}
+
+.card-cover-wrap {
+  overflow: hidden;
+  border-radius: 1rem;
+  margin-bottom: 1rem;
+}
+
+.card-cover {
+  border-radius: 1rem;
+  filter: saturate(0.92);
+}
+
+#mainview {
+  background: rgba(14, 16, 25, 0.88);
+  border-radius: 1.35rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 2rem;
+  box-shadow: 0 24px 55px rgba(0, 0, 0, 0.55);
+}
+
+#mainview h1 {
+  font-size: 2.4rem;
+}
+
+#mainview h2 {
+  font-size: 1.9rem;
+}
+
+#mainview h3 {
+  font-size: 1.45rem;
+}
+
+#mainview p {
+  line-height: 1.95;
+}
+
+pre, code {
+  background: var(--code-bg);
+  color: var(--code-text);
+  border-radius: 0.75rem;
+}
+
+.notice {
+  background: rgba(18, 20, 29, 0.9);
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.site-footer {
+  margin-top: 4rem;
+  padding: 2.5rem 2rem 3rem;
+  background: linear-gradient(180deg, rgba(8, 9, 14, 0) 0%, rgba(8, 9, 14, 0.65) 100%);
+  color: var(--muted);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.site-footer .footer-inner {
+  max-width: 76rem;
+  margin: 0 auto;
+}
+
+.site-footer a {
+  color: var(--primary);
+}
+
+@media (max-width: 1100px) {
+  .nocturne-hero {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.5rem;
+  }
+  .nocturne-route {
+    align-items: flex-start;
+    text-align: left;
+  }
+  .nocturne-grid {
+    grid-template-columns: 1fr;
+  }
+  .nocturne-aside {
+    position: static;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+  .nocturne-aside .box {
+    flex: 1 1 18rem;
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    padding-top: 1.5rem;
+  }
+  .container {
+    padding: 0 1.25rem 3rem;
+  }
+  .nocturne-hero {
+    padding: 2.5rem 1.25rem 1.75rem;
+    margin-bottom: 1rem;
+  }
+  .nocturne-brand-mark {
+    width: 4rem;
+    height: 4rem;
+    border-radius: 1rem;
+    font-size: 2rem;
+  }
+  #mainview {
+    padding: 1.5rem;
+  }
+}

--- a/assets/themes/packs.json
+++ b/assets/themes/packs.json
@@ -1,4 +1,5 @@
 [
-  { "value": "native", "label": "Native" },
-  { "value": "github", "label": "GitHub" }
+  { "value": "native", "label": "Native Classic" },
+  { "value": "github", "label": "GitHub" },
+  { "value": "nocturne", "label": "Nocturne Atelier" }
 ]


### PR DESCRIPTION
## Summary
- add a runtime-aware theme manager that reads pack manifests, loads optional modules, and exposes a theme event bus
- emit lifecycle notifications from the main renderer so themes can react to loading, rendering, and route changes
- migrate the native pack onto the new manifest/runtime format and add the Nocturne Atelier theme with a redesigned layout

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d848b873988328a3bbd6aaebc95dd3