### PR TITLE
Stack article meta vertically in solstice theme

### DIFF
--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -1078,8 +1078,8 @@ body {
 }
 
 .solstice-article__meta {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: clamp(1.25rem, 1rem + 1vw, 2rem);
   align-items: stretch;
 }


### PR DESCRIPTION
## Summary
- update the Solstice theme article metadata container to use a vertical layout
- keep existing spacing while switching from a responsive grid to a column stack

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da6d36ed648328868c2941ad9fc7f6