### PR TITLE
Add Bivium theme with dual-column layout

### DIFF
--- a/assets/themes/bivium/modules/interactions.js
+++ b/assets/themes/bivium/modules/interactions.js
@@ -1,0 +1,851 @@
+import { t, withLangParam, getCurrentLang, switchLanguage } from '../../../js/i18n.js';
+import {
+  renderTags,
+  escapeHtml,
+  formatDisplayDate,
+  cardImageSrc,
+  fallbackCover,
+  getContentRoot,
+  getQueryVariable,
+  sanitizeUrl,
+  sanitizeImageUrl
+} from '../../../js/utils.js';
+import {
+  applySavedTheme,
+  bindThemeToggle,
+  bindThemePackPicker,
+  bindPostEditor,
+  refreshLanguageSelector,
+  getSavedThemePack
+} from '../../../js/theme.js';
+import { hydratePostImages, hydratePostVideos, applyLazyLoadingIn, hydrateCardCovers } from '../../../js/post-render.js';
+import { renderPostMetaCard, renderOutdatedCard } from '../../../js/templates.js';
+import { attachHoverTooltip, renderTagSidebar as renderDefaultTags } from '../../../js/tags.js';
+import { prefersReducedMotion } from '../../../js/dom-utils.js';
+
+const defaultWindow = typeof window !== 'undefined' ? window : undefined;
+const defaultDocument = typeof document !== 'undefined' ? document : undefined;
+
+const CLASS_HIDDEN = 'is-hidden';
+
+let currentSiteConfig = null;
+
+function localized(cfg, key) {
+  if (!cfg) return '';
+  const val = cfg[key];
+  if (!val) return '';
+  if (typeof val === 'string') return val;
+  const lang = getCurrentLang && getCurrentLang();
+  if (lang && val[lang]) return val[lang];
+  return val.default || '';
+}
+
+function getRoleElement(role, documentRef = defaultDocument) {
+  if (!documentRef) return null;
+  switch (role) {
+    case 'main':
+      return documentRef.getElementById('mainview');
+    case 'toc':
+      return documentRef.getElementById('tocview');
+    case 'sidebar':
+      return documentRef.getElementById('tagview');
+    case 'content':
+      return documentRef.querySelector('.bivium-mainpanel');
+    case 'container':
+      return documentRef.querySelector('.bivium-shell');
+    default:
+      return null;
+  }
+}
+
+function fadeIn(element) {
+  if (!element) return;
+  element.classList.remove(CLASS_HIDDEN);
+  element.hidden = false;
+  element.style.removeProperty('display');
+  requestAnimationFrame(() => {
+    element.classList.add('is-visible');
+  });
+}
+
+function fadeOut(element, onDone) {
+  if (!element) {
+    if (typeof onDone === 'function') onDone();
+    return;
+  }
+  element.classList.remove('is-visible');
+  const finish = () => {
+    element.classList.add(CLASS_HIDDEN);
+    element.hidden = true;
+    if (typeof onDone === 'function') onDone();
+  };
+  if (prefersReducedMotion && prefersReducedMotion()) {
+    finish();
+  } else {
+    element.addEventListener('transitionend', finish, { once: true });
+    const timer = setTimeout(finish, 320);
+    element.addEventListener('transitioncancel', () => clearTimeout(timer), { once: true });
+  }
+}
+
+function resolveCoverSource(meta = {}, siteConfig = {}) {
+  const allowFallback = !(siteConfig && siteConfig.cardCoverFallback === false);
+  if (!meta) return { coverSrc: '', allowFallback };
+
+  const preferred = meta.thumb || meta.cover || meta.image;
+  let coverSrc = '';
+  if (typeof preferred === 'string') {
+    coverSrc = preferred.trim();
+  } else if (preferred && typeof preferred === 'object') {
+    const maybeString = preferred.src || preferred.url || '';
+    coverSrc = typeof maybeString === 'string' ? maybeString.trim() : '';
+  }
+
+  if (coverSrc) {
+    const isProtocolRelative = coverSrc.startsWith('//');
+    const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(coverSrc);
+    if (!hasScheme && !isProtocolRelative && !coverSrc.startsWith('/') && !coverSrc.startsWith('#')) {
+      const hasDirectorySegment = coverSrc.includes('/');
+      const isDotRelative = coverSrc.startsWith('./') || coverSrc.startsWith('../');
+      if (isDotRelative || !hasDirectorySegment) {
+        const baseLoc = meta && meta.location ? String(meta.location) : '';
+        const lastSlash = baseLoc.lastIndexOf('/');
+        const baseDir = lastSlash >= 0 ? baseLoc.slice(0, lastSlash + 1) : '';
+        if (isDotRelative) {
+          try {
+            const resolved = new URL(coverSrc, `https://example.invalid/${baseDir}`);
+            coverSrc = resolved.pathname.replace(/^\/+/, '');
+          } catch (_) {
+            coverSrc = `${baseDir}${coverSrc}`.replace(/\/+/g, '/');
+          }
+        } else {
+          coverSrc = `${baseDir}${coverSrc}`.replace(/\/+/g, '/');
+        }
+      }
+    }
+    const root = typeof getContentRoot === 'function' ? getContentRoot() : '';
+    const normalizedRoot = String(root || '').replace(/^\/+|\/+$/g, '');
+    if (normalizedRoot && coverSrc.startsWith(`${normalizedRoot}/`)) {
+      coverSrc = coverSrc.slice(normalizedRoot.length + 1);
+    }
+    const safeSrc = sanitizeImageUrl ? sanitizeImageUrl(coverSrc) : coverSrc;
+    if (safeSrc) {
+      return { coverSrc: safeSrc, allowFallback };
+    }
+  }
+
+  return { coverSrc: '', allowFallback };
+}
+
+function normalizeCoverUrl(coverSrc) {
+  if (!coverSrc) return '';
+  if (/^(?:https?:|data:|blob:)/i.test(coverSrc)) return coverSrc;
+  return cardImageSrc(coverSrc);
+}
+
+function renderCardCover(meta, title, siteConfig) {
+  const heading = typeof title === 'string' ? title : '';
+  const { coverSrc, allowFallback } = resolveCoverSource(meta, siteConfig);
+  if (coverSrc) {
+    const resolved = normalizeCoverUrl(coverSrc);
+    if (resolved) {
+      const alt = meta && meta.coverAlt ? meta.coverAlt : heading;
+      return `<div class="bivium-card__cover"><span class="ph-skeleton" aria-hidden="true"></span><img class="card-cover" src="${escapeHtml(resolved)}" alt="${escapeHtml(String(alt || ''))}" loading="lazy" decoding="async" fetchpriority="low" /></div>`;
+    }
+  }
+  if (allowFallback) {
+    const fallback = fallbackCover(heading);
+    return `<div class="bivium-card__cover card-cover-wrap">${fallback}</div>`;
+  }
+  return '';
+}
+
+function buildCard({ title, meta, translate, link, siteConfig }) {
+  const safeTitle = escapeHtml(String(title || 'Untitled'));
+  const excerpt = meta && meta.excerpt ? escapeHtml(String(meta.excerpt)) : '';
+  const date = meta && meta.date ? formatDisplayDate(meta.date) : '';
+  const tags = meta ? renderTags(meta.tag) : '';
+  const coverHtml = renderCardCover(meta, title, siteConfig);
+  const classes = ['bivium-card'];
+  if (coverHtml) classes.push('bivium-card--with-cover');
+  return `<article class="${classes.join(' ')}">
+    <a class="bivium-card__link" href="${escapeHtml(link)}">
+      ${coverHtml}
+      <div class="bivium-card__body">
+        <h3 class="bivium-card__title">${safeTitle}</h3>
+        ${date ? `<div class="bivium-card__meta">${escapeHtml(date)}</div>` : ''}
+        ${excerpt ? `<p class="bivium-card__excerpt">${excerpt}</p>` : ''}
+        ${tags ? `<div class="bivium-card__tags">${tags}</div>` : ''}
+      </div>
+    </a>
+  </article>`;
+}
+
+function buildPagination({ page, totalPages, baseHref, query }) {
+  if (!totalPages || totalPages <= 1) return '';
+  const mkHref = (p) => {
+    try {
+      const url = new URL(baseHref, defaultWindow ? defaultWindow.location.href : (typeof location !== 'undefined' ? location.href : ''));
+      url.searchParams.set('page', p);
+      if (query && query.q) {
+        if (query.q) url.searchParams.set('q', query.q);
+        else url.searchParams.delete('q');
+      }
+      if (query && query.tag) {
+        if (query.tag) url.searchParams.set('tag', query.tag);
+        else url.searchParams.delete('tag');
+      }
+      return url.toString();
+    } catch (_) {
+      return baseHref;
+    }
+  };
+  const items = [];
+  for (let i = 1; i <= totalPages; i++) {
+    const href = mkHref(i);
+    items.push(`<a class="bivium-page${i === page ? ' is-current' : ''}" href="${escapeHtml(href)}">${i}</a>`);
+  }
+  const prevHref = page > 1 ? mkHref(page - 1) : '';
+  const nextHref = page < totalPages ? mkHref(page + 1) : '';
+  return `<nav class="bivium-pagination" aria-label="${t('ui.pagination')}">
+    <a class="bivium-page prev${prevHref ? '' : ' is-disabled'}" href="${prevHref ? escapeHtml(prevHref) : '#'}" ${prevHref ? '' : 'aria-disabled="true"'}>${t('ui.prev')}</a>
+    <div class="bivium-page__list">${items.join('')}</div>
+    <a class="bivium-page next${nextHref ? '' : ' is-disabled'}" href="${nextHref ? escapeHtml(nextHref) : '#'}" ${nextHref ? '' : 'aria-disabled="true"'}>${t('ui.next')}</a>
+  </nav>`;
+}
+
+function decorateArticle(container, translate, utilities, markdown, meta, title) {
+  if (!container) return;
+  const copyBtn = container.querySelector('.post-meta-copy');
+  if (copyBtn) {
+    copyBtn.addEventListener('click', async () => {
+      const loc = defaultWindow && defaultWindow.location ? defaultWindow.location.href : (typeof location !== 'undefined' ? location.href : '');
+      const href = String(loc || '').split('#')[0];
+      let ok = false;
+      try {
+        const nav = defaultWindow && defaultWindow.navigator;
+        if (nav && nav.clipboard && typeof nav.clipboard.writeText === 'function') {
+          await nav.clipboard.writeText(href);
+          ok = true;
+        }
+      } catch (_) {}
+      if (!ok && defaultDocument && defaultDocument.execCommand) {
+        const temp = defaultDocument.createElement('textarea');
+        temp.value = href;
+        temp.setAttribute('readonly', '');
+        temp.style.position = 'absolute';
+        temp.style.left = '-9999px';
+        defaultDocument.body.appendChild(temp);
+        temp.select();
+        try { defaultDocument.execCommand('copy'); ok = true; } catch (_) {}
+        defaultDocument.body.removeChild(temp);
+      }
+      if (ok) {
+        copyBtn.classList.add('copied');
+        copyBtn.textContent = translate('ui.linkCopied');
+        setTimeout(() => {
+          copyBtn.classList.remove('copied');
+          copyBtn.textContent = translate('ui.copyLink');
+        }, 2200);
+      }
+    });
+  }
+
+  const aiFlags = Array.from(container.querySelectorAll('.post-meta-card .ai-flag'));
+  aiFlags.forEach(flag => attachHoverTooltip(flag, () => translate('ui.aiFlagTooltip'), { delay: 0 }));
+
+  try {
+    if (typeof utilities.hydratePostImages === 'function') utilities.hydratePostImages(container);
+    if (typeof utilities.hydratePostVideos === 'function') utilities.hydratePostVideos(container);
+    if (typeof utilities.applyLazyLoadingIn === 'function') utilities.applyLazyLoadingIn(container);
+  } catch (_) {}
+}
+
+function renderNavLinks(nav, tabsBySlug, activeSlug, postsEnabled, getHomeSlug) {
+  if (!nav) return;
+  const items = [];
+  const homeSlug = typeof getHomeSlug === 'function' ? getHomeSlug() : 'posts';
+  if (postsEnabled()) {
+    items.push({ slug: 'posts', label: t('ui.allPosts'), href: withLangParam('?tab=posts') });
+  }
+  Object.entries(tabsBySlug || {}).forEach(([slug, info]) => {
+    const label = info && info.title ? String(info.title) : slug;
+    items.push({ slug, label, href: withLangParam(`?tab=${encodeURIComponent(slug)}`) });
+  });
+  nav.innerHTML = items.map(item => `<a class="bivium-nav__item${item.slug === activeSlug ? ' is-current' : ''}" data-tab="${escapeHtml(item.slug)}" href="${escapeHtml(item.href)}">${escapeHtml(item.label)}</a>`).join('');
+  nav.setAttribute('data-active', activeSlug || homeSlug);
+}
+
+function renderFooterLinks(root, tabsBySlug, postsEnabled, getHomeSlug, getHomeLabel) {
+  if (!root) return;
+  const links = [];
+  const homeSlug = getHomeSlug();
+  const homeLabel = getHomeLabel();
+  if (postsEnabled()) {
+    links.push({ href: withLangParam(`?tab=${encodeURIComponent(homeSlug)}`), label: homeLabel });
+  }
+  Object.entries(tabsBySlug || {}).forEach(([slug, info]) => {
+    const label = info && info.title ? String(info.title) : slug;
+    links.push({ href: withLangParam(`?tab=${encodeURIComponent(slug)}`), label });
+  });
+  links.push({ href: withLangParam('?tab=search'), label: t('ui.searchTab') });
+  root.innerHTML = `<ul class="bivium-footernav__list">${links.map(link => `<li><a href="${escapeHtml(link.href)}">${escapeHtml(link.label)}</a></li>`).join('')}</ul>`;
+}
+
+function renderLinksList(root, cfg) {
+  if (!root) return;
+  const list = Array.isArray(cfg && cfg.profileLinks) ? cfg.profileLinks : [];
+  if (!list.length) {
+    root.innerHTML = `<li class="bivium-links__empty">${t('editor.site.noLinks')}</li>`;
+    return;
+  }
+  root.innerHTML = list.map(item => {
+    if (!item || !item.href) return '';
+    const label = item.label || item.href;
+    const href = sanitizeUrl(String(item.href));
+    if (!href) return '';
+    return `<li><a href="${escapeHtml(href)}" target="_blank" rel="noopener">${escapeHtml(label)}</a></li>`;
+  }).join('');
+}
+
+function updateSearchPlaceholder(documentRef = defaultDocument) {
+  const input = documentRef ? documentRef.getElementById('searchInput') : null;
+  if (!input) return;
+  input.setAttribute('placeholder', t('sidebar.searchPlaceholder'));
+}
+
+function sanitizePackValue(value) {
+  return String(value || '').trim().toLowerCase().replace(/[^a-z0-9_-]/g, '');
+}
+
+function prettifyPackLabel(value, label) {
+  if (label && String(label).trim()) return String(label).trim();
+  if (!value) return '';
+  return value.replace(/[-_]+/g, ' ').replace(/\b([a-z])/g, (m, c) => c.toUpperCase());
+}
+
+function populateThemePackOptions(documentRef = defaultDocument, windowRef = defaultWindow) {
+  const select = documentRef ? documentRef.getElementById('themePack') : null;
+  if (!select || !documentRef) return false;
+
+  const fallbackOptions = [
+    { value: 'native', label: 'Native' },
+    { value: 'solstice', label: 'Solstice' }
+  ];
+
+  const seen = new Set();
+
+  const appendOption = (value, label) => {
+    const sanitized = sanitizePackValue(value);
+    if (!sanitized || seen.has(sanitized)) return;
+    const option = documentRef.createElement('option');
+    option.value = sanitized;
+    option.textContent = prettifyPackLabel(sanitized, label);
+    select.appendChild(option);
+    seen.add(sanitized);
+  };
+
+  const ensureSavedOptionVisible = () => {
+    let saved = '';
+    try {
+      saved = getSavedThemePack ? getSavedThemePack() : '';
+    } catch (_) {
+      saved = '';
+    }
+    const normalized = sanitizePackValue(saved) || (select.options[0] ? select.options[0].value : '');
+    if (normalized && !Array.from(select.options).some(opt => opt.value === normalized)) {
+      appendOption(normalized, null);
+    }
+    if (normalized) {
+      select.value = normalized;
+    } else if (select.options.length) {
+      select.selectedIndex = 0;
+    }
+  };
+
+  const applyOptions = (options) => {
+    select.innerHTML = '';
+    seen.clear();
+    (options || []).forEach(item => {
+      if (!item) return;
+      const sourceValue = item.value != null ? item.value : (item.slug != null ? item.slug : item.name);
+      appendOption(sourceValue, item.label);
+    });
+    if (!select.options.length) {
+      fallbackOptions.forEach(item => appendOption(item.value, item.label));
+    }
+    ensureSavedOptionVisible();
+  };
+
+  try {
+    const packsData = windowRef && windowRef.__ns_themePacks ? windowRef.__ns_themePacks : null;
+    if (Array.isArray(packsData)) {
+      applyOptions(packsData);
+    } else {
+      applyOptions(null);
+    }
+  } catch (_) {
+    applyOptions(null);
+  }
+
+  ensureSavedOptionVisible();
+  return true;
+}
+
+function setupToolsPanel(documentRef = defaultDocument, windowRef = defaultWindow) {
+  const panel = documentRef && documentRef.getElementById('toolsPanel');
+  if (!panel) return false;
+  panel.innerHTML = `
+    <div class="bivium-tools" id="tools">
+      <button id="themeToggle" class="bivium-tool" type="button" aria-label="${t('tools.toggleTheme')}">
+        <span class="bivium-tool__icon">🌓</span>
+        <span class="bivium-tool__label">${t('tools.toggleTheme')}</span>
+      </button>
+      <button id="postEditor" class="bivium-tool" type="button" aria-label="${t('tools.postEditor')}">
+        <span class="bivium-tool__icon">📝</span>
+        <span class="bivium-tool__label">${t('tools.postEditor')}</span>
+      </button>
+      <label class="bivium-tool bivium-tool--select" for="themePack">
+        <span class="bivium-tool__label">${t('tools.themePack')}</span>
+        <select id="themePack"></select>
+      </label>
+      <label class="bivium-tool bivium-tool--select" for="langSelect">
+        <span class="bivium-tool__label">${t('tools.language')}</span>
+        <select id="langSelect"></select>
+      </label>
+      <button id="langReset" class="bivium-tool" type="button" aria-label="${t('tools.resetLanguage')}">
+        <span class="bivium-tool__icon">♻️</span>
+        <span class="bivium-tool__label">${t('tools.resetLanguage')}</span>
+      </button>
+    </div>`;
+  try { applySavedTheme(); } catch (_) {}
+  try { bindThemeToggle(); } catch (_) {}
+  try { bindPostEditor(); } catch (_) {}
+  try { populateThemePackOptions(documentRef, windowRef); } catch (_) {}
+  try { bindThemePackPicker(); } catch (_) {}
+  try { refreshLanguageSelector(); } catch (_) {}
+  try {
+    const langSel = documentRef.getElementById('langSelect');
+    if (langSel) {
+      langSel.addEventListener('change', () => {
+        const val = langSel.value || 'en';
+        switchLanguage(val);
+      });
+    }
+    const reset = documentRef.getElementById('langReset');
+    if (reset) {
+      reset.addEventListener('click', () => {
+        try { localStorage.removeItem('lang'); } catch (_) {}
+        try {
+          const url = new URL(windowRef ? windowRef.location.href : window.location.href);
+          url.searchParams.delete('lang');
+          if (windowRef && windowRef.history && windowRef.history.replaceState) {
+            windowRef.history.replaceState(windowRef.history.state, documentRef.title, url.toString());
+          }
+        } catch (_) {}
+        try {
+          if (windowRef && windowRef.__ns_softResetLang) {
+            windowRef.__ns_softResetLang();
+            return;
+          }
+        } catch (_) {}
+        try {
+          if (windowRef && windowRef.location) {
+            windowRef.location.reload();
+          }
+        } catch (_) {}
+      });
+    }
+  } catch (_) {}
+  return true;
+}
+
+function resetToolsPanel(documentRef = defaultDocument, windowRef = defaultWindow) {
+  const panel = documentRef && documentRef.getElementById('toolsPanel');
+  if (!panel) return false;
+  panel.innerHTML = '';
+  return setupToolsPanel(documentRef, windowRef);
+}
+
+function showToc(tocEl, tocHtml, articleTitle) {
+  if (!tocEl) return;
+  if (!tocHtml) {
+    tocEl.innerHTML = '';
+    tocEl.hidden = true;
+    return;
+  }
+  tocEl.innerHTML = `<div class="bivium-toc__inner"><div class="bivium-toc__title">${escapeHtml(articleTitle || t('ui.tableOfContents'))}</div>${tocHtml}</div>`;
+  tocEl.hidden = false;
+  fadeIn(tocEl);
+}
+
+function renderLoader(target, message) {
+  if (!target) return;
+  target.innerHTML = `<div class="bivium-loader" role="status">
+    <div class="bivium-loader__spinner"></div>
+    <div class="bivium-loader__text">${escapeHtml(message || t('ui.loading'))}</div>
+  </div>`;
+}
+
+function renderStaticView(container, title, html) {
+  if (!container) return;
+  const safeHtml = html != null ? html : '';
+  container.innerHTML = `<article class="bivium-static">
+    <header class="bivium-static__header">
+      <h1>${escapeHtml(title || '')}</h1>
+    </header>
+    <div class="bivium-static__body">${safeHtml}</div>
+  </article>`;
+}
+
+function renderPostArticle({
+  container,
+  title,
+  markdownHtml,
+  tocHtml,
+  markdown,
+  postMetadata,
+  siteConfig,
+  translate,
+  utilities
+}) {
+  if (!container) return { decorated: false, title };
+  const safeTitle = escapeHtml(String(title || 'Untitled Post'));
+  const metaHtml = renderPostMetaCard(title, postMetadata, markdown);
+  const outdated = renderOutdatedCard(postMetadata, siteConfig);
+  const cover = renderCardCover(postMetadata, title, siteConfig);
+  const hero = cover ? `<div class="bivium-article__hero">${cover}</div>` : '';
+  container.innerHTML = `<article class="bivium-article">
+    <header class="bivium-article__header">
+      ${hero}
+      <h1 class="bivium-article__title">${safeTitle}</h1>
+      ${metaHtml}
+    </header>
+    <div class="bivium-article__content">${markdownHtml}</div>
+    ${outdated}
+  </article>`;
+  if (tocHtml) {
+    const tocEl = getRoleElement('toc');
+    showToc(tocEl, tocHtml, title);
+  }
+  decorateArticle(container, translate, utilities, markdown, postMetadata, title);
+  return { decorated: true, title };
+}
+
+function handleDocumentClick(event, documentRef = defaultDocument) {
+  if (!event || !documentRef) return false;
+  const target = event.target;
+  if (!target || typeof target.closest !== 'function') return false;
+  if (target.closest('.bivium-nav__item')) return false;
+  return false;
+}
+
+function scrollViewportToTop(documentRef = defaultDocument, windowRef = defaultWindow) {
+  const behavior = prefersReducedMotion && prefersReducedMotion() ? 'auto' : 'smooth';
+  try {
+    if (windowRef && typeof windowRef.scrollTo === 'function') {
+      windowRef.scrollTo({ top: 0, left: 0, behavior });
+      return true;
+    }
+  } catch (_) {}
+  try {
+    if (windowRef && typeof windowRef.scrollTo === 'function') {
+      windowRef.scrollTo(0, 0);
+      return true;
+    }
+  } catch (_) {}
+  try {
+    if (documentRef) {
+      if (documentRef.documentElement) documentRef.documentElement.scrollTop = 0;
+      if (documentRef.body) documentRef.body.scrollTop = 0;
+      return true;
+    }
+  } catch (_) {}
+  return false;
+}
+
+function mountHooks(documentRef = defaultDocument, windowRef = defaultWindow) {
+  const hooks = {};
+
+  hooks.resolveViewContainers = ({ view }) => ({
+    view,
+    mainElement: getRoleElement('main', documentRef),
+    tocElement: getRoleElement('toc', documentRef),
+    sidebarElement: getRoleElement('sidebar', documentRef),
+    contentElement: getRoleElement('content', documentRef),
+    containerElement: getRoleElement('container', documentRef)
+  });
+
+  hooks.getViewContainer = ({ role }) => getRoleElement(role, documentRef);
+
+  hooks.showElement = ({ element }) => fadeIn(element);
+  hooks.hideElement = ({ element, onDone }) => { fadeOut(element, onDone); return true; };
+
+  hooks.renderSiteIdentity = ({ config }) => {
+    currentSiteConfig = config || currentSiteConfig;
+    const title = localized(config, 'siteTitle');
+    const subtitle = localized(config, 'siteSubtitle');
+    const titleEl = documentRef.querySelector('[data-site-title]');
+    const subtitleEl = documentRef.querySelector('[data-site-subtitle]');
+    if (titleEl) titleEl.textContent = title || 'NanoSite';
+    if (subtitleEl) subtitleEl.textContent = subtitle || '';
+  };
+
+  hooks.renderSiteLinks = ({ config }) => {
+    const root = documentRef.querySelector('[data-site-links]');
+    renderLinksList(root, config);
+  };
+
+  hooks.updateLayoutLoadingState = ({ isLoading, containerElement }) => {
+    const target = containerElement || getRoleElement('content', documentRef);
+    if (!target) return;
+    target.classList.toggle('is-loading', !!isLoading);
+  };
+
+  hooks.renderPostTOC = ({ tocElement, tocHtml, articleTitle }) => {
+    const toc = tocElement || getRoleElement('toc', documentRef);
+    showToc(toc, tocHtml, articleTitle);
+    return true;
+  };
+
+  hooks.renderErrorState = ({ targetElement, title, message, actions }) => {
+    const target = targetElement || getRoleElement('main', documentRef);
+    if (!target) return false;
+    const actionHtml = Array.isArray(actions) && actions.length
+      ? `<div class="bivium-error__actions">${actions.map(a => `<a class="bivium-btn" href="${escapeHtml(withLangParam(a.href || '#'))}">${escapeHtml(a.label || '')}</a>`).join('')}</div>`
+      : '';
+    const heading = title || t('errors.pageUnavailableTitle');
+    const body = message || t('errors.pageUnavailableBody');
+    target.innerHTML = `<section class="bivium-error" role="alert">
+      <h2>${escapeHtml(heading)}</h2>
+      <p>${escapeHtml(body)}</p>
+      ${actionHtml}
+    </section>`;
+    return true;
+  };
+
+  hooks.handleViewChange = ({ view }) => {
+    if (!documentRef || !documentRef.body) return;
+    documentRef.body.setAttribute('data-bivium-view', view || 'posts');
+    const toc = getRoleElement('toc', documentRef);
+    if (toc && view !== 'post') {
+      toc.hidden = true;
+      toc.innerHTML = '';
+    }
+    const input = documentRef.getElementById('searchInput');
+    if (input) input.value = view === 'search' ? (getQueryVariable('q') || '') : '';
+  };
+
+  hooks.renderTagSidebar = ({ postsIndex, utilities }) => {
+    const render = utilities && typeof utilities.renderTagSidebar === 'function'
+      ? utilities.renderTagSidebar
+      : renderDefaultTags;
+    try { render(postsIndex || {}); } catch (_) {}
+    return true;
+  };
+
+  hooks.enhanceIndexLayout = (params = {}) => {
+    const container = params.containerElement || getRoleElement('main', documentRef);
+    try { if (typeof hydrateCardCovers === 'function') hydrateCardCovers(container); } catch (_) {}
+    try { if (typeof applyLazyLoadingIn === 'function') applyLazyLoadingIn(container); } catch (_) {}
+    try { if (typeof params.setupSearch === 'function') params.setupSearch(params.allEntries || []); } catch (_) {}
+    try { if (typeof params.renderTagSidebar === 'function') params.renderTagSidebar(params.postsIndexMap || {}); } catch (_) {}
+    return true;
+  };
+
+  hooks.renderTabs = ({ tabsBySlug, activeSlug, getHomeSlug, postsEnabled }) => {
+    const nav = documentRef.getElementById('tabsNav');
+    if (!nav) return false;
+    renderNavLinks(nav, tabsBySlug, activeSlug, postsEnabled, getHomeSlug);
+    return true;
+  };
+
+  hooks.renderFooterNav = ({ tabsBySlug, getHomeSlug, getHomeLabel, postsEnabled }) => {
+    const nav = documentRef.querySelector('.bivium-footernav');
+    if (!nav) return false;
+    renderFooterLinks(nav, tabsBySlug, postsEnabled, getHomeSlug, getHomeLabel);
+    return true;
+  };
+
+  hooks.renderPostLoadingState = ({ containers, translator }) => {
+    const main = containers && containers.mainElement ? containers.mainElement : getRoleElement('main', documentRef);
+    renderLoader(main, translator('ui.loading'));
+    return true;
+  };
+
+  hooks.renderPostView = ({ containers, markdownHtml, tocHtml, markdown, fallbackTitle, postMetadata, siteConfig, translate, utilities }) => {
+    const main = containers && containers.mainElement ? containers.mainElement : getRoleElement('main', documentRef);
+    const title = (postMetadata && postMetadata.title) || fallbackTitle;
+    return renderPostArticle({
+      container: main,
+      title,
+      markdownHtml,
+      tocHtml,
+      markdown,
+      postMetadata,
+      siteConfig,
+      translate,
+      utilities
+    });
+  };
+
+  hooks.decoratePostView = ({ container, translate, utilities, markdown, postMetadata, articleTitle }) => {
+    decorateArticle(container, translate, utilities, markdown, postMetadata, articleTitle);
+    return true;
+  };
+
+  hooks.scrollToHash = ({ hash }) => {
+    if (!hash) return false;
+    const target = documentRef.getElementById(hash);
+    if (!target) return false;
+    target.scrollIntoView({ behavior: prefersReducedMotion && prefersReducedMotion() ? 'auto' : 'smooth', block: 'start' });
+    return true;
+  };
+
+  hooks.paginateEntries = ({ entries, page, pageSize }) => {
+    const start = (page - 1) * pageSize;
+    const end = start + pageSize;
+    return { pageEntries: entries.slice(start, end), page };
+  };
+
+  hooks.renderIndexView = ({ container, pageEntries, page, totalPages, withLangParam, translate, siteConfig }) => {
+    if (!container) return false;
+    const cards = pageEntries.map(([title, meta]) => buildCard({
+      title,
+      meta,
+      translate,
+      link: withLangParam(`?id=${encodeURIComponent(meta.location || '')}`),
+      siteConfig
+    })).join('');
+    const pagination = buildPagination({
+      page,
+      totalPages,
+      baseHref: withLangParam('?tab=posts'),
+      query: {}
+    });
+    container.innerHTML = `<div class="bivium-index">
+      <div class="bivium-cardgrid">${cards || `<p class="bivium-empty">${translate('ui.noResultsTitle') || 'No posts yet.'}</p>`}</div>
+      ${pagination}
+    </div>`;
+    return true;
+  };
+
+  hooks.afterIndexRender = ({ containerElement }) => {
+    try { if (typeof hydrateCardCovers === 'function') hydrateCardCovers(containerElement); } catch (_) {}
+    return true;
+  };
+
+  hooks.filterSearchEntries = ({ entries, query, tagFilter, utilities }) => {
+    const filter = utilities && typeof utilities.defaultFilter === 'function'
+      ? utilities.defaultFilter
+      : ((list, q, tag) => list);
+    return filter(entries, query, tagFilter);
+  };
+
+  hooks.renderSearchResults = ({ container, pageEntries, total, query, tagFilter, translate, withLangParam, page, totalPages }) => {
+    if (!container) return false;
+    const cards = pageEntries.map(([title, meta]) => buildCard({
+      title,
+      meta,
+      translate,
+      link: withLangParam(`?id=${encodeURIComponent(meta.location || '')}`),
+      siteConfig: currentSiteConfig || {}
+    })).join('');
+    const summary = query
+      ? translate('titles.search', query) || `Search: ${escapeHtml(query)}`
+      : (tagFilter ? (translate('ui.tagSearch', tagFilter) || `Tag: ${escapeHtml(tagFilter)}`) : translate('ui.searchTab'));
+    const countText = `${total} ${total === 1 ? 'result' : 'results'}`;
+    const pagination = buildPagination({
+      page,
+      totalPages,
+      baseHref: withLangParam('?tab=search'),
+      query: { q: query, tag: tagFilter }
+    });
+    container.innerHTML = `<div class="bivium-search">
+      <header class="bivium-search__header">
+        <h2>${summary}</h2>
+        <p>${countText}</p>
+      </header>
+      <div class="bivium-cardgrid">${cards || `<p class="bivium-empty">${translate('ui.noResultsBody', query) || 'No results found.'}</p>`}</div>
+      ${pagination}
+    </div>`;
+    return true;
+  };
+
+  hooks.afterSearchRender = ({ containerElement }) => {
+    try { if (typeof hydrateCardCovers === 'function') hydrateCardCovers(containerElement); } catch (_) {}
+    return true;
+  };
+
+  hooks.renderStaticTabLoadingState = ({ container }) => {
+    renderLoader(container, t('ui.loading'));
+    return true;
+  };
+
+  hooks.renderStaticTabView = ({ container, title, html }) => {
+    renderStaticView(container, title, html);
+    return true;
+  };
+
+  hooks.handleDocumentClick = ({ event }) => handleDocumentClick(event, documentRef);
+
+  hooks.handleRouteScroll = ({ document: doc, window: win } = {}) => {
+    const scrolled = scrollViewportToTop(doc || documentRef, win || windowRef);
+    return scrolled ? true : undefined;
+  };
+
+  hooks.handleWindowResize = () => true;
+
+  hooks.setupThemeControls = () => setupToolsPanel(documentRef, windowRef);
+  hooks.resetThemeControls = () => resetToolsPanel(documentRef, windowRef);
+  hooks.updateSearchPlaceholder = () => { updateSearchPlaceholder(documentRef); return true; };
+
+  hooks.setupResponsiveTabsObserver = () => {
+    const shell = documentRef.querySelector('.bivium-shell');
+    if (!shell || typeof IntersectionObserver === 'undefined') return false;
+    const nav = documentRef.querySelector('.bivium-nav');
+    if (!nav) return false;
+    const sentinel = documentRef.createElement('div');
+    sentinel.className = 'bivium-nav-sentinel';
+    shell.insertBefore(sentinel, shell.firstChild);
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        nav.classList.toggle('is-floating', !entry.isIntersecting);
+      });
+    });
+    observer.observe(sentinel);
+    return true;
+  };
+
+  hooks.reflectThemeConfig = ({ config }) => {
+    const root = documentRef.querySelector('.bivium-shell');
+    if (root && config && config.themePack) {
+      root.setAttribute('data-theme-pack', config.themePack);
+    }
+    return true;
+  };
+
+  hooks.setupFooter = () => {
+    const meta = documentRef.querySelector('.bivium-footer__credit');
+    if (meta) {
+      const year = new Date().getFullYear();
+      const siteTitle = localized(currentSiteConfig || {}, 'siteTitle') || 'NanoSite';
+      meta.textContent = `© ${year} ${siteTitle}`;
+    }
+    return true;
+  };
+
+  if (windowRef) {
+    windowRef.__ns_themeHooks = Object.assign({}, windowRef.__ns_themeHooks || {}, hooks);
+  }
+  return hooks;
+}
+
+export function mount(context = {}) {
+  const doc = context.document || defaultDocument;
+  const win = (context.document && context.document.defaultView) || defaultWindow;
+  mountHooks(doc, win);
+  updateSearchPlaceholder(doc);
+  setupToolsPanel(doc, win);
+  return context;
+}

--- a/assets/themes/bivium/modules/layout.js
+++ b/assets/themes/bivium/modules/layout.js
@@ -1,0 +1,134 @@
+const NAV_ID = 'tabsNav';
+const MAINVIEW_ID = 'mainview';
+const TOCVIEW_ID = 'tocview';
+const FOOTER_NAV_ID = 'footerNav';
+const TAGVIEW_ID = 'tagview';
+
+function ensureElement(parent, selector, creator) {
+  const existing = parent.querySelector(selector);
+  if (existing) return existing;
+  const el = creator();
+  parent.appendChild(el);
+  return el;
+}
+
+export function mount(context = {}) {
+  const doc = context.document || document;
+  if (!doc || !doc.body) return context;
+
+  let container = doc.querySelector('[data-theme-root="container"]');
+  if (!container) {
+    container = doc.createElement('div');
+    container.setAttribute('data-theme-root', 'container');
+    doc.body.insertBefore(container, doc.body.firstChild);
+  }
+  container.className = 'bivium-shell';
+
+  const sidebar = ensureElement(container, '.bivium-sidebar', () => {
+    const el = doc.createElement('aside');
+    el.className = 'bivium-sidebar';
+    el.setAttribute('role', 'complementary');
+    el.innerHTML = `
+      <div class="bivium-sidebar__inner">
+        <a class="bivium-brand" href="?tab=posts" data-site-home>
+          <div class="bivium-brand__emblem" aria-hidden="true"></div>
+          <div class="bivium-brand__text">
+            <div class="bivium-brand__title" data-site-title></div>
+            <div class="bivium-brand__subtitle" data-site-subtitle></div>
+          </div>
+        </a>
+        <div class="bivium-sidebar__info">
+          <ul class="bivium-links" data-site-links></ul>
+        </div>
+        <nav id="${NAV_ID}" class="bivium-nav" aria-label="Primary navigation"></nav>
+        <div id="toolsPanel" class="bivium-sidebar__tools" aria-label="Quick controls"></div>
+      </div>`;
+    return el;
+  });
+
+  const body = ensureElement(container, '.bivium-body', () => {
+    const el = doc.createElement('div');
+    el.className = 'bivium-body';
+    return el;
+  });
+
+  const bodyInner = ensureElement(body, '.bivium-body__inner', () => {
+    const el = doc.createElement('div');
+    el.className = 'bivium-body__inner';
+    return el;
+  });
+
+  const mainPanel = ensureElement(bodyInner, '.bivium-mainpanel', () => {
+    const el = doc.createElement('div');
+    el.className = 'bivium-mainpanel';
+    el.innerHTML = `
+      <header class="bivium-toolbar" aria-label="Site toolbar">
+        <label class="bivium-search" for="searchInput">
+          <span class="bivium-search__icon" aria-hidden="true">🔍</span>
+          <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
+        </label>
+      </header>`;
+    return el;
+  });
+
+  const mainview = ensureElement(mainPanel, `#${MAINVIEW_ID}`, () => {
+    const el = doc.createElement('section');
+    el.id = MAINVIEW_ID;
+    el.className = 'bivium-mainview';
+    el.setAttribute('tabindex', '-1');
+    el.setAttribute('role', 'main');
+    return el;
+  });
+
+  let tagBand = doc.getElementById(TAGVIEW_ID);
+  if (!tagBand) {
+    tagBand = doc.createElement('section');
+    tagBand.id = TAGVIEW_ID;
+  }
+  tagBand.className = 'bivium-tagpanel';
+  tagBand.setAttribute('aria-label', 'Tag filters');
+  if (tagBand.parentElement !== mainPanel) {
+    mainPanel.appendChild(tagBand);
+  }
+
+  const tocview = ensureElement(bodyInner, `#${TOCVIEW_ID}`, () => {
+    const el = doc.createElement('aside');
+    el.id = TOCVIEW_ID;
+    el.className = 'bivium-toc';
+    el.setAttribute('aria-label', 'Table of contents');
+    el.hidden = true;
+    return el;
+  });
+
+  const footer = ensureElement(body, '.bivium-footer', () => {
+    const el = doc.createElement('footer');
+    el.className = 'bivium-footer';
+    el.setAttribute('role', 'contentinfo');
+    el.innerHTML = `
+      <div class="bivium-footer__inner">
+        <div class="bivium-footer__nav" aria-label="Secondary navigation">
+          <div id="${FOOTER_NAV_ID}" class="bivium-footernav"></div>
+        </div>
+        <div class="bivium-footer__meta">
+          <div class="bivium-footer__credit">NanoSite</div>
+        </div>
+      </div>`;
+    return el;
+  });
+
+  context.document = doc;
+  context.regions = {
+    container,
+    sidebar,
+    main: mainPanel,
+    content: mainPanel,
+    mainview,
+    toc: tocview,
+    footer,
+    footerNav: footer.querySelector(`#${FOOTER_NAV_ID}`),
+    tagBand,
+    toolsPanel: sidebar.querySelector('#toolsPanel')
+  };
+
+  return context;
+}

--- a/assets/themes/bivium/theme.css
+++ b/assets/themes/bivium/theme.css
@@ -1,0 +1,1008 @@
+:root {
+  --bivium-bg: #f3f3f8;
+  --bivium-surface: rgba(255, 255, 255, 0.82);
+  --bivium-surface-strong: #ffffff;
+  --bivium-border: rgba(69, 56, 117, 0.12);
+  --bivium-border-strong: rgba(69, 56, 117, 0.25);
+  --bivium-shadow: 0 28px 60px rgba(27, 18, 66, 0.15);
+  --bivium-text: #282642;
+  --bivium-muted: #6b688b;
+  --bivium-accent: #7057ff;
+  --bivium-accent-strong: #4f2dff;
+  --bivium-highlight: rgba(112, 87, 255, 0.08);
+  --bivium-card-radius: 26px;
+  --bivium-font-ui: "Poppins", "SF Pro Display", "Segoe UI", sans-serif;
+  --bivium-font-body: "Source Sans 3", "Helvetica Neue", Arial, sans-serif;
+  --bivium-font-serif: "Iowan Old Style", "Times New Roman", Times, serif;
+  --bivium-code-bg: #15142a;
+  --bivium-code-border: rgba(255, 255, 255, 0.08);
+  --bivium-code-text: #f5f5ff;
+  --bivium-code-shadow: 0 18px 42px rgba(18, 12, 40, 0.4);
+  --bivium-code-accent: #ffaf45;
+  --bivium-scroll-track: rgba(112, 87, 255, 0.06);
+  --bivium-scroll-thumb: rgba(112, 87, 255, 0.35);
+  --bivium-callout-note: #7057ff;
+  --bivium-callout-info: #3298ff;
+  --bivium-callout-tip: #35c56c;
+  --bivium-callout-caution: #ffb347;
+  --bivium-callout-danger: #f55b7d;
+}
+
+[data-theme='dark'] {
+  --bivium-bg: radial-gradient(circle at top left, #141424 0%, #0b0b16 45%, #06060d 100%);
+  --bivium-surface: rgba(18, 17, 36, 0.86);
+  --bivium-surface-strong: rgba(25, 23, 54, 0.96);
+  --bivium-border: rgba(190, 180, 255, 0.08);
+  --bivium-border-strong: rgba(190, 180, 255, 0.18);
+  --bivium-shadow: 0 26px 48px rgba(4, 5, 15, 0.6);
+  --bivium-text: #e9e7ff;
+  --bivium-muted: #a8a5d4;
+  --bivium-accent: #a88bff;
+  --bivium-accent-strong: #cdb3ff;
+  --bivium-highlight: rgba(168, 139, 255, 0.12);
+  --bivium-code-bg: #0f0f1f;
+  --bivium-code-border: rgba(168, 139, 255, 0.18);
+  --bivium-code-text: #fdfcff;
+  --bivium-code-shadow: 0 22px 60px rgba(0, 0, 0, 0.5);
+  --bivium-code-accent: #ffd280;
+  --bivium-scroll-track: rgba(255, 255, 255, 0.08);
+  --bivium-scroll-thumb: rgba(168, 139, 255, 0.36);
+}
+
+html, body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--bivium-font-body);
+  color: var(--bivium-text);
+  background: var(--bivium-bg);
+  -webkit-font-smoothing: antialiased;
+  min-height: 100%;
+}
+
+a {
+  color: var(--bivium-accent-strong);
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--bivium-accent);
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(112, 87, 255, 0.12);
+  color: var(--bivium-accent-strong);
+  font-size: 0.8rem;
+  text-decoration: none;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(120% 80% at 0% 0%, rgba(112, 87, 255, 0.18), transparent 55%),
+              radial-gradient(120% 70% at 100% 0%, rgba(255, 143, 214, 0.16), transparent 60%);
+  pointer-events: none;
+  z-index: -2;
+}
+
+.bivium-shell {
+  display: flex;
+  align-items: stretch;
+  min-height: 100vh;
+  position: relative;
+  isolation: isolate;
+}
+
+.bivium-shell::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), transparent 60%);
+  pointer-events: none;
+  mix-blend-mode: screen;
+  opacity: 0.6;
+  z-index: -1;
+}
+
+[data-theme='dark'] .bivium-shell::after {
+  opacity: 0.25;
+  mix-blend-mode: normal;
+}
+
+.bivium-sidebar {
+  width: min(340px, 28vw);
+  padding: 48px 36px;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  backdrop-filter: blur(22px);
+  background: var(--bivium-surface);
+  border-right: 1px solid var(--bivium-border);
+  box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.12);
+  z-index: 4;
+}
+
+.bivium-sidebar__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  height: 100%;
+}
+
+.bivium-brand {
+  display: flex;
+  gap: 16px;
+  text-decoration: none;
+  align-items: center;
+  color: inherit;
+}
+
+.bivium-brand__emblem {
+  width: 64px;
+  height: 64px;
+  border-radius: 22px;
+  background: linear-gradient(150deg, var(--bivium-accent), rgba(255, 143, 214, 0.8));
+  box-shadow: 0 12px 35px rgba(112, 87, 255, 0.45);
+  position: relative;
+}
+
+.bivium-brand__emblem::after {
+  content: '';
+  position: absolute;
+  inset: 12px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.22);
+  backdrop-filter: blur(6px);
+}
+
+.bivium-brand__text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.bivium-brand__title {
+  font-family: var(--bivium-font-ui);
+  font-size: 1.45rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.bivium-brand__subtitle {
+  font-size: 0.95rem;
+  color: var(--bivium-muted);
+}
+
+.bivium-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.bivium-links li a {
+  color: inherit;
+  text-decoration: none;
+  font-size: 0.95rem;
+  opacity: 0.8;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.bivium-links li a:hover,
+.bivium-links li a:focus-visible {
+  opacity: 1;
+  color: var(--bivium-accent-strong);
+}
+
+.bivium-links__empty {
+  font-size: 0.9rem;
+  color: var(--bivium-muted);
+  opacity: 0.7;
+}
+
+.bivium-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.bivium-nav__item {
+  text-decoration: none;
+  color: inherit;
+  font-family: var(--bivium-font-ui);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  padding: 10px 14px;
+  border-radius: 16px;
+  position: relative;
+  transition: transform 160ms ease, color 160ms ease, background 160ms ease;
+  background: transparent;
+}
+
+.bivium-nav__item::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(112, 87, 255, 0.18), rgba(255, 143, 214, 0.14));
+  opacity: 0;
+  transition: opacity 160ms ease;
+  z-index: -1;
+}
+
+.bivium-nav__item:hover,
+.bivium-nav__item:focus-visible {
+  transform: translateX(6px);
+  color: var(--bivium-accent-strong);
+}
+
+.bivium-nav__item.is-current {
+  color: var(--bivium-accent-strong);
+}
+
+.bivium-nav__item.is-current::before,
+.bivium-nav__item:hover::before,
+.bivium-nav__item:focus-visible::before {
+  opacity: 1;
+}
+
+.bivium-sidebar__tools {
+  margin-top: auto;
+  padding-top: 16px;
+  border-top: 1px solid var(--bivium-border);
+}
+
+.bivium-tools {
+  display: grid;
+  gap: 12px;
+}
+
+.bivium-tool {
+  width: 100%;
+  border: none;
+  border-radius: 18px;
+  background: var(--bivium-surface-strong);
+  color: inherit;
+  padding: 12px 16px;
+  font-family: var(--bivium-font-ui);
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.08);
+  transition: transform 140ms ease, box-shadow 140ms ease;
+}
+
+.bivium-tool:hover,
+.bivium-tool:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 36px rgba(112, 87, 255, 0.18);
+  outline: none;
+}
+
+.bivium-tool--select {
+  cursor: default;
+}
+
+.bivium-tool--select select {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  appearance: none;
+}
+
+.bivium-tool__icon {
+  font-size: 1.1rem;
+}
+
+.bivium-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 48px 56px 56px;
+  position: relative;
+}
+
+.bivium-body__inner {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 48px;
+  align-items: start;
+}
+
+.bivium-mainpanel {
+  background: var(--bivium-surface);
+  border-radius: 32px;
+  box-shadow: var(--bivium-shadow);
+  padding: 36px 40px;
+  position: relative;
+  overflow: hidden;
+}
+
+.bivium-mainpanel::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  pointer-events: none;
+}
+
+.bivium-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 28px;
+}
+
+.bivium-search {
+  width: min(320px, 100%);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: 18px;
+  border: 1px solid var(--bivium-border);
+  background: var(--bivium-surface-strong);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.3);
+}
+
+.bivium-search__icon {
+  opacity: 0.6;
+}
+
+.bivium-search input {
+  border: none;
+  background: transparent;
+  width: 100%;
+  font: inherit;
+  color: inherit;
+  outline: none;
+}
+
+.bivium-mainview {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.bivium-cardgrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 28px;
+}
+
+.bivium-card {
+  border-radius: var(--bivium-card-radius);
+  background: var(--bivium-surface-strong);
+  border: 1px solid var(--bivium-border);
+  overflow: hidden;
+  box-shadow: 0 18px 32px rgba(17, 12, 45, 0.15);
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.bivium-card:hover,
+.bivium-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 28px 52px rgba(17, 12, 45, 0.22);
+}
+
+.bivium-card__link {
+  color: inherit;
+  text-decoration: none;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100%;
+}
+
+.bivium-card__cover {
+  position: relative;
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  background: var(--bivium-highlight);
+}
+
+.card-cover-wrap,
+.bivium-card__cover {
+  border-radius: inherit;
+}
+
+.card-cover-wrap {
+  position: relative;
+  display: block;
+  overflow: hidden;
+}
+
+.ph-skeleton {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.22));
+  animation: bivium-shimmer 1.6s linear infinite;
+}
+
+.bivium-card__cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.bivium-card__body {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.bivium-card__title {
+  font-family: var(--bivium-font-ui);
+  font-weight: 600;
+  font-size: 1.15rem;
+}
+
+.bivium-card__meta {
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--bivium-muted);
+}
+
+.bivium-card__excerpt {
+  color: color-mix(in srgb, var(--bivium-text) 70%, transparent);
+  font-style: italic;
+  transform: skewY(-2deg);
+  transform-origin: left;
+}
+
+.bivium-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.bivium-card__tags .tag {
+  font-size: 0.75rem;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--bivium-highlight);
+  color: var(--bivium-accent-strong);
+}
+
+.bivium-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 28px;
+}
+
+.bivium-page {
+  text-decoration: none;
+  font-family: var(--bivium-font-ui);
+  font-size: 0.9rem;
+  color: var(--bivium-text);
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  transition: background 140ms ease, color 140ms ease;
+}
+
+.bivium-page.is-current {
+  background: var(--bivium-accent);
+  color: #fff;
+  box-shadow: 0 18px 36px rgba(112, 87, 255, 0.28);
+}
+
+.bivium-page:hover,
+.bivium-page:focus-visible {
+  border-color: var(--bivium-accent);
+  color: var(--bivium-accent-strong);
+}
+
+.bivium-page.is-disabled {
+  pointer-events: none;
+  opacity: 0.45;
+}
+
+.bivium-tagpanel {
+  margin-top: 36px;
+  border-radius: 20px;
+  background: rgba(112, 87, 255, 0.12);
+  border: 1px dashed var(--bivium-border);
+  padding: 18px;
+}
+
+.bivium-tagpanel .taglist {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.bivium-tagpanel .tag {
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: var(--bivium-surface-strong);
+  border: 1px solid transparent;
+  color: inherit;
+  text-decoration: none;
+  font-size: 0.85rem;
+}
+
+.bivium-tagpanel .tag:hover,
+.bivium-tagpanel .tag:focus-visible {
+  border-color: var(--bivium-accent);
+  color: var(--bivium-accent-strong);
+}
+
+.bivium-toc {
+  position: sticky;
+  top: 48px;
+  background: var(--bivium-surface);
+  border-radius: 24px;
+  padding: 24px;
+  border: 1px solid var(--bivium-border);
+  box-shadow: var(--bivium-shadow);
+  max-height: calc(100vh - 96px);
+  overflow: hidden;
+}
+
+.bivium-toc__inner {
+  overflow-y: auto;
+  max-height: inherit;
+  padding-right: 8px;
+}
+
+.bivium-toc__inner::-webkit-scrollbar {
+  width: 6px;
+}
+
+.bivium-toc__inner::-webkit-scrollbar-track {
+  background: var(--bivium-scroll-track);
+}
+
+.bivium-toc__inner::-webkit-scrollbar-thumb {
+  background: var(--bivium-scroll-thumb);
+  border-radius: 999px;
+}
+
+.bivium-toc__title {
+  font-family: var(--bivium-font-ui);
+  font-weight: 600;
+  margin-bottom: 12px;
+  letter-spacing: 0.02em;
+}
+
+.bivium-toc nav ul {
+  list-style: none;
+  padding-left: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.bivium-toc nav a {
+  text-decoration: none;
+  color: inherit;
+  font-size: 0.92rem;
+  line-height: 1.4;
+  opacity: 0.78;
+}
+
+.bivium-toc nav a:hover,
+.bivium-toc nav a:focus-visible {
+  opacity: 1;
+  color: var(--bivium-accent-strong);
+}
+
+.bivium-article__header {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.bivium-article__hero {
+  border-radius: 28px;
+  overflow: hidden;
+  background: var(--bivium-highlight);
+  box-shadow: 0 20px 44px rgba(17, 12, 45, 0.28);
+}
+
+.bivium-article__hero img,
+.bivium-article__hero .card-cover {
+  width: 100%;
+  display: block;
+}
+
+.bivium-article__title {
+  font-family: var(--bivium-font-serif);
+  font-weight: 600;
+  font-size: clamp(2.2rem, 3vw, 3rem);
+  letter-spacing: 0.01em;
+}
+
+.bivium-article__content {
+  display: grid;
+  gap: 20px;
+  font-size: 1.05rem;
+  line-height: 1.75;
+}
+
+.bivium-article__content p {
+  margin: 0;
+}
+
+.bivium-article__content h2,
+.bivium-article__content h3,
+.bivium-article__content h4 {
+  font-family: var(--bivium-font-serif);
+  margin-top: 32px;
+  margin-bottom: 12px;
+}
+
+.bivium-article__content blockquote {
+  margin: 0;
+  padding: 20px 24px;
+  border-left: 4px solid var(--bivium-accent);
+  background: rgba(112, 87, 255, 0.08);
+  border-radius: 14px;
+  font-style: italic;
+}
+
+.bivium-article__content a {
+  color: var(--bivium-accent-strong);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-decoration-color: color-mix(in srgb, var(--bivium-accent-strong) 50%, transparent);
+}
+
+.bivium-article__content pre {
+  background: var(--bivium-code-bg);
+  color: var(--bivium-code-text);
+  padding: 18px 20px;
+  border-radius: 18px;
+  border: 1px solid var(--bivium-code-border);
+  box-shadow: var(--bivium-code-shadow);
+  overflow: auto;
+  font-size: 0.92rem;
+}
+
+.bivium-article__content code {
+  font-family: "JetBrains Mono", "Fira Code", "Menlo", monospace;
+  background: rgba(112, 87, 255, 0.12);
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+
+.bivium-article__content pre code {
+  background: transparent;
+  padding: 0;
+}
+
+.bivium-article__content table {
+  width: 100%;
+  border-collapse: collapse;
+  overflow: hidden;
+  border-radius: 16px;
+  box-shadow: inset 0 0 0 1px var(--bivium-border);
+}
+
+.bivium-article__content th,
+.bivium-article__content td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--bivium-border);
+  text-align: left;
+}
+
+.bivium-article__content tr:nth-child(odd) {
+  background: rgba(112, 87, 255, 0.05);
+}
+
+.post-meta-card {
+  border-radius: 20px;
+  padding: 18px 22px;
+  background: rgba(112, 87, 255, 0.12);
+  position: relative;
+  overflow: hidden;
+}
+
+.post-meta-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  pointer-events: none;
+}
+
+.post-meta-title {
+  font-family: var(--bivium-font-ui);
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.post-meta-line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: 0.9rem;
+  color: var(--bivium-muted);
+}
+
+.post-meta-copy {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  background: var(--bivium-surface-strong);
+  border: none;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  color: var(--bivium-accent-strong);
+  box-shadow: 0 8px 18px rgba(112, 87, 255, 0.24);
+}
+
+.post-meta-copy.copied {
+  background: var(--bivium-accent);
+  color: #fff;
+}
+
+.post-outdated-card {
+  margin-top: 36px;
+  padding: 18px 22px;
+  border-radius: 18px;
+  background: rgba(255, 176, 92, 0.15);
+  border: 1px solid rgba(255, 176, 92, 0.35);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.post-outdated-close {
+  background: transparent;
+  border: none;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  color: inherit;
+}
+
+.bivium-error {
+  text-align: center;
+  padding: 64px 32px;
+  border-radius: 24px;
+  border: 1px solid var(--bivium-border-strong);
+  background: rgba(255, 96, 139, 0.08);
+  box-shadow: 0 18px 34px rgba(255, 96, 139, 0.24);
+}
+
+.bivium-error__actions {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.bivium-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 18px;
+  border-radius: 999px;
+  background: var(--bivium-accent);
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+  box-shadow: 0 18px 32px rgba(112, 87, 255, 0.24);
+}
+
+.bivium-loader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 16px;
+  padding: 64px 0;
+}
+
+.bivium-loader__spinner {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  border: 4px solid rgba(112, 87, 255, 0.15);
+  border-top-color: var(--bivium-accent);
+  animation: bivium-spin 720ms linear infinite;
+}
+
+@keyframes bivium-spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes bivium-shimmer {
+  0% { transform: translateX(-60%); }
+  100% { transform: translateX(60%); }
+}
+
+.bivium-search__header {
+  margin-bottom: 28px;
+  display: grid;
+  gap: 6px;
+}
+
+.bivium-empty {
+  text-align: center;
+  font-size: 1rem;
+  color: var(--bivium-muted);
+}
+
+.bivium-footer {
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid var(--bivium-border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--bivium-muted);
+  font-size: 0.9rem;
+}
+
+.bivium-footernav__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 18px;
+}
+
+.bivium-footernav__list a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.bivium-footernav__list a:hover,
+.bivium-footernav__list a:focus-visible {
+  color: var(--bivium-accent-strong);
+}
+
+.is-loading {
+  position: relative;
+  min-height: 160px;
+}
+
+.is-loading::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.3);
+  backdrop-filter: blur(6px);
+  animation: bivium-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes bivium-pulse {
+  0%, 100% { opacity: 0.1; }
+  50% { opacity: 0.25; }
+}
+
+[data-theme='dark'] .bivium-card,
+[data-theme='dark'] .bivium-mainpanel,
+[data-theme='dark'] .bivium-toc,
+[data-theme='dark'] .bivium-sidebar,
+[data-theme='dark'] .bivium-tool,
+[data-theme='dark'] .bivium-search {
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.48);
+}
+
+[data-theme='dark'] .bivium-card__tags .tag,
+[data-theme='dark'] .bivium-tagpanel .tag {
+  background: rgba(168, 139, 255, 0.12);
+}
+
+[data-theme='dark'] .bivium-card__meta,
+[data-theme='dark'] .bivium-links li a,
+[data-theme='dark'] .bivium-footer {
+  color: var(--bivium-muted);
+}
+
+[data-theme='dark'] .post-meta-card {
+  background: rgba(168, 139, 255, 0.16);
+}
+
+[data-theme='dark'] .post-meta-copy {
+  background: rgba(0, 0, 0, 0.45);
+  color: var(--bivium-accent-strong);
+}
+
+[data-theme='dark'] .post-meta-copy.copied {
+  background: var(--bivium-accent-strong);
+  color: #140f2a;
+}
+
+[data-theme='dark'] .bivium-article__content code {
+  background: rgba(168, 139, 255, 0.18);
+}
+
+[data-theme='dark'] .bivium-article__content tr:nth-child(odd) {
+  background: rgba(168, 139, 255, 0.08);
+}
+
+[data-theme='dark'] .bivium-error {
+  background: rgba(255, 96, 139, 0.18);
+  border-color: rgba(255, 96, 139, 0.32);
+}
+
+@media (max-width: 1280px) {
+  .bivium-body {
+    padding: 36px 32px 48px;
+  }
+
+  .bivium-body__inner {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .bivium-toc {
+    position: static;
+    max-height: none;
+  }
+}
+
+@media (max-width: 980px) {
+  .bivium-shell {
+    flex-direction: column;
+  }
+
+  .bivium-sidebar {
+    position: static;
+    width: auto;
+    height: auto;
+    padding: 28px 24px;
+    border-right: none;
+    border-bottom: 1px solid var(--bivium-border);
+    flex-direction: column;
+  }
+
+  .bivium-body {
+    padding: 28px 24px 48px;
+  }
+}
+
+@media (max-width: 640px) {
+  .bivium-mainpanel {
+    padding: 26px 24px;
+  }
+
+  .bivium-toolbar {
+    justify-content: center;
+  }
+
+  .bivium-cardgrid {
+    grid-template-columns: 1fr;
+  }
+
+  .bivium-footer {
+    flex-direction: column;
+    gap: 12px;
+  }
+}

--- a/assets/themes/bivium/theme.json
+++ b/assets/themes/bivium/theme.json
@@ -1,0 +1,7 @@
+{
+  "name": "Bivium",
+  "modules": [
+    "modules/layout.js",
+    "modules/interactions.js"
+  ]
+}

--- a/assets/themes/packs.json
+++ b/assets/themes/packs.json
@@ -1,4 +1,5 @@
 [
   { "value": "native", "label": "Native" },
-  { "value": "solstice", "label": "Solstice" }
+  { "value": "solstice", "label": "Solstice" },
+  { "value": "bivium", "label": "Bivium" }
 ]

--- a/site.yaml
+++ b/site.yaml
@@ -41,7 +41,7 @@ contentRoot: wwwroot      # Root directory for content files
 
 # Theme override configurations
 themeMode: user
-themePack: solstice
+themePack: bivium
 themeOverride: true
 
 # Repository information used for internal linking of "report issue" etc.


### PR DESCRIPTION
## Summary
- add the new Bivium theme with a fixed sidebar and content column layout
- implement theme-specific interactions for cards, search, TOC, and theme controls
- register the Bivium pack and switch the demo configuration to use it by default

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68da8e1915348328847104bd5439bd0b