### PR TITLE
Adjust Solstice header behavior on scroll

### DIFF
--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -354,10 +354,10 @@ body {
   max-width: 960px;
   margin: 0 auto;
   padding: 1.25rem 1.5rem;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 1.5rem;
+  display: flex;
   align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
   transition: padding 0.3s ease;
 }
 
@@ -398,7 +398,9 @@ body {
 
 .solstice-header__inner #tabsNav,
 .solstice-header__inner .solstice-nav {
-  align-self: center;
+  display: flex;
+  align-items: center;
+  margin-left: auto;
 }
 
 .solstice-header.is-condensed #tabsNav,
@@ -2131,12 +2133,17 @@ body {
 
 @media (max-width: 720px) {
   .solstice-header__inner {
-    grid-template-columns: 1fr;
-    justify-items: flex-start;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .solstice-header__inner #tabsNav,
+  .solstice-header__inner .solstice-nav {
+    margin-left: 0;
+    width: 100%;
   }
 
   .solstice-nav {
-    width: 100%;
     justify-content: flex-start;
     overflow-x: auto;
   }

--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -364,6 +364,7 @@ body {
 .solstice-brand {
   display: inline-flex;
   flex-direction: column;
+  justify-content: center;
   gap: 0.15rem;
   text-decoration: none;
   color: inherit;
@@ -373,6 +374,7 @@ body {
   font-size: clamp(1.35rem, 2vw + 0.5rem, 2rem);
   font-weight: 700;
   letter-spacing: -0.02em;
+  line-height: 1.05;
   transition: font-size 0.3s ease;
 }
 
@@ -386,11 +388,23 @@ body {
 }
 
 .solstice-header.is-condensed .solstice-brand__title {
-  font-size: clamp(1.05rem, 1.5vw + 0.35rem, 1.6rem);
+  font-size: clamp(0.95rem, 1.1vw + 0.35rem, 1.4rem);
+  font-weight: 500;
 }
 
 .solstice-header.is-condensed .solstice-brand__subtitle {
   display: none;
+}
+
+.solstice-header__inner #tabsNav,
+.solstice-header__inner .solstice-nav {
+  align-self: center;
+}
+
+.solstice-header.is-condensed #tabsNav,
+.solstice-header.is-condensed .solstice-nav {
+  display: flex;
+  align-items: center;
 }
 
 .solstice-nav {

--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -354,10 +354,10 @@ body {
   max-width: 960px;
   margin: 0 auto;
   padding: 1.25rem 1.5rem;
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr;
   align-items: center;
-  gap: 1.5rem;
-  flex-wrap: wrap;
+  column-gap: 1.5rem;
   transition: padding 0.3s ease;
 }
 
@@ -400,13 +400,14 @@ body {
 .solstice-header__inner .solstice-nav {
   display: flex;
   align-items: center;
-  margin-left: auto;
+  justify-self: end;
 }
 
 .solstice-header.is-condensed #tabsNav,
 .solstice-header.is-condensed .solstice-nav {
   display: flex;
   align-items: center;
+  justify-self: end;
 }
 
 .solstice-nav {
@@ -2133,14 +2134,18 @@ body {
 
 @media (max-width: 720px) {
   .solstice-header__inner {
+    display: flex;
     flex-direction: column;
     align-items: flex-start;
+    gap: 0.75rem;
   }
 
   .solstice-header__inner #tabsNav,
   .solstice-header__inner .solstice-nav {
     margin-left: 0;
     width: 100%;
+    align-self: stretch;
+    justify-content: flex-start;
   }
 
   .solstice-nav {

--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -333,6 +333,7 @@ body {
   backdrop-filter: blur(24px);
   background: rgba(245, 245, 247, 0.72);
   border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  --solstice-header-collapse: 0;
   transition: transform 0.3s ease, background 0.3s ease, border-color 0.3s ease;
 }
 
@@ -342,6 +343,7 @@ body {
 }
 
 .solstice-header.is-condensed {
+  --solstice-header-collapse: 1;
   transform: translateY(-12px);
   background: rgba(245, 245, 247, 0.9);
 }
@@ -353,12 +355,16 @@ body {
 .solstice-header__inner {
   max-width: 960px;
   margin: 0 auto;
-  padding: 1.25rem 1.5rem;
-  display: grid;
-  grid-template-columns: auto 1fr;
+  padding: calc(1.25rem - 0.45rem * var(--solstice-header-collapse)) 1.5rem;
+  display: flex;
   align-items: center;
-  column-gap: 1.5rem;
+  gap: 1.5rem;
   transition: padding 0.3s ease;
+}
+
+.solstice-header__inner > * {
+  align-self: center;
+  min-width: 0;
 }
 
 .solstice-brand {
@@ -371,51 +377,51 @@ body {
 }
 
 .solstice-brand__title {
-  font-size: clamp(1.35rem, 2vw + 0.5rem, 2rem);
-  font-weight: 700;
+  font-size: clamp(1.25rem, calc(1.2rem + 0.8vw - 0.3rem * var(--solstice-header-collapse)), 2rem);
+  font-weight: 600;
   letter-spacing: -0.02em;
   line-height: 1.05;
-  transition: font-size 0.3s ease;
+  transition: font-size 0.3s ease, font-weight 0.3s ease;
 }
 
 .solstice-brand__subtitle {
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   color: var(--solstice-muted);
-}
-
-.solstice-header.is-condensed .solstice-header__inner {
-  padding: 0.75rem 1.5rem;
+  max-height: 3rem;
+  opacity: 1;
+  overflow: hidden;
+  transition: opacity 0.25s ease, max-height 0.3s ease, transform 0.3s ease;
 }
 
 .solstice-header.is-condensed .solstice-brand__title {
-  font-size: clamp(0.95rem, 1.1vw + 0.35rem, 1.4rem);
-  font-weight: 500;
+  font-size: clamp(0.95rem, calc(1vw + 0.45rem), 1.35rem);
+  font-weight: 450;
 }
 
 .solstice-header.is-condensed .solstice-brand__subtitle {
-  display: none;
+  opacity: 0;
+  max-height: 0;
+  transform: translateY(-0.35rem);
 }
 
 .solstice-header__inner #tabsNav,
 .solstice-header__inner .solstice-nav {
+  margin-left: auto;
   display: flex;
   align-items: center;
-  justify-self: end;
-}
-
-.solstice-header.is-condensed #tabsNav,
-.solstice-header.is-condensed .solstice-nav {
-  display: flex;
-  align-items: center;
-  justify-self: end;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  align-content: center;
+  gap: 1.25rem;
 }
 
 .solstice-nav {
   display: flex;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1.25rem;
   justify-content: flex-end;
   flex-wrap: wrap;
+  align-content: center;
 }
 
 .solstice-nav__item {

--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -358,6 +358,7 @@ body {
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 1.5rem;
   align-items: center;
+  transition: padding 0.3s ease;
 }
 
 .solstice-brand {
@@ -372,11 +373,24 @@ body {
   font-size: clamp(1.35rem, 2vw + 0.5rem, 2rem);
   font-weight: 700;
   letter-spacing: -0.02em;
+  transition: font-size 0.3s ease;
 }
 
 .solstice-brand__subtitle {
   font-size: 0.95rem;
   color: var(--solstice-muted);
+}
+
+.solstice-header.is-condensed .solstice-header__inner {
+  padding: 0.75rem 1.5rem;
+}
+
+.solstice-header.is-condensed .solstice-brand__title {
+  font-size: clamp(1.05rem, 1.5vw + 0.35rem, 1.6rem);
+}
+
+.solstice-header.is-condensed .solstice-brand__subtitle {
+  display: none;
 }
 
 .solstice-nav {

--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -356,14 +356,14 @@ body {
   max-width: 960px;
   margin: 0 auto;
   padding: calc(1.25rem - 0.45rem * var(--solstice-header-collapse)) 1.5rem;
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
   align-items: center;
   gap: 1.5rem;
   transition: padding 0.3s ease;
 }
 
 .solstice-header__inner > * {
-  align-self: center;
   min-width: 0;
 }
 
@@ -377,7 +377,7 @@ body {
 }
 
 .solstice-brand__title {
-  font-size: clamp(1.25rem, calc(1.2rem + 0.8vw - 0.3rem * var(--solstice-header-collapse)), 2rem);
+  font-size: clamp(1.2rem, calc(1.25rem + 0.85vw - 0.45rem * var(--solstice-header-collapse)), 2rem);
   font-weight: 600;
   letter-spacing: -0.02em;
   line-height: 1.05;
@@ -393,9 +393,13 @@ body {
   transition: opacity 0.25s ease, max-height 0.3s ease, transform 0.3s ease;
 }
 
+.solstice-header.is-condensed .solstice-brand {
+  gap: 0;
+}
+
 .solstice-header.is-condensed .solstice-brand__title {
-  font-size: clamp(0.95rem, calc(1vw + 0.45rem), 1.35rem);
-  font-weight: 450;
+  font-size: clamp(0.85rem, calc(0.8rem + 0.55vw), 1.15rem);
+  font-weight: 400;
 }
 
 .solstice-header.is-condensed .solstice-brand__subtitle {
@@ -407,12 +411,15 @@ body {
 .solstice-header__inner #tabsNav,
 .solstice-header__inner .solstice-nav {
   margin-left: auto;
+  justify-self: end;
+  align-self: center;
   display: flex;
   align-items: center;
   justify-content: flex-end;
   flex-wrap: wrap;
   align-content: center;
   gap: 1.25rem;
+  row-gap: 0.5rem;
 }
 
 .solstice-nav {


### PR DESCRIPTION
## Summary
- shrink the Solstice header padding and title size when the condensed state is active
- hide the Solstice subtitle in the condensed state and add transitions for smoother changes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da2cd7ac5083289fd09337d1338925