### PR TITLE
Move footer search into meta section

### DIFF
--- a/assets/themes/solstice/modules/layout.js
+++ b/assets/themes/solstice/modules/layout.js
@@ -72,12 +72,6 @@ export function mount(context = {}) {
         <div class="solstice-footer__columns">
           <div class="solstice-footer__column solstice-footer__column--tools" data-footer-column="tools">
             <section class="solstice-footer__tools" id="toolsPanel" aria-label="Quick tools"></section>
-            <section class="solstice-footer__search" aria-label="Search">
-              <label class="solstice-search" for="searchInput">
-                <span class="solstice-search__icon" aria-hidden="true">🔍</span>
-                <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
-              </label>
-            </section>
           </div>
           <div class="solstice-footer__column solstice-footer__column--nav" data-footer-column="nav">
             <section class="solstice-footer__nav" aria-label="Secondary navigation">
@@ -92,6 +86,12 @@ export function mount(context = {}) {
         </div>
         <section class="solstice-footer__meta" aria-label="Site meta">
           <div class="solstice-footer__credit">NanoSite</div>
+          <section class="solstice-footer__search" aria-label="Search">
+            <label class="solstice-search" for="searchInput">
+              <span class="solstice-search__icon" aria-hidden="true">🔍</span>
+              <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
+            </label>
+          </section>
         </section>
       </div>`;
     return el;

--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -1992,6 +1992,10 @@ body {
   justify-content: flex-start;
 }
 
+.solstice-footer__meta > .solstice-footer__search {
+  margin-left: auto;
+}
+
 .solstice-footer__search .solstice-search {
   width: 100%;
   max-width: 360px;
@@ -2110,6 +2114,11 @@ body {
   .solstice-footer__meta {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .solstice-footer__meta > .solstice-footer__search {
+    margin-left: 0;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary
- move the footer search markup from the tools column into the meta section so it appears to the right of the site credit
- adjust footer meta styling so the search aligns to the right on wide screens and expands on small screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da4b4bf7e08328bb7d355463b29db1