### PR TITLE
Add Solstice single-column theme

### DIFF
--- a/assets/themes/packs.json
+++ b/assets/themes/packs.json
@@ -1,3 +1,4 @@
 [
-  { "value": "native", "label": "Native" }
+  { "value": "native", "label": "Native" },
+  { "value": "solstice", "label": "Solstice" }
 ]

--- a/assets/themes/solstice/modules/interactions.js
+++ b/assets/themes/solstice/modules/interactions.js
@@ -1,0 +1,643 @@
+import { t, withLangParam, getCurrentLang, switchLanguage } from '../../../js/i18n.js';
+import { renderTags, escapeHtml, formatDisplayDate, cardImageSrc, fallbackCover, isModifiedClick, getQueryVariable, sanitizeUrl } from '../../../js/utils.js';
+import { applySavedTheme, bindThemeToggle, bindThemePackPicker, bindPostEditor, refreshLanguageSelector } from '../../../js/theme.js';
+import { hydratePostImages, hydratePostVideos, applyLazyLoadingIn, hydrateCardCovers } from '../../../js/post-render.js';
+import { renderPostMetaCard, renderOutdatedCard } from '../../../js/templates.js';
+import { attachHoverTooltip, renderTagSidebar as renderDefaultTags } from '../../../js/tags.js';
+import { prefersReducedMotion } from '../../../js/dom-utils.js';
+
+const defaultWindow = typeof window !== 'undefined' ? window : undefined;
+const defaultDocument = typeof document !== 'undefined' ? document : undefined;
+
+const CLASS_HIDDEN = 'is-hidden';
+
+let currentSiteConfig = null;
+
+function localized(cfg, key) {
+  if (!cfg) return '';
+  const val = cfg[key];
+  if (!val) return '';
+  if (typeof val === 'string') return val;
+  const lang = getCurrentLang && getCurrentLang();
+  if (lang && val[lang]) return val[lang];
+  return val.default || '';
+}
+
+function getRoleElement(role, documentRef = defaultDocument) {
+  if (!documentRef) return null;
+  switch (role) {
+    case 'main':
+      return documentRef.getElementById('mainview');
+    case 'toc':
+      return documentRef.getElementById('tocview');
+    case 'sidebar':
+      return documentRef.getElementById('tagview');
+    case 'content':
+      return documentRef.querySelector('.solstice-main');
+    case 'container':
+      return documentRef.querySelector('.solstice-shell');
+    default:
+      return null;
+  }
+}
+
+function fadeIn(element) {
+  if (!element) return;
+  element.classList.remove(CLASS_HIDDEN);
+  element.hidden = false;
+  element.style.removeProperty('display');
+  requestAnimationFrame(() => {
+    element.classList.add('is-visible');
+  });
+}
+
+function fadeOut(element, onDone) {
+  if (!element) { if (typeof onDone === 'function') onDone(); return; }
+  element.classList.remove('is-visible');
+  const finish = () => {
+    element.classList.add(CLASS_HIDDEN);
+    element.hidden = true;
+    if (typeof onDone === 'function') onDone();
+  };
+  if (prefersReducedMotion()) {
+    finish();
+  } else {
+    element.addEventListener('transitionend', finish, { once: true });
+    const timer = setTimeout(finish, 320);
+    element.addEventListener('transitioncancel', () => clearTimeout(timer), { once: true });
+  }
+}
+
+function buildCard({ title, meta, translate, link, siteConfig }) {
+  const safeTitle = escapeHtml(String(title || 'Untitled'));
+  const excerpt = meta && meta.excerpt ? escapeHtml(String(meta.excerpt)) : '';
+  const date = meta && meta.date ? formatDisplayDate(meta.date) : '';
+  const tags = meta ? renderTags(meta.tag) : '';
+  const cover = cardImageSrc(meta, siteConfig) || (fallbackCover(siteConfig) || '');
+  const coverHtml = cover
+    ? `<div class="solstice-card__cover"><span class="ph-skeleton" aria-hidden="true"></span><img class="card-cover" src="${escapeHtml(cover)}" alt="" loading="lazy" decoding="async" /></div>`
+    : '';
+  return `<article class="solstice-card">
+    <a class="solstice-card__link" href="${escapeHtml(link)}">
+      ${coverHtml}
+      <div class="solstice-card__body">
+        <h3 class="solstice-card__title">${safeTitle}</h3>
+        ${date ? `<div class="solstice-card__meta">${escapeHtml(date)}</div>` : ''}
+        ${excerpt ? `<p class="solstice-card__excerpt">${excerpt}</p>` : ''}
+        ${tags ? `<div class="solstice-card__tags">${tags}</div>` : ''}
+      </div>
+    </a>
+  </article>`;
+}
+
+function buildPagination({ page, totalPages, baseHref, query }) {
+  if (!totalPages || totalPages <= 1) return '';
+  const mkHref = (p) => {
+    try {
+      const url = new URL(baseHref, defaultWindow ? defaultWindow.location.href : (typeof location !== 'undefined' ? location.href : ''));
+      url.searchParams.set('page', p);
+      if (query && query.q) {
+        if (query.q) url.searchParams.set('q', query.q);
+        else url.searchParams.delete('q');
+      }
+      if (query && query.tag) {
+        if (query.tag) url.searchParams.set('tag', query.tag);
+        else url.searchParams.delete('tag');
+      }
+      return url.toString();
+    } catch (_) {
+      return baseHref;
+    }
+  };
+  const items = [];
+  for (let i = 1; i <= totalPages; i++) {
+    const href = mkHref(i);
+    items.push(`<a class="solstice-page${i === page ? ' is-current' : ''}" href="${escapeHtml(href)}">${i}</a>`);
+  }
+  const prevHref = page > 1 ? mkHref(page - 1) : '';
+  const nextHref = page < totalPages ? mkHref(page + 1) : '';
+  return `<nav class="solstice-pagination" aria-label="${t('ui.pagination')}">
+    <a class="solstice-page prev${prevHref ? '' : ' is-disabled'}" href="${prevHref ? escapeHtml(prevHref) : '#'}" ${prevHref ? '' : 'aria-disabled="true"'}>${t('ui.prev')}</a>
+    <div class="solstice-page__list">${items.join('')}</div>
+    <a class="solstice-page next${nextHref ? '' : ' is-disabled'}" href="${nextHref ? escapeHtml(nextHref) : '#'}" ${nextHref ? '' : 'aria-disabled="true"'}>${t('ui.next')}</a>
+  </nav>`;
+}
+
+function decorateArticle(container, translate, utilities, markdown, meta, title) {
+  if (!container) return;
+  const copyBtn = container.querySelector('.post-meta-copy');
+  if (copyBtn) {
+    copyBtn.addEventListener('click', async () => {
+      const loc = defaultWindow && defaultWindow.location ? defaultWindow.location.href : (typeof location !== 'undefined' ? location.href : '');
+      const href = String(loc || '').split('#')[0];
+      let ok = false;
+      try {
+        const nav = defaultWindow && defaultWindow.navigator;
+        if (nav && nav.clipboard && typeof nav.clipboard.writeText === 'function') {
+          await nav.clipboard.writeText(href);
+          ok = true;
+        }
+      } catch (_) {}
+      if (!ok && defaultDocument && defaultDocument.execCommand) {
+        const tmp = defaultDocument.createElement('textarea');
+        tmp.value = href;
+        defaultDocument.body.appendChild(tmp);
+        tmp.select();
+        ok = defaultDocument.execCommand('copy');
+        defaultDocument.body.removeChild(tmp);
+      }
+      if (ok) {
+        copyBtn.classList.add('copied');
+        copyBtn.setAttribute('data-status', 'copied');
+        setTimeout(() => {
+          copyBtn.classList.remove('copied');
+          copyBtn.removeAttribute('data-status');
+        }, 1200);
+      }
+    });
+  }
+
+  const versionSelect = container.querySelector('.post-version-select');
+  if (versionSelect) {
+    versionSelect.addEventListener('change', () => {
+      const target = versionSelect.value;
+      if (!target) return;
+      const href = withLangParam(`?id=${encodeURIComponent(target)}`);
+      if (defaultWindow) {
+        defaultWindow.location.href = href;
+      } else {
+        location.href = href; // eslint-disable-line no-restricted-globals
+      }
+    });
+  }
+
+  const outdated = container.querySelector('.post-outdated-card');
+  if (outdated) {
+    const close = outdated.querySelector('.post-outdated-close');
+    if (close) close.addEventListener('click', () => outdated.remove());
+  }
+
+  try {
+    const aiFlags = Array.from(container.querySelectorAll('.ai-flag'));
+    aiFlags.forEach(flag => attachHoverTooltip(flag, () => translate('ui.aiFlagTooltip'), { delay: 0 }));
+  } catch (_) {}
+
+  try {
+    if (typeof utilities.hydratePostImages === 'function') utilities.hydratePostImages(container);
+    if (typeof utilities.hydratePostVideos === 'function') utilities.hydratePostVideos(container);
+    if (typeof utilities.applyLazyLoadingIn === 'function') utilities.applyLazyLoadingIn(container);
+  } catch (_) {}
+}
+
+function renderNavLinks(nav, tabsBySlug, activeSlug, postsEnabled, getHomeSlug) {
+  if (!nav) return;
+  const items = [];
+  const homeSlug = typeof getHomeSlug === 'function' ? getHomeSlug() : 'posts';
+  if (postsEnabled()) {
+    items.push({ slug: 'posts', label: t('ui.allPosts'), href: withLangParam('?tab=posts') });
+  }
+  items.push({ slug: 'search', label: t('ui.searchTab'), href: withLangParam('?tab=search') });
+  Object.entries(tabsBySlug || {}).forEach(([slug, info]) => {
+    const label = info && info.title ? String(info.title) : slug;
+    items.push({ slug, label, href: withLangParam(`?tab=${encodeURIComponent(slug)}`) });
+  });
+  nav.innerHTML = items.map(item => `<a class="solstice-nav__item${item.slug === activeSlug ? ' is-current' : ''}" data-tab="${escapeHtml(item.slug)}" href="${escapeHtml(item.href)}">${escapeHtml(item.label)}</a>`).join('');
+  nav.setAttribute('data-active', activeSlug || homeSlug);
+}
+
+function renderFooterLinks(root, tabsBySlug, postsEnabled, getHomeSlug, getHomeLabel) {
+  if (!root) return;
+  const links = [];
+  const homeSlug = getHomeSlug();
+  const homeLabel = getHomeLabel();
+  links.push({ href: withLangParam(`?tab=${encodeURIComponent(homeSlug)}`), label: homeLabel });
+  Object.entries(tabsBySlug || {}).forEach(([slug, info]) => {
+    const label = info && info.title ? String(info.title) : slug;
+    links.push({ href: withLangParam(`?tab=${encodeURIComponent(slug)}`), label });
+  });
+  links.push({ href: withLangParam('?tab=search'), label: t('ui.searchTab') });
+  root.innerHTML = `<ul class="solstice-footer__list">${links.map(link => `<li><a href="${escapeHtml(link.href)}">${escapeHtml(link.label)}</a></li>`).join('')}</ul>`;
+}
+
+function renderLinksList(root, cfg) {
+  if (!root) return;
+  const list = Array.isArray(cfg && cfg.profileLinks) ? cfg.profileLinks : [];
+  if (!list.length) {
+    root.innerHTML = `<li class="solstice-linklist__empty">${t('editor.site.noLinks')}</li>`;
+    return;
+  }
+  root.innerHTML = list.map(item => {
+    if (!item || !item.href) return '';
+    const label = item.label || item.href;
+    const href = sanitizeUrl(String(item.href));
+    if (!href) return '';
+    return `<li><a href="${escapeHtml(href)}" target="_blank" rel="noopener">${escapeHtml(label)}</a></li>`;
+  }).join('');
+}
+
+function updateSearchPlaceholder(documentRef = defaultDocument) {
+  const input = documentRef ? documentRef.getElementById('searchInput') : null;
+  if (!input) return;
+  input.setAttribute('placeholder', t('sidebar.searchPlaceholder'));
+}
+
+function setupToolsPanel(documentRef = defaultDocument, windowRef = defaultWindow) {
+  const panel = documentRef && documentRef.getElementById('toolsPanel');
+  if (!panel) return false;
+  panel.innerHTML = `
+    <div class="solstice-tools" id="tools">
+      <button id="themeToggle" class="solstice-tool" type="button" aria-label="${t('tools.toggleTheme')}">
+        <span class="solstice-tool__icon">🌓</span>
+        <span class="solstice-tool__label">${t('tools.toggleTheme')}</span>
+      </button>
+      <button id="postEditor" class="solstice-tool" type="button" aria-label="${t('tools.postEditor')}">
+        <span class="solstice-tool__icon">📝</span>
+        <span class="solstice-tool__label">${t('tools.postEditor')}</span>
+      </button>
+      <label class="solstice-tool solstice-tool--select" for="themePack">
+        <span class="solstice-tool__label">${t('tools.themePack')}</span>
+        <select id="themePack"></select>
+      </label>
+      <label class="solstice-tool solstice-tool--select" for="langSelect">
+        <span class="solstice-tool__label">${t('tools.language')}</span>
+        <select id="langSelect"></select>
+      </label>
+      <button id="langReset" class="solstice-tool" type="button" aria-label="${t('tools.resetLanguage')}">
+        <span class="solstice-tool__icon">♻️</span>
+        <span class="solstice-tool__label">${t('tools.resetLanguage')}</span>
+      </button>
+    </div>`;
+  try { applySavedTheme(); } catch (_) {}
+  try { bindThemeToggle(); } catch (_) {}
+  try { bindPostEditor(); } catch (_) {}
+  try { bindThemePackPicker(); } catch (_) {}
+  try { refreshLanguageSelector(); } catch (_) {}
+  try {
+    const langSel = documentRef.getElementById('langSelect');
+    if (langSel) {
+      langSel.addEventListener('change', () => {
+        const val = langSel.value || 'en';
+        switchLanguage(val);
+      });
+    }
+    const reset = documentRef.getElementById('langReset');
+    if (reset) {
+      reset.addEventListener('click', () => {
+        try { localStorage.removeItem('lang'); } catch (_) {}
+        try {
+          const url = new URL(windowRef ? windowRef.location.href : window.location.href);
+          url.searchParams.delete('lang');
+          if (windowRef && windowRef.history && windowRef.history.replaceState) {
+            windowRef.history.replaceState(windowRef.history.state, documentRef.title, url.toString());
+          }
+        } catch (_) {}
+        try {
+          if (windowRef && windowRef.__ns_softResetLang) {
+            windowRef.__ns_softResetLang();
+            return;
+          }
+        } catch (_) {}
+        try {
+          if (windowRef && windowRef.location) {
+            windowRef.location.reload();
+          }
+        } catch (_) {}
+      });
+    }
+  } catch (_) {}
+  return true;
+}
+
+function resetToolsPanel(documentRef = defaultDocument, windowRef = defaultWindow) {
+  const panel = documentRef && documentRef.getElementById('toolsPanel');
+  if (!panel) return false;
+  panel.innerHTML = '';
+  return setupToolsPanel(documentRef, windowRef);
+}
+
+function showToc(tocEl, tocHtml, articleTitle) {
+  if (!tocEl) return;
+  if (!tocHtml) {
+    tocEl.innerHTML = '';
+    tocEl.hidden = true;
+    return;
+  }
+  tocEl.innerHTML = `<div class="solstice-toc__inner"><div class="solstice-toc__title">${escapeHtml(articleTitle || t('ui.tableOfContents'))}</div>${tocHtml}</div>`;
+  tocEl.hidden = false;
+  fadeIn(tocEl);
+}
+
+function renderLoader(target, message) {
+  if (!target) return;
+  target.innerHTML = `<div class="solstice-loader" role="status">
+    <div class="solstice-loader__spinner"></div>
+    <div class="solstice-loader__text">${escapeHtml(message || t('ui.loading'))}</div>
+  </div>`;
+}
+
+function renderStaticView(container, title, html) {
+  if (!container) return;
+  container.innerHTML = `<article class="solstice-static">
+    <header class="solstice-static__header">
+      <h1>${escapeHtml(title || '')}</h1>
+    </header>
+    <div class="solstice-static__body">${html}</div>
+  </article>`;
+}
+
+function mountHooks(documentRef = defaultDocument, windowRef = defaultWindow) {
+  const hooks = {};
+
+  hooks.resolveViewContainers = ({ view }) => {
+    return {
+      view,
+      mainElement: getRoleElement('main', documentRef),
+      tocElement: getRoleElement('toc', documentRef),
+      sidebarElement: getRoleElement('sidebar', documentRef),
+      contentElement: getRoleElement('content', documentRef),
+      containerElement: getRoleElement('container', documentRef)
+    };
+  };
+
+  hooks.getViewContainer = ({ role }) => getRoleElement(role, documentRef);
+
+  hooks.showElement = ({ element }) => fadeIn(element);
+  hooks.hideElement = ({ element, onDone }) => { fadeOut(element, onDone); return true; };
+
+  hooks.renderSiteIdentity = ({ config }) => {
+    currentSiteConfig = config || currentSiteConfig;
+    const title = localized(config, 'siteTitle');
+    const subtitle = localized(config, 'siteSubtitle');
+    const titleEl = documentRef.querySelector('[data-site-title]');
+    const subtitleEl = documentRef.querySelector('[data-site-subtitle]');
+    if (titleEl) titleEl.textContent = title || 'NanoSite';
+    if (subtitleEl) subtitleEl.textContent = subtitle || '';
+  };
+
+  hooks.renderSiteLinks = ({ config }) => {
+    const root = documentRef.querySelector('[data-site-links]');
+    renderLinksList(root, config);
+  };
+
+  hooks.updateLayoutLoadingState = ({ isLoading, containerElement }) => {
+    const target = containerElement || getRoleElement('content', documentRef);
+    if (!target) return;
+    target.classList.toggle('is-loading', !!isLoading);
+  };
+
+  hooks.renderPostTOC = ({ tocElement, tocHtml, articleTitle }) => {
+    const toc = tocElement || getRoleElement('toc', documentRef);
+    showToc(toc, tocHtml, articleTitle);
+    return true;
+  };
+
+  hooks.renderErrorState = ({ targetElement, title, message, actions }) => {
+    const target = targetElement || getRoleElement('main', documentRef);
+    if (!target) return false;
+    const actionHtml = Array.isArray(actions) && actions.length
+      ? `<div class="solstice-error__actions">${actions.map(a => `<a class="solstice-btn" href="${escapeHtml(withLangParam(a.href || '#'))}">${escapeHtml(a.label || '')}</a>`).join('')}</div>`
+      : '';
+    const heading = title || t('errors.pageUnavailableTitle');
+    const body = message || t('errors.pageUnavailableBody');
+    target.innerHTML = `<section class="solstice-error" role="alert">
+      <h2>${escapeHtml(heading)}</h2>
+      <p>${escapeHtml(body)}</p>
+      ${actionHtml}
+    </section>`;
+    return true;
+  };
+
+  hooks.handleViewChange = ({ view }) => {
+    if (!documentRef || !documentRef.body) return;
+    documentRef.body.setAttribute('data-active-view', view || 'posts');
+    const toc = getRoleElement('toc', documentRef);
+    if (toc && view !== 'post') {
+      toc.hidden = true;
+      toc.innerHTML = '';
+    }
+    const input = documentRef.getElementById('searchInput');
+    if (input) input.value = view === 'search' ? (getQueryVariable('q') || '') : '';
+  };
+
+  hooks.renderTagSidebar = ({ postsIndex, utilities }) => {
+    const render = utilities && typeof utilities.renderTagSidebar === 'function'
+      ? utilities.renderTagSidebar
+      : renderDefaultTags;
+    try { render(postsIndex || {}); } catch (_) {}
+    return true;
+  };
+
+  hooks.enhanceIndexLayout = (params = {}) => {
+    const container = params.containerElement || getRoleElement('main', documentRef);
+    try { if (typeof hydrateCardCovers === 'function') hydrateCardCovers(container); } catch (_) {}
+    try { if (typeof applyLazyLoadingIn === 'function') applyLazyLoadingIn(container); } catch (_) {}
+    try { if (typeof params.setupSearch === 'function') params.setupSearch(params.allEntries || []); } catch (_) {}
+    try { if (typeof params.renderTagSidebar === 'function') params.renderTagSidebar(params.postsIndexMap || {}); } catch (_) {}
+    return true;
+  };
+
+  hooks.renderTabs = ({ tabsBySlug, activeSlug, getHomeSlug, postsEnabled }) => {
+    const nav = documentRef.getElementById('tabsNav');
+    if (!nav) return false;
+    renderNavLinks(nav, tabsBySlug, activeSlug, postsEnabled, getHomeSlug);
+    return true;
+  };
+
+  hooks.renderFooterNav = ({ tabsBySlug, postsEnabled, getHomeSlug, getHomeLabel }) => {
+    const footerNav = documentRef.getElementById('footerNav');
+    if (!footerNav) return false;
+    renderFooterLinks(footerNav, tabsBySlug, postsEnabled, getHomeSlug, getHomeLabel);
+    return true;
+  };
+
+  hooks.renderPostLoadingState = ({ containers }) => {
+    const main = containers && containers.mainElement ? containers.mainElement : getRoleElement('main', documentRef);
+    renderLoader(main, t('ui.loading'));
+    return true;
+  };
+
+  hooks.renderPostView = ({ containers, markdownHtml, fallbackTitle, postMetadata, markdown, postsIndex, postId, siteConfig, translate, utilities }) => {
+    const main = containers && containers.mainElement ? containers.mainElement : getRoleElement('main', documentRef);
+    if (!main) return;
+    const title = (postMetadata && postMetadata.title) || fallbackTitle || '';
+    const cover = cardImageSrc(postMetadata, siteConfig) || '';
+    const date = postMetadata && postMetadata.date ? formatDisplayDate(postMetadata.date) : '';
+    const tagMarkup = postMetadata ? renderTags(postMetadata.tag) : '';
+    const metaCard = renderPostMetaCard(title, postMetadata || {}, markdown);
+    const outdatedCard = renderOutdatedCard(postMetadata || {}, siteConfig);
+
+    main.innerHTML = `
+      <article class="solstice-article" data-post-id="${escapeHtml(postId || '')}">
+        <header class="solstice-article__header">
+          ${cover ? `<div class="solstice-article__hero"><img src="${escapeHtml(cover)}" alt="" loading="lazy" decoding="async" /></div>` : ''}
+          <div class="solstice-article__heading">
+            <p class="solstice-article__meta-line">${date ? escapeHtml(date) : ''}</p>
+            <h1 class="solstice-article__title">${escapeHtml(title)}</h1>
+            ${tagMarkup ? `<div class="solstice-article__tags">${tagMarkup}</div>` : ''}
+          </div>
+          <div class="solstice-article__meta">
+            ${outdatedCard || ''}
+            ${metaCard || ''}
+          </div>
+        </header>
+        <div class="solstice-article__body">${markdownHtml}</div>
+        <footer class="solstice-article__footer">
+          <div class="solstice-article__nav" data-post-nav></div>
+        </footer>
+      </article>`;
+
+    try { if (utilities && typeof utilities.renderPostNav === 'function') utilities.renderPostNav(main.querySelector('[data-post-nav]'), postsIndex || {}, postMetadata && postMetadata.location); } catch (_) {}
+    decorateArticle(main, translate || t, { hydratePostImages, hydratePostVideos, applyLazyLoadingIn }, markdown, postMetadata, title);
+    return { decorated: true, title };
+  };
+
+  hooks.decoratePostView = ({ container, translate, utilities, markdown, postMetadata, articleTitle }) => {
+    decorateArticle(container || getRoleElement('main', documentRef), translate || t, utilities || { hydratePostImages, hydratePostVideos, applyLazyLoadingIn }, markdown, postMetadata, articleTitle);
+    return true;
+  };
+
+  hooks.scrollToHash = ({ hash }) => {
+    if (!hash) return false;
+    try {
+      const target = documentRef.getElementById(hash) || documentRef.querySelector(`[id='${hash}']`);
+      if (!target) return false;
+      target.scrollIntoView({ behavior: prefersReducedMotion() ? 'auto' : 'smooth', block: 'start' });
+      return true;
+    } catch (_) { return false; }
+  };
+
+  hooks.renderIndexView = ({ container, pageEntries, page, totalPages, siteConfig }) => {
+    if (!container) container = getRoleElement('main', documentRef);
+    if (!container) return false;
+    const cards = (pageEntries || []).map(([title, meta]) => {
+      const href = meta && meta.location ? withLangParam(`?id=${encodeURIComponent(meta.location)}`) : '#';
+      return buildCard({ title, meta, translate: t, link: href, siteConfig });
+    }).join('');
+    const baseHref = withLangParam('?tab=posts');
+    container.innerHTML = `<div class="solstice-index">
+      <div class="solstice-index__grid">${cards || `<p class="solstice-empty">${t('ui.noResultsTitle')}</p>`}</div>
+      ${buildPagination({ page, totalPages, baseHref, query: {} })}
+    </div>`;
+    return true;
+  };
+
+  hooks.afterIndexRender = ({ container }) => {
+    try { if (container) hydrateCardCovers(container); else hydrateCardCovers(getRoleElement('main', documentRef)); } catch (_) {}
+    return true;
+  };
+
+  hooks.renderSearchResults = ({ container, entries, query, totalPages, page, siteConfig, tagFilter }) => {
+    if (!container) container = getRoleElement('main', documentRef);
+    if (!container) return false;
+    const cards = (entries || []).map(([title, meta]) => {
+      const href = meta && meta.location ? withLangParam(`?id=${encodeURIComponent(meta.location)}`) : '#';
+      return buildCard({ title, meta, translate: t, link: href, siteConfig });
+    }).join('');
+    const baseHref = withLangParam('?tab=search');
+    const summary = query
+      ? `${t('ui.searchTab')} · ${escapeHtml(query)}`
+      : tagFilter
+        ? `${t('ui.tags')} · ${escapeHtml(tagFilter)}`
+        : t('ui.searchTab');
+    container.innerHTML = `<div class="solstice-index solstice-index--search">
+      <header class="solstice-index__header"><h2>${escapeHtml(summary)}</h2></header>
+      <div class="solstice-index__grid">${cards || `<p class="solstice-empty">${t('ui.noResultsTitle')}</p>`}</div>
+      ${buildPagination({ page, totalPages, baseHref, query: { q: query, tag: tagFilter } })}
+    </div>`;
+    return true;
+  };
+
+  hooks.afterSearchRender = ({ container }) => {
+    try { if (container) hydrateCardCovers(container); else hydrateCardCovers(getRoleElement('main', documentRef)); } catch (_) {}
+    return true;
+  };
+
+  hooks.renderStaticTabLoadingState = ({ containers }) => {
+    const main = containers && containers.mainElement ? containers.mainElement : getRoleElement('main', documentRef);
+    renderLoader(main, t('ui.loading'));
+    return true;
+  };
+
+  hooks.renderStaticTabView = ({ containers, title, html }) => {
+    const main = containers && containers.mainElement ? containers.mainElement : getRoleElement('main', documentRef);
+    renderStaticView(main, title, html);
+    return true;
+  };
+
+  hooks.handleDocumentClick = ({ event }) => {
+    const target = event.target;
+    if (!target) return false;
+    if (target.closest('.solstice-nav__item')) {
+      if (isModifiedClick(event)) return false;
+      event.preventDefault();
+      const href = target.getAttribute('href');
+      if (href && windowRef) {
+        windowRef.location.href = href;
+      }
+      return true;
+    }
+    return false;
+  };
+
+  hooks.handleRouteScroll = () => {
+    return false;
+  };
+
+  hooks.handleWindowResize = () => {
+    return true;
+  };
+
+  hooks.setupThemeControls = () => setupToolsPanel(documentRef, windowRef);
+  hooks.resetThemeControls = () => resetToolsPanel(documentRef, windowRef);
+  hooks.updateSearchPlaceholder = () => { updateSearchPlaceholder(documentRef); return true; };
+
+  hooks.setupResponsiveTabsObserver = () => {
+    const header = documentRef.querySelector('.solstice-header');
+    if (!header || typeof IntersectionObserver === 'undefined') return false;
+    let sentinel = documentRef.querySelector('.solstice-header-sentinel');
+    if (!sentinel) {
+      sentinel = documentRef.createElement('div');
+      sentinel.className = 'solstice-header-sentinel';
+      header.parentElement.insertBefore(sentinel, header);
+    }
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        header.classList.toggle('is-condensed', !entry.isIntersecting);
+      });
+    });
+    observer.observe(sentinel);
+    return true;
+  };
+
+  hooks.reflectThemeConfig = ({ siteConfig }) => {
+    const root = documentRef.querySelector('.solstice-shell');
+    if (root && siteConfig && siteConfig.themePack) {
+      root.setAttribute('data-theme-pack', siteConfig.themePack);
+    }
+    return true;
+  };
+
+  hooks.setupFooter = () => {
+    const meta = documentRef.querySelector('.solstice-footer__credit');
+    if (meta) {
+      const year = new Date().getFullYear();
+      const siteTitle = localized(currentSiteConfig || {}, 'siteTitle') || 'NanoSite';
+      meta.textContent = `© ${year} ${siteTitle}`;
+    }
+    return true;
+  };
+
+  if (windowRef) {
+    windowRef.__ns_themeHooks = Object.assign({}, windowRef.__ns_themeHooks || {}, hooks);
+  }
+  return hooks;
+}
+
+export function mount(context = {}) {
+  const doc = context.document || defaultDocument;
+  const win = (context.document && context.document.defaultView) || defaultWindow;
+  mountHooks(doc, win);
+  updateSearchPlaceholder(doc);
+  setupToolsPanel(doc, win);
+  return context;
+}

--- a/assets/themes/solstice/modules/layout.js
+++ b/assets/themes/solstice/modules/layout.js
@@ -1,0 +1,115 @@
+const NAV_ID = 'tabsNav';
+const MAINVIEW_ID = 'mainview';
+const TOCVIEW_ID = 'tocview';
+const FOOTER_NAV_ID = 'footerNav';
+const TAGVIEW_ID = 'tagview';
+
+function ensureElement(parent, selector, creator) {
+  const existing = parent.querySelector(selector);
+  if (existing) return existing;
+  const el = creator();
+  parent.appendChild(el);
+  return el;
+}
+
+export function mount(context = {}) {
+  const doc = context.document || document;
+  if (!doc || !doc.body) return context;
+
+  let container = doc.querySelector('[data-theme-root="container"]');
+  if (!container) {
+    container = doc.createElement('div');
+    container.setAttribute('data-theme-root', 'container');
+    doc.body.insertBefore(container, doc.body.firstChild);
+  }
+  container.className = 'solstice-shell';
+
+  const header = ensureElement(container, '.solstice-header', () => {
+    const el = doc.createElement('header');
+    el.className = 'solstice-header';
+    el.setAttribute('role', 'banner');
+    el.innerHTML = `
+      <div class="solstice-header__inner">
+        <a class="solstice-brand" href="?tab=posts" data-site-home>
+          <div class="solstice-brand__title" data-site-title></div>
+          <div class="solstice-brand__subtitle" data-site-subtitle></div>
+        </a>
+        <nav id="${NAV_ID}" class="solstice-nav" aria-label="Primary navigation"></nav>
+        <div class="solstice-header__actions">
+          <label class="solstice-search" for="searchInput">
+            <span class="solstice-search__icon" aria-hidden="true">🔍</span>
+            <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
+          </label>
+        </div>
+      </div>`;
+    return el;
+  });
+
+  const tagBand = ensureElement(container, `#${TAGVIEW_ID}`, () => {
+    const el = doc.createElement('section');
+    el.id = TAGVIEW_ID;
+    el.className = 'solstice-tagband';
+    el.setAttribute('aria-label', 'Tag filters');
+    return el;
+  });
+
+  const main = ensureElement(container, '.solstice-main', () => {
+    const el = doc.createElement('main');
+    el.className = 'solstice-main';
+    el.setAttribute('role', 'main');
+    return el;
+  });
+
+  const mainview = ensureElement(main, `#${MAINVIEW_ID}`, () => {
+    const el = doc.createElement('section');
+    el.id = MAINVIEW_ID;
+    el.className = 'solstice-mainview';
+    el.setAttribute('tabindex', '-1');
+    return el;
+  });
+
+  const tocview = ensureElement(main, `#${TOCVIEW_ID}`, () => {
+    const el = doc.createElement('aside');
+    el.id = TOCVIEW_ID;
+    el.className = 'solstice-toc';
+    el.setAttribute('aria-label', 'Table of contents');
+    el.hidden = true;
+    return el;
+  });
+
+  const footer = ensureElement(container, '.solstice-footer', () => {
+    const el = doc.createElement('footer');
+    el.className = 'solstice-footer';
+    el.setAttribute('role', 'contentinfo');
+    el.innerHTML = `
+      <div class="solstice-footer__inner">
+        <section class="solstice-footer__tools" id="toolsPanel" aria-label="Quick tools"></section>
+        <section class="solstice-footer__nav" aria-label="Secondary navigation">
+          <div id="${FOOTER_NAV_ID}" class="solstice-footer-nav"></div>
+        </section>
+        <section class="solstice-footer__links" aria-label="Profile links">
+          <ul class="solstice-linklist" data-site-links></ul>
+        </section>
+        <section class="solstice-footer__meta" aria-label="Site meta">
+          <div class="solstice-footer__credit">NanoSite</div>
+        </section>
+      </div>`;
+    return el;
+  });
+
+  context.document = doc;
+  context.regions = {
+    container,
+    header,
+    main,
+    content: main,
+    mainview,
+    toc: tocview,
+    footer,
+    footerNav: footer.querySelector(`#${FOOTER_NAV_ID}`),
+    tagBand,
+    toolsPanel: footer.querySelector('#toolsPanel')
+  };
+
+  return context;
+}

--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -1,0 +1,900 @@
+:root {
+  --solstice-bg: #f5f5f7;
+  --solstice-surface: rgba(255, 255, 255, 0.8);
+  --solstice-border: rgba(0, 0, 0, 0.08);
+  --solstice-text: #1d1d1f;
+  --solstice-muted: #6e6e73;
+  --solstice-accent: #0071e3;
+  --solstice-accent-strong: #0057b8;
+  --solstice-shadow: 0 18px 40px rgba(0, 0, 0, 0.15);
+  --solstice-radius: 18px;
+  --solstice-gap: min(4vw, 48px);
+  --solstice-font: 'SF Pro Display', 'SF Pro Text', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+[data-theme='dark'] {
+  --solstice-bg: #0a0a0a;
+  --solstice-surface: rgba(20, 20, 20, 0.85);
+  --solstice-border: rgba(255, 255, 255, 0.08);
+  --solstice-text: #f5f5f7;
+  --solstice-muted: rgba(255, 255, 255, 0.6);
+  --solstice-accent: #2997ff;
+  --solstice-accent-strong: #0a84ff;
+  --solstice-shadow: 0 20px 50px rgba(0, 0, 0, 0.45);
+}
+
+body {
+  margin: 0;
+  font-family: var(--solstice-font);
+  color: var(--solstice-text);
+  background: var(--solstice-bg);
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.solstice-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, rgba(255,255,255,0.9) 0%, rgba(255,255,255,0.65) 60%, rgba(255,255,255,0.45) 100%);
+  backdrop-filter: blur(20px);
+}
+
+[data-theme='dark'] .solstice-shell {
+  background: linear-gradient(180deg, rgba(18,18,18,0.95) 0%, rgba(18,18,18,0.8) 60%, rgba(18,18,18,0.65) 100%);
+}
+
+.solstice-header {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  backdrop-filter: blur(24px);
+  background: rgba(245, 245, 247, 0.72);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  transition: transform 0.3s ease, background 0.3s ease, border-color 0.3s ease;
+}
+
+[data-theme='dark'] .solstice-header {
+  background: rgba(28, 28, 30, 0.86);
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+.solstice-header.is-condensed {
+  transform: translateY(-12px);
+  background: rgba(245, 245, 247, 0.9);
+}
+
+[data-theme='dark'] .solstice-header.is-condensed {
+  background: rgba(28, 28, 30, 0.92);
+}
+
+.solstice-header__inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1.25rem 1.5rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.solstice-brand {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.solstice-brand__title {
+  font-size: clamp(1.35rem, 2vw + 0.5rem, 2rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.solstice-brand__subtitle {
+  font-size: 0.95rem;
+  color: var(--solstice-muted);
+}
+
+.solstice-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
+.solstice-nav__item {
+  position: relative;
+  font-size: 0.95rem;
+  color: var(--solstice-muted);
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s ease;
+  padding-bottom: 0.35rem;
+}
+
+.solstice-nav__item::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  background: var(--solstice-accent);
+  border-radius: 999px;
+  transform: scaleX(0);
+  transform-origin: 50% 100%;
+  transition: transform 0.2s ease;
+}
+
+.solstice-nav__item:hover,
+.solstice-nav__item:focus-visible {
+  color: var(--solstice-text);
+}
+
+.solstice-nav__item.is-current {
+  color: var(--solstice-text);
+}
+
+.solstice-nav__item.is-current::after {
+  transform: scaleX(1);
+}
+
+.solstice-header__actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.solstice-search {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--solstice-border);
+  background: var(--solstice-surface);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.4);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.solstice-search:focus-within {
+  border-color: var(--solstice-accent);
+  box-shadow: 0 0 0 4px rgba(0,113,227,0.12);
+}
+
+.solstice-search__icon {
+  font-size: 1rem;
+  opacity: 0.7;
+}
+
+.solstice-search input {
+  border: none;
+  background: transparent;
+  outline: none;
+  font-size: 0.95rem;
+  color: var(--solstice-text);
+  width: min(220px, 100%);
+}
+
+.solstice-tagband {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 1.5rem 1.5rem 0;
+}
+
+#tagview .section-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  color: var(--solstice-muted);
+}
+
+#tagview .tagbox {
+  border: 1px solid var(--solstice-border);
+  border-radius: var(--solstice-radius);
+  padding: 1rem 1.25rem;
+  background: var(--solstice-surface);
+  backdrop-filter: blur(20px);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.08);
+}
+
+#tagview .tag-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+#tagview .tag-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(0,0,0,0.04);
+  color: inherit;
+  text-decoration: none;
+  font-size: 0.85rem;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+#tagview .tag-link.active {
+  background: var(--solstice-accent);
+  color: white;
+  border-color: transparent;
+}
+
+#tagview .tag-count {
+  font-variant-numeric: tabular-nums;
+  opacity: 0.7;
+}
+
+#tagview .tag-toggle {
+  margin-top: 1rem;
+  border: none;
+  background: transparent;
+  color: var(--solstice-accent);
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.tag-tooltip {
+  position: fixed;
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  padding: 0.35rem 0.65rem;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+  z-index: 1000;
+}
+
+.tag-tooltip.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.tag-tooltip::after {
+  content: '';
+  position: absolute;
+  bottom: -6px;
+  left: var(--arrow-pct, 50%);
+  transform: translateX(-50%);
+  width: 10px;
+  height: 6px;
+  background: inherit;
+  clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+}
+
+.tag-tooltip.below {
+  transform: translateY(4px);
+}
+
+.tag-tooltip.below::after {
+  top: -6px;
+  bottom: auto;
+  clip-path: polygon(0 0, 100% 0, 50% 100%);
+}
+
+.solstice-main {
+  flex: 1;
+  width: 100%;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+
+.solstice-mainview {
+  min-height: 50vh;
+}
+
+.solstice-toc {
+  margin-top: 3rem;
+  border-radius: var(--solstice-radius);
+  border: 1px solid var(--solstice-border);
+  background: var(--solstice-surface);
+  padding: 1.5rem;
+  box-shadow: 0 18px 40px rgba(0,0,0,0.08);
+}
+
+.solstice-toc.is-hidden,
+.solstice-toc[hidden] {
+  display: none !important;
+}
+
+.solstice-toc__title {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--solstice-muted);
+  margin-bottom: 0.75rem;
+}
+
+.solstice-index {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.solstice-index__header h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 1.5vw + 1rem, 2.2rem);
+  letter-spacing: -0.015em;
+}
+
+.solstice-index__grid {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.solstice-card {
+  list-style: none;
+}
+
+.solstice-card__link {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1.25rem;
+  padding: 1.75rem;
+  border-radius: calc(var(--solstice-radius) + 6px);
+  background: var(--solstice-surface);
+  border: 1px solid transparent;
+  box-shadow: 0 25px 45px rgba(0,0,0,0.08);
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.solstice-card__link:hover,
+.solstice-card__link:focus-visible {
+  transform: translateY(-6px);
+  box-shadow: var(--solstice-shadow);
+  border-color: rgba(0,0,0,0.08);
+}
+
+.solstice-card__cover {
+  position: relative;
+  overflow: hidden;
+  border-radius: calc(var(--solstice-radius) + 4px);
+  aspect-ratio: 16 / 9;
+  background: rgba(0,0,0,0.05);
+}
+
+.solstice-card__cover .ph-skeleton {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(0,0,0,0.06) 0%, rgba(0,0,0,0.02) 50%, rgba(0,0,0,0.06) 100%);
+  animation: solstice-shimmer 1.6s infinite;
+}
+
+.solstice-card__cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+}
+
+.solstice-card__cover img.is-loaded {
+  opacity: 1;
+}
+
+.solstice-card__title {
+  font-size: clamp(1.3rem, 2vw + 0.4rem, 1.9rem);
+  margin: 0 0 0.75rem;
+  letter-spacing: -0.015em;
+}
+
+.solstice-card__meta {
+  font-size: 0.95rem;
+  color: var(--solstice-muted);
+  margin-bottom: 0.75rem;
+}
+
+.solstice-card__excerpt {
+  font-size: 1rem;
+  line-height: 1.7;
+  color: var(--solstice-text);
+  margin: 0 0 1.25rem;
+}
+
+.solstice-card__tags {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.solstice-card__tags .tag {
+  background: rgba(0,0,0,0.05);
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.8rem;
+}
+
+.solstice-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.95rem;
+}
+
+.solstice-page {
+  text-decoration: none;
+  color: var(--solstice-muted);
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.solstice-page__list {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.solstice-page.is-current {
+  background: var(--solstice-accent);
+  color: #fff;
+}
+
+.solstice-page:hover,
+.solstice-page:focus-visible {
+  color: var(--solstice-text);
+  border-color: rgba(0,0,0,0.1);
+}
+
+.solstice-page.is-disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.solstice-loader {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 4rem 0;
+}
+
+.solstice-loader__spinner {
+  width: 42px;
+  height: 42px;
+  border: 4px solid rgba(0,0,0,0.1);
+  border-top-color: var(--solstice-accent);
+  border-radius: 50%;
+  animation: solstice-spin 0.9s linear infinite;
+}
+
+.solstice-loader__text {
+  font-size: 1rem;
+  color: var(--solstice-muted);
+}
+
+.solstice-error {
+  border-radius: var(--solstice-radius);
+  border: 1px solid var(--solstice-border);
+  background: var(--solstice-surface);
+  padding: 2rem;
+  box-shadow: 0 25px 45px rgba(0,0,0,0.12);
+  text-align: center;
+}
+
+.solstice-error__actions {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.solstice-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.6rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: var(--solstice-accent);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.solstice-btn:hover,
+.solstice-btn:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 30px rgba(0,0,0,0.16);
+}
+
+.solstice-article__header {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin-bottom: 2rem;
+}
+
+.solstice-article__hero {
+  border-radius: calc(var(--solstice-radius) + 6px);
+  overflow: hidden;
+  box-shadow: var(--solstice-shadow);
+}
+
+.solstice-article__hero img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.solstice-article__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.solstice-article__meta-line {
+  font-size: 0.95rem;
+  color: var(--solstice-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.solstice-article__title {
+  font-size: clamp(2.2rem, 3vw + 1rem, 3.4rem);
+  margin: 0;
+  letter-spacing: -0.02em;
+}
+
+.solstice-article__tags {
+  display: flex;
+  gap: 0.65rem;
+  flex-wrap: wrap;
+}
+
+.solstice-article__meta {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.post-meta-card {
+  border-radius: var(--solstice-radius);
+  border: 1px solid var(--solstice-border);
+  padding: 1.25rem 1.5rem;
+  background: rgba(255,255,255,0.72);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 20px 40px rgba(0,0,0,0.08);
+}
+
+[data-theme='dark'] .post-meta-card {
+  background: rgba(30,30,30,0.8);
+}
+
+.post-meta-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.post-meta-line {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  font-size: 0.9rem;
+  color: var(--solstice-muted);
+}
+
+.post-meta-copy {
+  border: none;
+  background: rgba(0,0,0,0.06);
+  color: inherit;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  margin-left: auto;
+  transition: background 0.2s ease;
+}
+
+.post-meta-copy:hover,
+.post-meta-copy:focus-visible,
+.post-meta-copy.copied {
+  background: var(--solstice-accent);
+  color: #fff;
+}
+
+.post-meta-excerpt {
+  margin-top: 1rem;
+  line-height: 1.6;
+}
+
+.post-meta-card .tag-list,
+.post-meta-card .tag,
+.post-meta-card .tags {
+  display: inline-flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.post-meta-card .tag {
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(0,0,0,0.05);
+  font-size: 0.8rem;
+}
+
+.post-outdated-card {
+  border-radius: var(--solstice-radius);
+  border: 1px solid rgba(255, 181, 66, 0.3);
+  background: linear-gradient(145deg, rgba(255, 181, 66, 0.12), rgba(255, 107, 53, 0.16));
+  padding: 1rem 1.25rem;
+  color: #8f5500;
+}
+
+.post-outdated-close {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 1.1rem;
+  cursor: pointer;
+  margin-left: 0.5rem;
+}
+
+.solstice-article__body {
+  line-height: 1.8;
+  font-size: 1.05rem;
+  backdrop-filter: blur(12px);
+  border-radius: calc(var(--solstice-radius) + 4px);
+  border: 1px solid var(--solstice-border);
+  background: var(--solstice-surface);
+  padding: clamp(1.5rem, 2vw + 1rem, 3rem);
+  box-shadow: 0 30px 60px rgba(0,0,0,0.1);
+}
+
+.solstice-article__body img {
+  max-width: 100%;
+  border-radius: 18px;
+}
+
+.solstice-article__footer {
+  margin-top: 3rem;
+}
+
+.solstice-article__nav {
+  margin-top: 2rem;
+}
+
+.post-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: var(--solstice-radius);
+  border: 1px solid var(--solstice-border);
+  background: var(--solstice-surface);
+  box-shadow: 0 16px 30px rgba(0,0,0,0.08);
+}
+
+.post-nav a {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.post-nav .nav-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--solstice-muted);
+}
+
+.post-nav .nav-title {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.post-nav .disabled {
+  opacity: 0.4;
+}
+
+.solstice-static {
+  border-radius: var(--solstice-radius);
+  border: 1px solid var(--solstice-border);
+  background: var(--solstice-surface);
+  padding: clamp(1.75rem, 2vw + 1.5rem, 3rem);
+  box-shadow: 0 25px 50px rgba(0,0,0,0.1);
+}
+
+.solstice-static__header h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(2rem, 2vw + 1.2rem, 2.8rem);
+}
+
+.solstice-footer {
+  margin-top: auto;
+  border-top: 1px solid rgba(0,0,0,0.05);
+  background: rgba(255,255,255,0.78);
+  backdrop-filter: blur(20px);
+}
+
+[data-theme='dark'] .solstice-footer {
+  border-color: rgba(255,255,255,0.08);
+  background: rgba(18,18,18,0.85);
+}
+
+.solstice-footer__inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 3rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.solstice-footer__tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.solstice-tools {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.solstice-tool {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(0,0,0,0.05);
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.solstice-tool--select {
+  padding-right: 1rem;
+}
+
+.solstice-tool select {
+  border: none;
+  background: transparent;
+  font-size: 0.95rem;
+  color: inherit;
+  outline: none;
+}
+
+.solstice-tool:hover,
+.solstice-tool:focus-visible {
+  background: rgba(0,0,0,0.08);
+  transform: translateY(-2px);
+}
+
+[data-theme='dark'] .solstice-tool {
+  background: rgba(255,255,255,0.08);
+}
+
+.solstice-footer-nav .solstice-footer__list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  margin: 0;
+  padding: 0;
+}
+
+.solstice-footer__list a {
+  color: var(--solstice-muted);
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: color 0.2s ease;
+}
+
+.solstice-footer__list a:hover,
+.solstice-footer__list a:focus-visible {
+  color: var(--solstice-text);
+}
+
+.solstice-linklist {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+}
+
+.solstice-linklist__empty {
+  color: var(--solstice-muted);
+  font-size: 0.9rem;
+}
+
+.solstice-footer__credit {
+  color: var(--solstice-muted);
+  font-size: 0.85rem;
+}
+
+.solstice-empty {
+  text-align: center;
+  color: var(--solstice-muted);
+  font-size: 1rem;
+}
+
+.is-loading::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: rgba(255,255,255,0.55);
+  pointer-events: none;
+}
+
+[data-theme='dark'] .is-loading::after {
+  background: rgba(0,0,0,0.45);
+}
+
+.solstice-header-sentinel {
+  height: 1px;
+  width: 100%;
+}
+
+@keyframes solstice-spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes solstice-shimmer {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+@media (max-width: 720px) {
+  .solstice-header__inner {
+    grid-template-columns: 1fr;
+    justify-items: flex-start;
+  }
+
+  .solstice-header__actions {
+    justify-content: flex-start;
+  }
+
+  .solstice-nav {
+    width: 100%;
+    justify-content: flex-start;
+    overflow-x: auto;
+  }
+
+  .solstice-card__link {
+    padding: 1.5rem;
+  }
+
+  .solstice-article__title {
+    font-size: clamp(2rem, 6vw, 2.8rem);
+  }
+
+  .solstice-article__body {
+    padding: 1.5rem;
+  }
+
+  .solstice-footer__inner {
+    grid-template-columns: 1fr;
+  }
+}

--- a/assets/themes/solstice/theme.json
+++ b/assets/themes/solstice/theme.json
@@ -1,0 +1,7 @@
+{
+  "name": "Solstice",
+  "modules": [
+    "modules/layout.js",
+    "modules/interactions.js"
+  ]
+}

--- a/site.yaml
+++ b/site.yaml
@@ -41,7 +41,7 @@ contentRoot: wwwroot      # Root directory for content files
 
 # Theme override configurations
 themeMode: user
-themePack: native
+themePack: solstice
 themeOverride: true
 
 # Repository information used for internal linking of "report issue" etc.


### PR DESCRIPTION
## Summary
- add a new Solstice theme pack with modular layout and interaction hooks for the single-column experience
- style the theme with a glassmorphism-inspired header, post cards, article view, and footer tool area
- register the pack and set the default site configuration to use Solstice

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d9a4376da483288f54360969b8e289