### PR TITLE
Convert Solstice image cards to overlay layout

### DIFF
--- a/assets/themes/solstice/modules/interactions.js
+++ b/assets/themes/solstice/modules/interactions.js
@@ -206,7 +206,9 @@ function buildCard({ title, meta, translate, link, siteConfig }) {
   const date = meta && meta.date ? formatDisplayDate(meta.date) : '';
   const tags = meta ? renderTags(meta.tag) : '';
   const coverHtml = renderCardCover(meta, title, siteConfig);
-  return `<article class="solstice-card">
+  const hasCover = Boolean(coverHtml);
+  const cardClasses = `solstice-card${hasCover ? ' solstice-card--with-cover' : ''}`;
+  return `<article class="${cardClasses}">
     <a class="solstice-card__link" href="${escapeHtml(link)}">
       ${coverHtml}
       <div class="solstice-card__body">

--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -726,8 +726,7 @@ body {
 
 .solstice-card--with-cover .solstice-card__cover {
   border-radius: 0;
-  aspect-ratio: auto;
-  min-height: clamp(220px, 35vw, 320px);
+  aspect-ratio: 18 / 9;
 }
 
 .solstice-card--with-cover .solstice-card__cover img,

--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -687,6 +687,28 @@ body {
   transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
 }
 
+.solstice-card--with-cover .solstice-card__link {
+  position: relative;
+  display: block;
+  padding: 0;
+  overflow: hidden;
+  background: transparent;
+}
+
+.solstice-card--with-cover .solstice-card__link::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(0,0,0,0) 35%, rgba(0,0,0,0.75) 100%);
+  pointer-events: none;
+  transition: background 0.25s ease;
+}
+
+.solstice-card--with-cover .solstice-card__link:hover::after,
+.solstice-card--with-cover .solstice-card__link:focus-visible::after {
+  background: linear-gradient(180deg, rgba(0,0,0,0.15) 25%, rgba(0,0,0,0.85) 100%);
+}
+
 .solstice-card__link:hover,
 .solstice-card__link:focus-visible {
   transform: translateY(-6px);
@@ -700,6 +722,19 @@ body {
   border-radius: calc(var(--solstice-radius) + 4px);
   aspect-ratio: 16 / 9;
   background: rgba(0,0,0,0.05);
+}
+
+.solstice-card--with-cover .solstice-card__cover {
+  border-radius: 0;
+  aspect-ratio: auto;
+  min-height: clamp(220px, 35vw, 320px);
+}
+
+.solstice-card--with-cover .solstice-card__cover img,
+.solstice-card--with-cover .solstice-card__cover .ph-skeleton,
+.solstice-card--with-cover .solstice-card__cover.card-fallback {
+  border-radius: 0;
+  height: 100%;
 }
 
 .solstice-card__cover.card-fallback {
@@ -740,6 +775,37 @@ body {
   font-size: clamp(1.3rem, 2vw + 0.4rem, 1.9rem);
   margin: 0 0 0.75rem;
   letter-spacing: -0.015em;
+}
+
+.solstice-card--with-cover .solstice-card__body {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 1.75rem;
+  gap: 0.75rem;
+  color: rgba(255,255,255,0.94);
+  z-index: 1;
+}
+
+.solstice-card--with-cover .solstice-card__title {
+  margin-bottom: 0.4rem;
+  color: #fff;
+}
+
+.solstice-card--with-cover .solstice-card__meta {
+  color: rgba(255,255,255,0.8);
+}
+
+.solstice-card--with-cover .solstice-card__excerpt {
+  color: rgba(255,255,255,0.88);
+  margin-bottom: 0.5rem;
+}
+
+.solstice-card--with-cover .solstice-card__tags .tag {
+  background: rgba(255,255,255,0.2);
+  color: #fff;
 }
 
 .solstice-card__meta {


### PR DESCRIPTION
## Summary
- add a modifier class when a Solstice card renders with a cover image
- restyle covered cards so the artwork fills the tile and copy overlays with a gradient

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da60a9476c8328b57613044b7dcc94