### PR TITLE
Limit solstice hero height

### DIFF
--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -1000,11 +1000,14 @@ body {
   border-radius: calc(var(--solstice-radius) + 6px);
   overflow: hidden;
   box-shadow: var(--solstice-shadow);
+  max-height: 66vh;
 }
 
 .solstice-article__hero img {
   width: 100%;
   height: auto;
+  max-height: inherit;
+  object-fit: cover;
   display: block;
 }
 


### PR DESCRIPTION
## Summary
- limit the Solstice article hero container to 66vh so it never exceeds two thirds of the viewport height
- ensure hero images respect the inherited limit and use object-fit cover for consistent cropping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da9c520c148328890b0331a107baf9