### PR TITLE
Update Solstice article figure presentation

### DIFF
--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -2027,6 +2027,11 @@ body {
   opacity: 1;
   transform: translateY(0);
   transition: opacity 180ms ease, transform 220ms ease;
+  pointer-events: none;
+}
+
+.solstice-article__body figure figcaption :is(a, button, input, textarea, select, summary, details, [tabindex]:not([tabindex="-1"])),
+.solstice-static__body figure figcaption :is(a, button, input, textarea, select, summary, details, [tabindex]:not([tabindex="-1"])) {
   pointer-events: auto;
 }
 
@@ -2044,7 +2049,6 @@ body {
   .solstice-static__body figure:focus-within figcaption {
     opacity: 1;
     transform: translateY(0);
-    pointer-events: auto;
   }
 
   @supports selector(:has(*)) {
@@ -2052,7 +2056,6 @@ body {
     .solstice-static__body figure:not(:has(:is(a, button, input, textarea, select, summary, details, [tabindex]:not([tabindex="-1"])))) figcaption {
       opacity: 1;
       transform: translateY(0);
-      pointer-events: auto;
     }
   }
 }
@@ -2062,7 +2065,6 @@ body {
   .solstice-static__body figure figcaption {
     opacity: 1;
     transform: translateY(0);
-    pointer-events: auto;
   }
 }
 

--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -2024,19 +2024,46 @@ body {
   color: #f5f5f7;
   text-align: center;
   background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.65) 100%);
-  opacity: 0;
-  transform: translateY(12px);
-  transition: opacity 180ms ease, transform 220ms ease;
-  pointer-events: none;
-}
-
-.solstice-article__body figure:hover figcaption,
-.solstice-static__body figure:hover figcaption,
-.solstice-article__body figure:focus-within figcaption,
-.solstice-static__body figure:focus-within figcaption {
   opacity: 1;
   transform: translateY(0);
+  transition: opacity 180ms ease, transform 220ms ease;
   pointer-events: auto;
+}
+
+@media (hover: hover) {
+  .solstice-article__body figure figcaption,
+  .solstice-static__body figure figcaption {
+    opacity: 0;
+    transform: translateY(12px);
+    pointer-events: none;
+  }
+
+  .solstice-article__body figure:hover figcaption,
+  .solstice-static__body figure:hover figcaption,
+  .solstice-article__body figure:focus-within figcaption,
+  .solstice-static__body figure:focus-within figcaption {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  @supports selector(:has(*)) {
+    .solstice-article__body figure:not(:has(:is(a, button, input, textarea, select, summary, details, [tabindex]:not([tabindex="-1"])))) figcaption,
+    .solstice-static__body figure:not(:has(:is(a, button, input, textarea, select, summary, details, [tabindex]:not([tabindex="-1"])))) figcaption {
+      opacity: 1;
+      transform: translateY(0);
+      pointer-events: auto;
+    }
+  }
+}
+
+@media (hover: none) {
+  .solstice-article__body figure figcaption,
+  .solstice-static__body figure figcaption {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
 }
 
 .solstice-article__footer {

--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -1985,21 +1985,24 @@ body {
   --solstice-figure-radius: calc(var(--solstice-media-radius) + 8px);
   margin: clamp(2rem, 4.5vw, 3.25rem) auto;
   max-width: min(100%, 860px);
+  position: relative;
   border-radius: var(--solstice-figure-radius);
   background: var(--solstice-media-bg);
   border: 1px solid var(--solstice-media-border);
   box-shadow: var(--solstice-media-shadow);
-  padding: clamp(1rem, 2vw, 1.75rem);
   overflow: hidden;
 }
 
 .solstice-article__body figure > :where(img, picture, video, iframe),
 .solstice-static__body figure > :where(img, picture, video, iframe) {
+  display: block;
+  width: 100%;
+  height: auto;
   margin: 0;
   border: none;
   box-shadow: none;
   background: transparent;
-  border-radius: calc(var(--solstice-figure-radius) - 10px);
+  border-radius: inherit;
 }
 
 .solstice-article__body figure picture img,
@@ -2012,11 +2015,28 @@ body {
 
 .solstice-article__body figure figcaption,
 .solstice-static__body figure figcaption {
-  margin-top: 1.25rem;
+  position: absolute;
+  inset: auto 0 0;
+  margin: 0;
+  padding: clamp(0.75rem, 1.6vw, 1.25rem);
   font-size: 0.92rem;
   line-height: 1.6;
-  color: var(--solstice-media-caption);
+  color: #f5f5f7;
   text-align: center;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.65) 100%);
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 180ms ease, transform 220ms ease;
+  pointer-events: none;
+}
+
+.solstice-article__body figure:hover figcaption,
+.solstice-static__body figure:hover figcaption,
+.solstice-article__body figure:focus-within figcaption,
+.solstice-static__body figure:focus-within figcaption {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
 }
 
 .solstice-article__footer {

--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -2027,11 +2027,6 @@ body {
   opacity: 1;
   transform: translateY(0);
   transition: opacity 180ms ease, transform 220ms ease;
-  pointer-events: none;
-}
-
-.solstice-article__body figure figcaption :is(a, button, input, textarea, select, summary, details, [tabindex]:not([tabindex="-1"])),
-.solstice-static__body figure figcaption :is(a, button, input, textarea, select, summary, details, [tabindex]:not([tabindex="-1"])) {
   pointer-events: auto;
 }
 
@@ -2049,6 +2044,7 @@ body {
   .solstice-static__body figure:focus-within figcaption {
     opacity: 1;
     transform: translateY(0);
+    pointer-events: auto;
   }
 
   @supports selector(:has(*)) {
@@ -2056,6 +2052,7 @@ body {
     .solstice-static__body figure:not(:has(:is(a, button, input, textarea, select, summary, details, [tabindex]:not([tabindex="-1"])))) figcaption {
       opacity: 1;
       transform: translateY(0);
+      pointer-events: auto;
     }
   }
 }
@@ -2065,6 +2062,7 @@ body {
   .solstice-static__body figure figcaption {
     opacity: 1;
     transform: translateY(0);
+    pointer-events: auto;
   }
 }
 

--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -2024,46 +2024,19 @@ body {
   color: #f5f5f7;
   text-align: center;
   background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.65) 100%);
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 180ms ease, transform 220ms ease;
+  pointer-events: none;
+}
+
+.solstice-article__body figure:hover figcaption,
+.solstice-static__body figure:hover figcaption,
+.solstice-article__body figure:focus-within figcaption,
+.solstice-static__body figure:focus-within figcaption {
   opacity: 1;
   transform: translateY(0);
-  transition: opacity 180ms ease, transform 220ms ease;
   pointer-events: auto;
-}
-
-@media (hover: hover) {
-  .solstice-article__body figure figcaption,
-  .solstice-static__body figure figcaption {
-    opacity: 0;
-    transform: translateY(12px);
-    pointer-events: none;
-  }
-
-  .solstice-article__body figure:hover figcaption,
-  .solstice-static__body figure:hover figcaption,
-  .solstice-article__body figure:focus-within figcaption,
-  .solstice-static__body figure:focus-within figcaption {
-    opacity: 1;
-    transform: translateY(0);
-    pointer-events: auto;
-  }
-
-  @supports selector(:has(*)) {
-    .solstice-article__body figure:not(:has(:is(a, button, input, textarea, select, summary, details, [tabindex]:not([tabindex="-1"])))) figcaption,
-    .solstice-static__body figure:not(:has(:is(a, button, input, textarea, select, summary, details, [tabindex]:not([tabindex="-1"])))) figcaption {
-      opacity: 1;
-      transform: translateY(0);
-      pointer-events: auto;
-    }
-  }
-}
-
-@media (hover: none) {
-  .solstice-article__body figure figcaption,
-  .solstice-static__body figure figcaption {
-    opacity: 1;
-    transform: translateY(0);
-    pointer-events: auto;
-  }
 }
 
 .solstice-article__footer {


### PR DESCRIPTION
## Summary
- remove extra figure padding so article media fills the Solstice card container
- overlay the figure caption and reveal it on hover or focus for a cleaner default presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da8ff3d7148328a67572d46a93b9e8