### PR TITLE
Add Arcus dual-column theme

### DIFF
--- a/assets/themes/arcus/modules/interactions.js
+++ b/assets/themes/arcus/modules/interactions.js
@@ -1,0 +1,970 @@
+import { t, withLangParam, getCurrentLang, switchLanguage } from '../../../js/i18n.js';
+import {
+  renderTags,
+  escapeHtml,
+  formatDisplayDate,
+  cardImageSrc,
+  fallbackCover,
+  getContentRoot,
+  getQueryVariable,
+  sanitizeUrl,
+  sanitizeImageUrl
+} from '../../../js/utils.js';
+import {
+  applySavedTheme,
+  bindThemeToggle,
+  bindThemePackPicker,
+  bindPostEditor,
+  refreshLanguageSelector,
+  getSavedThemePack
+} from '../../../js/theme.js';
+import { hydratePostImages, hydratePostVideos, applyLazyLoadingIn, hydrateCardCovers } from '../../../js/post-render.js';
+import { renderPostMetaCard, renderOutdatedCard } from '../../../js/templates.js';
+import { attachHoverTooltip, renderTagSidebar as renderDefaultTags } from '../../../js/tags.js';
+import { prefersReducedMotion } from '../../../js/dom-utils.js';
+
+const defaultWindow = typeof window !== 'undefined' ? window : undefined;
+const defaultDocument = typeof document !== 'undefined' ? document : undefined;
+
+const CLASS_HIDDEN = 'is-hidden';
+
+let currentSiteConfig = null;
+
+function scrollViewportToTop(documentRef = defaultDocument, windowRef = defaultWindow) {
+  const behavior = prefersReducedMotion() ? 'auto' : 'smooth';
+  try {
+    if (windowRef && typeof windowRef.scrollTo === 'function') {
+      windowRef.scrollTo({ top: 0, left: 0, behavior });
+      return true;
+    }
+  } catch (_) { /* fall through to legacy handling */ }
+  try {
+    if (windowRef && typeof windowRef.scrollTo === 'function') {
+      windowRef.scrollTo(0, 0);
+      return true;
+    }
+  } catch (_) { /* fall through to DOM fallback */ }
+  try {
+    if (documentRef) {
+      if (documentRef.documentElement) documentRef.documentElement.scrollTop = 0;
+      if (documentRef.body) documentRef.body.scrollTop = 0;
+      return true;
+    }
+  } catch (_) { /* no-op */ }
+  return false;
+}
+
+function setupDynamicBackground(documentRef = defaultDocument, windowRef = defaultWindow) {
+  const root = documentRef && documentRef.querySelector ? documentRef.querySelector('.arcus-shell') : null;
+  if (!root) return false;
+
+  if (typeof prefersReducedMotion === 'function' && prefersReducedMotion()) {
+    root.style.setProperty('--arcus-scroll-offset', '0px');
+    root.style.setProperty('--arcus-scroll-tilt', '0deg');
+    return false;
+  }
+
+  let frame = null;
+
+  const readScrollPosition = () => {
+    frame = null;
+    let scrollY = 0;
+    if (windowRef && typeof windowRef.scrollY === 'number') {
+      scrollY = windowRef.scrollY;
+    } else if (documentRef && documentRef.documentElement) {
+      scrollY = documentRef.documentElement.scrollTop || 0;
+    }
+    const clampedOffset = Math.max(-800, Math.min(1600, scrollY));
+    const tilt = Math.max(-6, Math.min(10, clampedOffset * 0.01));
+    root.style.setProperty('--arcus-scroll-offset', `${clampedOffset}px`);
+    root.style.setProperty('--arcus-scroll-tilt', `${tilt}deg`);
+  };
+
+  const queueUpdate = () => {
+    if (frame != null) return;
+    if (windowRef && typeof windowRef.requestAnimationFrame === 'function') {
+      frame = windowRef.requestAnimationFrame(readScrollPosition);
+    } else {
+      frame = setTimeout(readScrollPosition, 16);
+    }
+  };
+
+  readScrollPosition();
+  queueUpdate();
+
+  if (windowRef && typeof windowRef.addEventListener === 'function') {
+    windowRef.addEventListener('scroll', queueUpdate, { passive: true });
+    windowRef.addEventListener('resize', queueUpdate);
+  }
+
+  return true;
+}
+
+function resolveCoverSource(meta = {}, siteConfig = {}) {
+  const allowFallback = !(siteConfig && siteConfig.cardCoverFallback === false);
+  if (!meta) return { coverSrc: '', allowFallback };
+
+  const preferred = meta.thumb || meta.cover || meta.image;
+  let coverSrc = '';
+  if (typeof preferred === 'string') {
+    coverSrc = preferred.trim();
+  } else if (preferred && typeof preferred === 'object') {
+    const maybeString = preferred.src || preferred.url || '';
+    coverSrc = typeof maybeString === 'string' ? maybeString.trim() : '';
+  }
+
+  if (coverSrc) {
+    const isProtocolRelative = coverSrc.startsWith('//');
+    const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(coverSrc);
+    if (!hasScheme && !isProtocolRelative && !coverSrc.startsWith('/') && !coverSrc.startsWith('#')) {
+      const hasDirectorySegment = coverSrc.includes('/');
+      const isDotRelative = coverSrc.startsWith('./') || coverSrc.startsWith('../');
+      if (isDotRelative || !hasDirectorySegment) {
+        const baseLoc = meta && meta.location ? String(meta.location) : '';
+        const lastSlash = baseLoc.lastIndexOf('/');
+        const baseDir = lastSlash >= 0 ? baseLoc.slice(0, lastSlash + 1) : '';
+        if (isDotRelative) {
+          try {
+            const resolved = new URL(coverSrc, `https://example.invalid/${baseDir}`);
+            coverSrc = resolved.pathname.replace(/^\/+/, '');
+          } catch (_) {
+            coverSrc = `${baseDir}${coverSrc}`.replace(/\/+/g, '/');
+          }
+        } else {
+          coverSrc = `${baseDir}${coverSrc}`.replace(/\/+/g, '/');
+        }
+      }
+    }
+    const root = typeof getContentRoot === 'function' ? getContentRoot() : '';
+    const normalizedRoot = String(root || '').replace(/^\/+|\/+$/g, '');
+    if (normalizedRoot && coverSrc.startsWith(`${normalizedRoot}/`)) {
+      coverSrc = coverSrc.slice(normalizedRoot.length + 1);
+    }
+    const safeSrc = sanitizeImageUrl ? sanitizeImageUrl(coverSrc) : coverSrc;
+    if (safeSrc) {
+      return { coverSrc: safeSrc, allowFallback };
+    }
+  }
+
+  return { coverSrc: '', allowFallback };
+}
+
+function applyArcusCoverClass(markup) {
+  if (!markup) return '';
+  if (markup.includes('arcus-card__cover')) return markup;
+  if (markup.includes('card-cover-wrap')) {
+    return markup.replace('card-cover-wrap', 'card-cover-wrap arcus-card__cover');
+  }
+  return `<div class="arcus-card__cover">${markup}</div>`;
+}
+
+function normalizeCoverUrl(coverSrc) {
+  if (!coverSrc) return '';
+  if (/^(?:https?:|data:|blob:)/i.test(coverSrc)) return coverSrc;
+  return cardImageSrc(coverSrc);
+}
+
+function renderCardCover(meta, title, siteConfig) {
+  const heading = typeof title === 'string' ? title : '';
+  const { coverSrc, allowFallback } = resolveCoverSource(meta, siteConfig);
+  if (coverSrc) {
+    const resolved = normalizeCoverUrl(coverSrc);
+    if (resolved) {
+      const alt = meta && meta.coverAlt ? meta.coverAlt : heading;
+      return `<div class="arcus-card__cover card-cover-wrap"><span class="ph-skeleton" aria-hidden="true"></span><img class="card-cover" src="${escapeHtml(resolved)}" alt="${escapeHtml(String(alt || ''))}" loading="lazy" decoding="async" fetchpriority="low" /></div>`;
+    }
+  }
+  if (allowFallback) {
+    const fallback = fallbackCover(heading);
+    return applyArcusCoverClass(fallback);
+  }
+  return '';
+}
+
+function renderHeroImage(meta, title, siteConfig) {
+  const heading = typeof title === 'string' ? title : '';
+  const { coverSrc } = resolveCoverSource(meta, siteConfig);
+  if (!coverSrc) return '';
+  const resolved = normalizeCoverUrl(coverSrc);
+  if (!resolved) return '';
+  const alt = meta && meta.coverAlt ? meta.coverAlt : heading;
+  return `<div class="arcus-article__hero"><img src="${escapeHtml(resolved)}" alt="${escapeHtml(String(alt || ''))}" loading="lazy" decoding="async" /></div>`;
+}
+
+function localized(cfg, key) {
+  if (!cfg) return '';
+  const val = cfg[key];
+  if (!val) return '';
+  if (typeof val === 'string') return val;
+  const lang = getCurrentLang && getCurrentLang();
+  if (lang && val[lang]) return val[lang];
+  return val.default || '';
+}
+
+function getRoleElement(role, documentRef = defaultDocument) {
+  if (!documentRef) return null;
+  switch (role) {
+    case 'main':
+      return documentRef.getElementById('mainview');
+    case 'toc':
+      return documentRef.getElementById('tocview');
+    case 'sidebar':
+      return documentRef.getElementById('tagview');
+    case 'content':
+      return documentRef.querySelector('.arcus-main');
+    case 'container':
+      return documentRef.querySelector('.arcus-shell');
+    default:
+      return null;
+  }
+}
+
+function fadeIn(element) {
+  if (!element) return;
+  element.classList.remove(CLASS_HIDDEN);
+  element.hidden = false;
+  element.style.removeProperty('display');
+  requestAnimationFrame(() => {
+    element.classList.add('is-visible');
+  });
+}
+
+function fadeOut(element, onDone) {
+  if (!element) { if (typeof onDone === 'function') onDone(); return; }
+  element.classList.remove('is-visible');
+  const finish = () => {
+    element.classList.add(CLASS_HIDDEN);
+    element.hidden = true;
+    if (typeof onDone === 'function') onDone();
+  };
+  if (prefersReducedMotion()) {
+    finish();
+  } else {
+    element.addEventListener('transitionend', finish, { once: true });
+    const timer = setTimeout(finish, 320);
+    element.addEventListener('transitioncancel', () => clearTimeout(timer), { once: true });
+  }
+}
+
+function buildCard({ title, meta, translate, link, siteConfig }) {
+  const safeTitle = escapeHtml(String(title || 'Untitled'));
+  const excerpt = meta && meta.excerpt ? escapeHtml(String(meta.excerpt)) : '';
+  const date = meta && meta.date ? formatDisplayDate(meta.date) : '';
+  const tags = meta ? renderTags(meta.tag) : '';
+  const coverHtml = renderCardCover(meta, title, siteConfig);
+  const hasCover = Boolean(coverHtml);
+  const cardClasses = `arcus-card${hasCover ? ' arcus-card--with-cover' : ''}`;
+  return `<article class="${cardClasses}">
+    <a class="arcus-card__link" href="${escapeHtml(link)}">
+      ${coverHtml}
+      <div class="arcus-card__body">
+        <h3 class="arcus-card__title">${safeTitle}</h3>
+        ${date ? `<div class="arcus-card__meta">${escapeHtml(date)}</div>` : ''}
+        ${excerpt ? `<p class="arcus-card__excerpt"><span class="arcus-card__excerpt-tilt">${excerpt}</span></p>` : ''}
+        ${tags ? `<div class="arcus-card__tags">${tags}</div>` : ''}
+      </div>
+    </a>
+  </article>`;
+}
+
+function buildPagination({ page, totalPages, baseHref, query }) {
+  if (!totalPages || totalPages <= 1) return '';
+  const mkHref = (p) => {
+    try {
+      const url = new URL(baseHref, defaultWindow ? defaultWindow.location.href : (typeof location !== 'undefined' ? location.href : ''));
+      url.searchParams.set('page', p);
+      if (query && query.q) {
+        if (query.q) url.searchParams.set('q', query.q);
+        else url.searchParams.delete('q');
+      }
+      if (query && query.tag) {
+        if (query.tag) url.searchParams.set('tag', query.tag);
+        else url.searchParams.delete('tag');
+      }
+      return url.toString();
+    } catch (_) {
+      return baseHref;
+    }
+  };
+  const items = [];
+  for (let i = 1; i <= totalPages; i++) {
+    const href = mkHref(i);
+    items.push(`<a class="arcus-page${i === page ? ' is-current' : ''}" href="${escapeHtml(href)}">${i}</a>`);
+  }
+  const prevHref = page > 1 ? mkHref(page - 1) : '';
+  const nextHref = page < totalPages ? mkHref(page + 1) : '';
+  return `<nav class="arcus-pagination" aria-label="${t('ui.pagination')}">
+    <a class="arcus-page prev${prevHref ? '' : ' is-disabled'}" href="${prevHref ? escapeHtml(prevHref) : '#'}" ${prevHref ? '' : 'aria-disabled="true"'}>${t('ui.prev')}</a>
+    <div class="arcus-page__list">${items.join('')}</div>
+    <a class="arcus-page next${nextHref ? '' : ' is-disabled'}" href="${nextHref ? escapeHtml(nextHref) : '#'}" ${nextHref ? '' : 'aria-disabled="true"'}>${t('ui.next')}</a>
+  </nav>`;
+}
+
+function decorateArticle(container, translate, utilities, markdown, meta, title) {
+  if (!container) return;
+  const copyBtn = container.querySelector('.post-meta-copy');
+  if (copyBtn) {
+    copyBtn.addEventListener('click', async () => {
+      const loc = defaultWindow && defaultWindow.location ? defaultWindow.location.href : (typeof location !== 'undefined' ? location.href : '');
+      const href = String(loc || '').split('#')[0];
+      let ok = false;
+      try {
+        const nav = defaultWindow && defaultWindow.navigator;
+        if (nav && nav.clipboard && typeof nav.clipboard.writeText === 'function') {
+          await nav.clipboard.writeText(href);
+          ok = true;
+        }
+      } catch (_) {}
+      if (!ok && defaultDocument && defaultDocument.execCommand) {
+        const tmp = defaultDocument.createElement('textarea');
+        tmp.value = href;
+        defaultDocument.body.appendChild(tmp);
+        tmp.select();
+        ok = defaultDocument.execCommand('copy');
+        defaultDocument.body.removeChild(tmp);
+      }
+      if (ok) {
+        copyBtn.classList.add('copied');
+        copyBtn.setAttribute('data-status', 'copied');
+        setTimeout(() => {
+          copyBtn.classList.remove('copied');
+          copyBtn.removeAttribute('data-status');
+        }, 1200);
+      }
+    });
+  }
+
+  const versionSelect = container.querySelector('.post-version-select');
+  if (versionSelect) {
+    versionSelect.addEventListener('change', () => {
+      const target = versionSelect.value;
+      if (!target) return;
+      const href = withLangParam(`?id=${encodeURIComponent(target)}`);
+      if (defaultWindow) {
+        defaultWindow.location.href = href;
+      } else {
+        location.href = href; // eslint-disable-line no-restricted-globals
+      }
+    });
+  }
+
+  const outdated = container.querySelector('.post-outdated-card');
+  if (outdated) {
+    const close = outdated.querySelector('.post-outdated-close');
+    if (close) close.addEventListener('click', () => outdated.remove());
+  }
+
+  try {
+    const aiFlags = Array.from(container.querySelectorAll('.ai-flag'));
+    aiFlags.forEach(flag => attachHoverTooltip(flag, () => translate('ui.aiFlagTooltip'), { delay: 0 }));
+  } catch (_) {}
+
+  try {
+    if (typeof utilities.hydratePostImages === 'function') utilities.hydratePostImages(container);
+    if (typeof utilities.hydratePostVideos === 'function') utilities.hydratePostVideos(container);
+    if (typeof utilities.applyLazyLoadingIn === 'function') utilities.applyLazyLoadingIn(container);
+  } catch (_) {}
+}
+
+function renderNavLinks(nav, tabsBySlug, activeSlug, postsEnabled, getHomeSlug) {
+  if (!nav) return;
+  const items = [];
+  const homeSlug = typeof getHomeSlug === 'function' ? getHomeSlug() : 'posts';
+  if (postsEnabled()) {
+    items.push({ slug: 'posts', label: t('ui.allPosts'), href: withLangParam('?tab=posts') });
+  }
+  Object.entries(tabsBySlug || {}).forEach(([slug, info]) => {
+    const label = info && info.title ? String(info.title) : slug;
+    items.push({ slug, label, href: withLangParam(`?tab=${encodeURIComponent(slug)}`) });
+  });
+  nav.innerHTML = items.map(item => `<a class="arcus-nav__item${item.slug === activeSlug ? ' is-current' : ''}" data-tab="${escapeHtml(item.slug)}" href="${escapeHtml(item.href)}">${escapeHtml(item.label)}</a>`).join('');
+  nav.setAttribute('data-active', activeSlug || homeSlug);
+}
+
+function renderFooterLinks(root, tabsBySlug, postsEnabled, getHomeSlug, getHomeLabel) {
+  if (!root) return;
+  const links = [];
+  const homeSlug = getHomeSlug();
+  const homeLabel = getHomeLabel();
+  links.push({ href: withLangParam(`?tab=${encodeURIComponent(homeSlug)}`), label: homeLabel });
+  Object.entries(tabsBySlug || {}).forEach(([slug, info]) => {
+    const label = info && info.title ? String(info.title) : slug;
+    links.push({ href: withLangParam(`?tab=${encodeURIComponent(slug)}`), label });
+  });
+  links.push({ href: withLangParam('?tab=search'), label: t('ui.searchTab') });
+  root.innerHTML = `<ul class="arcus-footer__list">${links.map(link => `<li><a href="${escapeHtml(link.href)}">${escapeHtml(link.label)}</a></li>`).join('')}</ul>`;
+}
+
+function renderLinksList(root, cfg) {
+  if (!root) return;
+  const list = Array.isArray(cfg && cfg.profileLinks) ? cfg.profileLinks : [];
+  if (!list.length) {
+    root.innerHTML = `<li class="arcus-linklist__empty">${t('editor.site.noLinks')}</li>`;
+    return;
+  }
+  root.innerHTML = list.map(item => {
+    if (!item || !item.href) return '';
+    const label = item.label || item.href;
+    const href = sanitizeUrl(String(item.href));
+    if (!href) return '';
+    return `<li><a href="${escapeHtml(href)}" target="_blank" rel="noopener">${escapeHtml(label)}</a></li>`;
+  }).join('');
+}
+
+function updateSearchPlaceholder(documentRef = defaultDocument) {
+  const input = documentRef ? documentRef.getElementById('searchInput') : null;
+  if (!input) return;
+  input.setAttribute('placeholder', t('sidebar.searchPlaceholder'));
+}
+
+function sanitizePackValue(value) {
+  return String(value || '').trim().toLowerCase().replace(/[^a-z0-9_-]/g, '');
+}
+
+function prettifyPackLabel(value, label) {
+  if (label && String(label).trim()) return String(label).trim();
+  if (!value) return '';
+  return value.replace(/[-_]+/g, ' ').replace(/\b([a-z])/g, (m, c) => c.toUpperCase());
+}
+
+function populateThemePackOptions(documentRef = defaultDocument, windowRef = defaultWindow) {
+  const select = documentRef ? documentRef.getElementById('themePack') : null;
+  if (!select || !documentRef) return false;
+
+  const fallbackOptions = [
+    { value: 'native', label: 'Native' },
+    { value: 'solstice', label: 'Solstice' },
+    { value: 'arcus', label: 'Arcus' }
+  ];
+
+  const seen = new Set();
+
+  const appendOption = (value, label) => {
+    const sanitized = sanitizePackValue(value);
+    if (!sanitized || seen.has(sanitized)) return;
+    const option = documentRef.createElement('option');
+    option.value = sanitized;
+    option.textContent = prettifyPackLabel(sanitized, label);
+    select.appendChild(option);
+    seen.add(sanitized);
+  };
+
+  const ensureSavedOptionVisible = () => {
+    let saved = '';
+    try {
+      saved = getSavedThemePack ? getSavedThemePack() : '';
+    } catch (_) {
+      saved = '';
+    }
+    const normalized = sanitizePackValue(saved) || (select.options[0] ? select.options[0].value : '');
+    if (normalized && !Array.from(select.options).some(opt => opt.value === normalized)) {
+      appendOption(normalized, null);
+    }
+    if (normalized) {
+      select.value = normalized;
+    } else if (select.options.length) {
+      select.selectedIndex = 0;
+    }
+  };
+
+  const applyOptions = (options) => {
+    select.innerHTML = '';
+    seen.clear();
+    (options || []).forEach(item => {
+      if (!item) return;
+      const sourceValue = item.value != null ? item.value : (item.slug != null ? item.slug : item.name);
+      appendOption(sourceValue, item.label);
+    });
+    if (!select.options.length) {
+      fallbackOptions.forEach(item => appendOption(item.value, item.label));
+    }
+  };
+
+  const fetcher = (windowRef && typeof windowRef.fetch === 'function')
+    ? windowRef.fetch.bind(windowRef)
+    : (typeof fetch === 'function' ? fetch : null);
+
+  if (!fetcher) {
+    applyOptions(fallbackOptions);
+    ensureSavedOptionVisible();
+    return true;
+  }
+
+  try {
+    fetcher('assets/themes/packs.json')
+      .then(response => {
+        if (!response || !response.ok) throw new Error('packs.json fetch failed');
+        return response.json();
+      })
+      .then(list => {
+        if (Array.isArray(list) && list.length) {
+          applyOptions(list);
+        } else {
+          applyOptions(fallbackOptions);
+        }
+      })
+      .catch(() => {
+        applyOptions(fallbackOptions);
+      })
+      .finally(() => {
+        ensureSavedOptionVisible();
+      });
+  } catch (_) {
+    applyOptions(fallbackOptions);
+    ensureSavedOptionVisible();
+  }
+
+  return true;
+}
+
+function setupToolsPanel(documentRef = defaultDocument, windowRef = defaultWindow) {
+  const panel = documentRef && documentRef.getElementById('toolsPanel');
+  if (!panel) return false;
+  panel.innerHTML = `
+    <div class="arcus-tools" id="tools">
+      <button id="themeToggle" class="arcus-tool" type="button" aria-label="${t('tools.toggleTheme')}">
+        <span class="arcus-tool__icon">🌓</span>
+        <span class="arcus-tool__label">${t('tools.toggleTheme')}</span>
+      </button>
+      <button id="postEditor" class="arcus-tool" type="button" aria-label="${t('tools.postEditor')}">
+        <span class="arcus-tool__icon">📝</span>
+        <span class="arcus-tool__label">${t('tools.postEditor')}</span>
+      </button>
+      <label class="arcus-tool arcus-tool--select" for="themePack">
+        <span class="arcus-tool__label">${t('tools.themePack')}</span>
+        <select id="themePack"></select>
+      </label>
+      <label class="arcus-tool arcus-tool--select" for="langSelect">
+        <span class="arcus-tool__label">${t('tools.language')}</span>
+        <select id="langSelect"></select>
+      </label>
+      <button id="langReset" class="arcus-tool" type="button" aria-label="${t('tools.resetLanguage')}">
+        <span class="arcus-tool__icon">♻️</span>
+        <span class="arcus-tool__label">${t('tools.resetLanguage')}</span>
+      </button>
+    </div>`;
+  try { applySavedTheme(); } catch (_) {}
+  try { bindThemeToggle(); } catch (_) {}
+  try { bindPostEditor(); } catch (_) {}
+  try { populateThemePackOptions(documentRef, windowRef); } catch (_) {}
+  try { bindThemePackPicker(); } catch (_) {}
+  try { refreshLanguageSelector(); } catch (_) {}
+  try {
+    const langSel = documentRef.getElementById('langSelect');
+    if (langSel) {
+      langSel.addEventListener('change', () => {
+        const val = langSel.value || 'en';
+        switchLanguage(val);
+      });
+    }
+    const reset = documentRef.getElementById('langReset');
+    if (reset) {
+      reset.addEventListener('click', () => {
+        try { localStorage.removeItem('lang'); } catch (_) {}
+        try {
+          const url = new URL(windowRef ? windowRef.location.href : window.location.href);
+          url.searchParams.delete('lang');
+          if (windowRef && windowRef.history && windowRef.history.replaceState) {
+            windowRef.history.replaceState(windowRef.history.state, documentRef.title, url.toString());
+          }
+        } catch (_) {}
+        try {
+          if (windowRef && windowRef.__ns_softResetLang) {
+            windowRef.__ns_softResetLang();
+            return;
+          }
+        } catch (_) {}
+        try {
+          if (windowRef && windowRef.location) {
+            windowRef.location.reload();
+          }
+        } catch (_) {}
+      });
+    }
+  } catch (_) {}
+  return true;
+}
+
+function resetToolsPanel(documentRef = defaultDocument, windowRef = defaultWindow) {
+  const panel = documentRef && documentRef.getElementById('toolsPanel');
+  if (!panel) return false;
+  panel.innerHTML = '';
+  return setupToolsPanel(documentRef, windowRef);
+}
+
+function showToc(tocEl, tocHtml, articleTitle) {
+  if (!tocEl) return;
+  if (!tocHtml) {
+    tocEl.innerHTML = '';
+    tocEl.hidden = true;
+    return;
+  }
+  tocEl.innerHTML = `<div class="arcus-toc__inner"><div class="arcus-toc__title">${escapeHtml(articleTitle || t('ui.tableOfContents'))}</div>${tocHtml}</div>`;
+  tocEl.hidden = false;
+  fadeIn(tocEl);
+}
+
+function renderLoader(target, message) {
+  if (!target) return;
+  target.innerHTML = `<div class="arcus-loader" role="status">
+    <div class="arcus-loader__spinner"></div>
+    <div class="arcus-loader__text">${escapeHtml(message || t('ui.loading'))}</div>
+  </div>`;
+}
+
+function renderStaticView(container, title, html) {
+  if (!container) return;
+  const safeHtml = html != null ? html : '';
+  container.innerHTML = `<article class="arcus-static">
+    <header class="arcus-static__header">
+      <h1>${escapeHtml(title || '')}</h1>
+    </header>
+    <div class="arcus-static__body">${safeHtml}</div>
+  </article>`;
+}
+
+function mountHooks(documentRef = defaultDocument, windowRef = defaultWindow) {
+  const hooks = {};
+
+  hooks.resolveViewContainers = ({ view }) => {
+    return {
+      view,
+      mainElement: getRoleElement('main', documentRef),
+      tocElement: getRoleElement('toc', documentRef),
+      sidebarElement: getRoleElement('sidebar', documentRef),
+      contentElement: getRoleElement('content', documentRef),
+      containerElement: getRoleElement('container', documentRef)
+    };
+  };
+
+  hooks.getViewContainer = ({ role }) => getRoleElement(role, documentRef);
+
+  hooks.showElement = ({ element }) => fadeIn(element);
+  hooks.hideElement = ({ element, onDone }) => { fadeOut(element, onDone); return true; };
+
+  hooks.renderSiteIdentity = ({ config }) => {
+    currentSiteConfig = config || currentSiteConfig;
+    const title = localized(config, 'siteTitle');
+    const subtitle = localized(config, 'siteSubtitle');
+    const titleEl = documentRef.querySelector('[data-site-title]');
+    const subtitleEl = documentRef.querySelector('[data-site-subtitle]');
+    if (titleEl) titleEl.textContent = title || 'NanoSite';
+    if (subtitleEl) subtitleEl.textContent = subtitle || '';
+  };
+
+  hooks.renderSiteLinks = ({ config }) => {
+    const root = documentRef.querySelector('[data-site-links]');
+    renderLinksList(root, config);
+  };
+
+  hooks.updateLayoutLoadingState = ({ isLoading, containerElement }) => {
+    const target = containerElement || getRoleElement('content', documentRef);
+    if (!target) return;
+    target.classList.toggle('is-loading', !!isLoading);
+  };
+
+  hooks.renderPostTOC = ({ tocElement, tocHtml, articleTitle }) => {
+    const toc = tocElement || getRoleElement('toc', documentRef);
+    showToc(toc, tocHtml, articleTitle);
+    return true;
+  };
+
+  hooks.renderErrorState = ({ targetElement, title, message, actions }) => {
+    const target = targetElement || getRoleElement('main', documentRef);
+    if (!target) return false;
+    const actionHtml = Array.isArray(actions) && actions.length
+      ? `<div class="arcus-error__actions">${actions.map(a => `<a class="arcus-btn" href="${escapeHtml(withLangParam(a.href || '#'))}">${escapeHtml(a.label || '')}</a>`).join('')}</div>`
+      : '';
+    const heading = title || t('errors.pageUnavailableTitle');
+    const body = message || t('errors.pageUnavailableBody');
+    target.innerHTML = `<section class="arcus-error" role="alert">
+      <h2>${escapeHtml(heading)}</h2>
+      <p>${escapeHtml(body)}</p>
+      ${actionHtml}
+    </section>`;
+    return true;
+  };
+
+  hooks.handleViewChange = ({ view }) => {
+    if (!documentRef || !documentRef.body) return;
+    documentRef.body.setAttribute('data-active-view', view || 'posts');
+    const toc = getRoleElement('toc', documentRef);
+    if (toc && view !== 'post') {
+      toc.hidden = true;
+      toc.innerHTML = '';
+    }
+    const input = documentRef.getElementById('searchInput');
+    if (input) input.value = view === 'search' ? (getQueryVariable('q') || '') : '';
+  };
+
+  hooks.renderTagSidebar = ({ postsIndex, utilities }) => {
+    const render = utilities && typeof utilities.renderTagSidebar === 'function'
+      ? utilities.renderTagSidebar
+      : renderDefaultTags;
+    try { render(postsIndex || {}); } catch (_) {}
+    return true;
+  };
+
+  hooks.enhanceIndexLayout = (params = {}) => {
+    const container = params.containerElement || getRoleElement('main', documentRef);
+    try { if (typeof hydrateCardCovers === 'function') hydrateCardCovers(container); } catch (_) {}
+    try { if (typeof applyLazyLoadingIn === 'function') applyLazyLoadingIn(container); } catch (_) {}
+    try { if (typeof params.setupSearch === 'function') params.setupSearch(params.allEntries || []); } catch (_) {}
+    try { if (typeof params.renderTagSidebar === 'function') params.renderTagSidebar(params.postsIndexMap || {}); } catch (_) {}
+    return true;
+  };
+
+  hooks.renderTabs = ({ tabsBySlug, activeSlug, getHomeSlug, postsEnabled }) => {
+    const nav = documentRef.getElementById('tabsNav');
+    if (!nav) return false;
+    renderNavLinks(nav, tabsBySlug, activeSlug, postsEnabled, getHomeSlug);
+    return true;
+  };
+
+  hooks.renderFooterNav = ({ tabsBySlug, postsEnabled, getHomeSlug, getHomeLabel }) => {
+    const footerNav = documentRef.getElementById('footerNav');
+    if (!footerNav) return false;
+    renderFooterLinks(footerNav, tabsBySlug, postsEnabled, getHomeSlug, getHomeLabel);
+    return true;
+  };
+
+  hooks.renderPostLoadingState = ({ containers }) => {
+    const main = containers && containers.mainElement ? containers.mainElement : getRoleElement('main', documentRef);
+    renderLoader(main, t('ui.loading'));
+    return true;
+  };
+
+  hooks.renderPostView = ({ containers, markdownHtml, fallbackTitle, postMetadata, markdown, postsIndex, postId, siteConfig, translate, utilities }) => {
+    const main = containers && containers.mainElement ? containers.mainElement : getRoleElement('main', documentRef);
+    if (!main) return;
+    const title = (postMetadata && postMetadata.title) || fallbackTitle || '';
+    const hero = renderHeroImage(postMetadata, title, siteConfig);
+    const date = postMetadata && postMetadata.date ? formatDisplayDate(postMetadata.date) : '';
+    const tagMarkup = postMetadata ? renderTags(postMetadata.tag) : '';
+    const metaCard = renderPostMetaCard(title, postMetadata || {}, markdown);
+    const outdatedCard = renderOutdatedCard(postMetadata || {}, siteConfig);
+
+    main.innerHTML = `
+      <article class="arcus-article" data-post-id="${escapeHtml(postId || '')}">
+        <header class="arcus-article__header">
+          ${hero || ''}
+          <div class="arcus-article__heading">
+            <p class="arcus-article__meta-line">${date ? escapeHtml(date) : ''}</p>
+            <h1 class="arcus-article__title">${escapeHtml(title)}</h1>
+            ${tagMarkup ? `<div class="arcus-article__tags">${tagMarkup}</div>` : ''}
+          </div>
+          <div class="arcus-article__meta">
+            ${outdatedCard || ''}
+            ${metaCard || ''}
+          </div>
+        </header>
+        <div class="arcus-article__body">${markdownHtml}</div>
+        <footer class="arcus-article__footer">
+          <div class="arcus-article__nav" data-post-nav></div>
+        </footer>
+      </article>`;
+
+    try { if (utilities && typeof utilities.renderPostNav === 'function') utilities.renderPostNav(main.querySelector('[data-post-nav]'), postsIndex || {}, postMetadata && postMetadata.location); } catch (_) {}
+    decorateArticle(main, translate || t, { hydratePostImages, hydratePostVideos, applyLazyLoadingIn }, markdown, postMetadata, title);
+    scrollViewportToTop(documentRef, windowRef);
+    return { decorated: true, title };
+  };
+
+  hooks.decoratePostView = ({ container, translate, utilities, markdown, postMetadata, articleTitle }) => {
+    decorateArticle(container || getRoleElement('main', documentRef), translate || t, utilities || { hydratePostImages, hydratePostVideos, applyLazyLoadingIn }, markdown, postMetadata, articleTitle);
+    return true;
+  };
+
+  hooks.scrollToHash = ({ hash }) => {
+    if (!hash) return false;
+    try {
+      const target = documentRef.getElementById(hash) || documentRef.querySelector(`[id='${hash}']`);
+      if (!target) return false;
+      target.scrollIntoView({ behavior: prefersReducedMotion() ? 'auto' : 'smooth', block: 'start' });
+      return true;
+    } catch (_) { return false; }
+  };
+
+  hooks.renderIndexView = ({ container, pageEntries, page, totalPages, siteConfig }) => {
+    if (!container) container = getRoleElement('main', documentRef);
+    if (!container) return false;
+    const cards = (pageEntries || []).map(([title, meta]) => {
+      const href = meta && meta.location ? withLangParam(`?id=${encodeURIComponent(meta.location)}`) : '#';
+      return buildCard({ title, meta, translate: t, link: href, siteConfig });
+    }).join('');
+    const baseHref = withLangParam('?tab=posts');
+    container.innerHTML = `<div class="arcus-index index">
+      <div class="arcus-index__grid">${cards || `<p class="arcus-empty">${t('ui.noResultsTitle')}</p>`}</div>
+      ${buildPagination({ page, totalPages, baseHref, query: {} })}
+    </div>`;
+    scrollViewportToTop(documentRef, windowRef);
+    return true;
+  };
+
+  hooks.afterIndexRender = ({ container }) => {
+    try { if (container) hydrateCardCovers(container); else hydrateCardCovers(getRoleElement('main', documentRef)); } catch (_) {}
+    return true;
+  };
+
+  hooks.renderSearchResults = ({ container, entries, query, totalPages, page, siteConfig, tagFilter }) => {
+    if (!container) container = getRoleElement('main', documentRef);
+    if (!container) return false;
+    const cards = (entries || []).map(([title, meta]) => {
+      const href = meta && meta.location ? withLangParam(`?id=${encodeURIComponent(meta.location)}`) : '#';
+      return buildCard({ title, meta, translate: t, link: href, siteConfig });
+    }).join('');
+    const baseHref = withLangParam('?tab=search');
+    const summary = query
+      ? `${t('ui.searchTab')} · ${escapeHtml(query)}`
+      : tagFilter
+        ? `${t('ui.tags')} · ${escapeHtml(tagFilter)}`
+        : t('ui.searchTab');
+    container.innerHTML = `<div class="arcus-index arcus-index--search index">
+      <header class="arcus-index__header"><h2>${escapeHtml(summary)}</h2></header>
+      <div class="arcus-index__grid">${cards || `<p class="arcus-empty">${t('ui.noResultsTitle')}</p>`}</div>
+      ${buildPagination({ page, totalPages, baseHref, query: { q: query, tag: tagFilter } })}
+    </div>`;
+    scrollViewportToTop(documentRef, windowRef);
+    return true;
+  };
+
+  hooks.afterSearchRender = ({ container }) => {
+    try { if (container) hydrateCardCovers(container); else hydrateCardCovers(getRoleElement('main', documentRef)); } catch (_) {}
+    return true;
+  };
+
+  hooks.renderStaticTabLoadingState = ({ containers }) => {
+    const main = containers && containers.mainElement ? containers.mainElement : getRoleElement('main', documentRef);
+    renderLoader(main, t('ui.loading'));
+    return true;
+  };
+
+  hooks.renderStaticTabView = ({
+    containers,
+    title,
+    html,
+    markdownHtml,
+    tocHtml,
+    tab,
+    translate,
+    utilities,
+    allowedLocations,
+    locationAliasMap,
+    postsByLocationTitle,
+    postsIndex,
+    siteConfig
+  }) => {
+    const main = containers && containers.mainElement ? containers.mainElement : getRoleElement('main', documentRef);
+    if (!main) return false;
+    const heading = title || (tab && tab.title) || '';
+    const bodyHtml = markdownHtml != null ? markdownHtml : html;
+    renderStaticView(main, heading, bodyHtml);
+    scrollViewportToTop(documentRef, windowRef);
+
+    const body = main.querySelector('.arcus-static__body') || main;
+    try { if (utilities && typeof utilities.hydratePostImages === 'function') utilities.hydratePostImages(body); } catch (_) {}
+    try { if (utilities && typeof utilities.hydratePostVideos === 'function') utilities.hydratePostVideos(body); } catch (_) {}
+    try { if (utilities && typeof utilities.applyLazyLoadingIn === 'function') utilities.applyLazyLoadingIn(body); } catch (_) {}
+    try { if (utilities && typeof utilities.applyLangHints === 'function') utilities.applyLangHints(body); } catch (_) {}
+    try {
+      if (utilities && typeof utilities.hydrateInternalLinkCards === 'function') {
+        const makeHref = utilities.makeLangHref || ((loc) => withLangParam(`?id=${encodeURIComponent(loc)}`));
+        const fetchMarkdown = utilities.fetchMarkdown || (() => Promise.resolve(''));
+        utilities.hydrateInternalLinkCards(body, {
+          allowedLocations: allowedLocations || new Set(),
+          locationAliasMap: locationAliasMap || new Map(),
+          postsByLocationTitle: postsByLocationTitle || {},
+          postsIndexCache: postsIndex || {},
+          siteConfig: siteConfig || {},
+          translate: translate || t,
+          makeHref,
+          fetchMarkdown
+        });
+      }
+    } catch (_) {}
+
+    const toc = containers && containers.tocElement ? containers.tocElement : getRoleElement('toc', documentRef);
+    if (toc) {
+      if (tocHtml) {
+        showToc(toc, tocHtml, heading);
+      } else {
+        toc.innerHTML = '';
+        toc.hidden = true;
+      }
+    }
+    return true;
+  };
+
+  hooks.handleDocumentClick = ({ event }) => {
+    const target = event && event.target;
+    if (!target) return false;
+    if (target.closest('.arcus-nav__item')) {
+      return false;
+    }
+    return false;
+  };
+
+  hooks.handleRouteScroll = ({ document: doc, window: win } = {}) => {
+    const scrolled = scrollViewportToTop(doc || documentRef, win || windowRef);
+    return scrolled ? true : undefined;
+  };
+
+  hooks.handleWindowResize = () => {
+    return true;
+  };
+
+  hooks.setupThemeControls = () => setupToolsPanel(documentRef, windowRef);
+  hooks.resetThemeControls = () => resetToolsPanel(documentRef, windowRef);
+  hooks.updateSearchPlaceholder = () => { updateSearchPlaceholder(documentRef); return true; };
+
+  hooks.setupResponsiveTabsObserver = () => {
+    const header = documentRef.querySelector('.arcus-header');
+    if (!header || typeof IntersectionObserver === 'undefined') return false;
+    let sentinel = documentRef.querySelector('.arcus-header-sentinel');
+    if (!sentinel) {
+      sentinel = documentRef.createElement('div');
+      sentinel.className = 'arcus-header-sentinel';
+      header.parentElement.insertBefore(sentinel, header);
+    }
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        header.classList.toggle('is-condensed', !entry.isIntersecting);
+      });
+    });
+    observer.observe(sentinel);
+    return true;
+  };
+
+  hooks.reflectThemeConfig = ({ siteConfig }) => {
+    const root = documentRef.querySelector('.arcus-shell');
+    if (root && siteConfig && siteConfig.themePack) {
+      root.setAttribute('data-theme-pack', siteConfig.themePack);
+    }
+    return true;
+  };
+
+  hooks.setupFooter = () => {
+    const meta = documentRef.querySelector('.arcus-footer__credit');
+    if (meta) {
+      const year = new Date().getFullYear();
+      const siteTitle = localized(currentSiteConfig || {}, 'siteTitle') || 'NanoSite';
+      meta.textContent = `© ${year} ${siteTitle}`;
+    }
+    return true;
+  };
+
+  if (windowRef) {
+    windowRef.__ns_themeHooks = Object.assign({}, windowRef.__ns_themeHooks || {}, hooks);
+  }
+  return hooks;
+}
+
+export function mount(context = {}) {
+  const doc = context.document || defaultDocument;
+  const win = (context.document && context.document.defaultView) || defaultWindow;
+  mountHooks(doc, win);
+  updateSearchPlaceholder(doc);
+  setupToolsPanel(doc, win);
+  setupDynamicBackground(doc, win);
+  return context;
+}

--- a/assets/themes/arcus/modules/interactions.js
+++ b/assets/themes/arcus/modules/interactions.js
@@ -685,6 +685,33 @@ function mountHooks(documentRef = defaultDocument, windowRef = defaultWindow) {
     const subtitleEl = documentRef.querySelector('[data-site-subtitle]');
     if (titleEl) titleEl.textContent = title || 'NanoSite';
     if (subtitleEl) subtitleEl.textContent = subtitle || '';
+
+    const markEl = documentRef.querySelector('.arcus-brand__mark');
+    const logoEl = documentRef.querySelector('[data-site-logo]');
+    let logoSrc = '';
+    if (config && typeof config.avatar === 'string') {
+      logoSrc = config.avatar;
+    } else if (config && config.avatar && typeof config.avatar === 'object') {
+      const lang = typeof getCurrentLang === 'function' ? getCurrentLang() : null;
+      logoSrc = (lang && config.avatar[lang]) || config.avatar.default || '';
+    }
+    const safeLogoSrc = logoSrc && typeof sanitizeImageUrl === 'function' ? sanitizeImageUrl(logoSrc) : logoSrc;
+
+    if (logoEl) {
+      if (safeLogoSrc) {
+        logoEl.setAttribute('src', safeLogoSrc);
+        logoEl.setAttribute('alt', title ? `${title}` : 'Site logo');
+        logoEl.removeAttribute('hidden');
+        if (markEl) markEl.classList.remove('arcus-brand__mark--placeholder');
+      } else {
+        logoEl.removeAttribute('src');
+        logoEl.setAttribute('alt', '');
+        logoEl.setAttribute('hidden', '');
+        if (markEl) markEl.classList.add('arcus-brand__mark--placeholder');
+      }
+    } else if (markEl && !safeLogoSrc) {
+      markEl.classList.add('arcus-brand__mark--placeholder');
+    }
   };
 
   hooks.renderSiteLinks = ({ config }) => {

--- a/assets/themes/arcus/modules/layout.js
+++ b/assets/themes/arcus/modules/layout.js
@@ -31,7 +31,9 @@ export function mount(context = {}) {
     el.innerHTML = `
       <div class="arcus-header__inner">
         <a class="arcus-brand" href="?tab=posts" data-site-home>
-          <div class="arcus-brand__mark" aria-hidden="true"></div>
+          <div class="arcus-brand__mark arcus-brand__mark--placeholder">
+            <img class="arcus-brand__logo" data-site-logo alt="" loading="lazy" decoding="async" hidden />
+          </div>
           <div class="arcus-brand__text">
             <div class="arcus-brand__title" data-site-title></div>
             <div class="arcus-brand__subtitle" data-site-subtitle></div>

--- a/assets/themes/arcus/modules/layout.js
+++ b/assets/themes/arcus/modules/layout.js
@@ -39,19 +39,6 @@ export function mount(context = {}) {
         </a>
         <div class="arcus-header__divider" aria-hidden="true"></div>
         <nav id="${NAV_ID}" class="arcus-nav" aria-label="Primary navigation"></nav>
-        <section class="arcus-header__search" aria-label="Search">
-          <label class="arcus-search" for="searchInput">
-            <span class="arcus-search__icon" aria-hidden="true">🔍</span>
-            <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
-          </label>
-        </section>
-        <section class="arcus-header__tools" aria-label="Quick tools">
-          <div id="toolsPanel" class="arcus-tools"></div>
-        </section>
-        <section class="arcus-header__links" aria-label="Profile links">
-          <ul class="arcus-linklist" data-site-links></ul>
-        </section>
-        <div class="arcus-header__credit arcus-footer__credit" aria-label="Site credit"></div>
       </div>`;
     return el;
   });
@@ -128,6 +115,35 @@ export function mount(context = {}) {
     rightColumn.insertBefore(tagBand, footer);
   }
 
+  const utilities = ensureElement(rightColumn, '.arcus-utility', () => {
+    const el = doc.createElement('section');
+    el.className = 'arcus-utility';
+    el.setAttribute('aria-label', 'Site utilities');
+    el.innerHTML = `
+      <div class="arcus-utility__inner">
+        <section class="arcus-utility__search" aria-label="Search">
+          <label class="arcus-search" for="searchInput">
+            <span class="arcus-search__icon" aria-hidden="true">🔍</span>
+            <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
+          </label>
+        </section>
+        <section class="arcus-utility__tools" aria-label="Quick tools">
+          <div id="toolsPanel" class="arcus-tools"></div>
+        </section>
+        <section class="arcus-utility__links" aria-label="Profile links">
+          <ul class="arcus-linklist" data-site-links></ul>
+        </section>
+        <div class="arcus-utility__credit arcus-footer__credit" aria-label="Site credit"></div>
+      </div>`;
+    return el;
+  });
+
+  if (utilities.parentElement !== rightColumn) {
+    rightColumn.insertBefore(utilities, footer);
+  } else if (utilities.nextElementSibling !== footer) {
+    rightColumn.insertBefore(utilities, footer);
+  }
+
   if (footer.parentElement !== rightColumn) {
     rightColumn.appendChild(footer);
   } else if (footer.nextElementSibling) {
@@ -144,9 +160,10 @@ export function mount(context = {}) {
     mainview,
     toc: tocview,
     footer,
+    utilities,
     footerNav: footer.querySelector(`#${FOOTER_NAV_ID}`),
     tagBand,
-    toolsPanel: header.querySelector('#toolsPanel'),
+    toolsPanel: utilities.querySelector('#toolsPanel'),
     scrollContainer: rightColumn
   };
 

--- a/assets/themes/arcus/modules/layout.js
+++ b/assets/themes/arcus/modules/layout.js
@@ -1,0 +1,123 @@
+const NAV_ID = 'tabsNav';
+const MAINVIEW_ID = 'mainview';
+const TOCVIEW_ID = 'tocview';
+const FOOTER_NAV_ID = 'footerNav';
+const TAGVIEW_ID = 'tagview';
+
+function ensureElement(parent, selector, creator) {
+  const existing = parent.querySelector(selector);
+  if (existing) return existing;
+  const el = creator();
+  parent.appendChild(el);
+  return el;
+}
+
+export function mount(context = {}) {
+  const doc = context.document || document;
+  if (!doc || !doc.body) return context;
+
+  let container = doc.querySelector('[data-theme-root="container"]');
+  if (!container) {
+    container = doc.createElement('div');
+    container.setAttribute('data-theme-root', 'container');
+    doc.body.insertBefore(container, doc.body.firstChild);
+  }
+  container.className = 'arcus-shell';
+
+  const header = ensureElement(container, '.arcus-header', () => {
+    const el = doc.createElement('header');
+    el.className = 'arcus-header';
+    el.setAttribute('role', 'banner');
+    el.innerHTML = `
+      <div class="arcus-header__inner">
+        <a class="arcus-brand" href="?tab=posts" data-site-home>
+          <div class="arcus-brand__mark" aria-hidden="true"></div>
+          <div class="arcus-brand__text">
+            <div class="arcus-brand__title" data-site-title></div>
+            <div class="arcus-brand__subtitle" data-site-subtitle></div>
+          </div>
+        </a>
+        <div class="arcus-header__divider" aria-hidden="true"></div>
+        <nav id="${NAV_ID}" class="arcus-nav" aria-label="Primary navigation"></nav>
+        <section class="arcus-header__search" aria-label="Search">
+          <label class="arcus-search" for="searchInput">
+            <span class="arcus-search__icon" aria-hidden="true">🔍</span>
+            <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
+          </label>
+        </section>
+        <section class="arcus-header__tools" aria-label="Quick tools">
+          <div id="toolsPanel" class="arcus-tools"></div>
+        </section>
+        <section class="arcus-header__links" aria-label="Profile links">
+          <ul class="arcus-linklist" data-site-links></ul>
+        </section>
+        <div class="arcus-header__credit arcus-footer__credit" aria-label="Site credit"></div>
+      </div>`;
+    return el;
+  });
+
+  const main = ensureElement(container, '.arcus-main', () => {
+    const el = doc.createElement('main');
+    el.className = 'arcus-main';
+    el.setAttribute('role', 'main');
+    return el;
+  });
+
+  const mainview = ensureElement(main, `#${MAINVIEW_ID}`, () => {
+    const el = doc.createElement('section');
+    el.id = MAINVIEW_ID;
+    el.className = 'arcus-mainview';
+    el.setAttribute('tabindex', '-1');
+    return el;
+  });
+
+  const tocview = ensureElement(main, `#${TOCVIEW_ID}`, () => {
+    const el = doc.createElement('aside');
+    el.id = TOCVIEW_ID;
+    el.className = 'arcus-toc';
+    el.setAttribute('aria-label', 'Table of contents');
+    el.hidden = true;
+    return el;
+  });
+
+  const tagBand = ensureElement(container, `#${TAGVIEW_ID}`, () => {
+    const el = doc.createElement('section');
+    el.id = TAGVIEW_ID;
+    return el;
+  });
+  tagBand.className = 'arcus-tagband';
+  tagBand.setAttribute('aria-label', 'Tag filters');
+
+  const footer = ensureElement(container, '.arcus-footer', () => {
+    const el = doc.createElement('footer');
+    el.className = 'arcus-footer';
+    el.setAttribute('role', 'contentinfo');
+    el.innerHTML = `
+      <div class="arcus-footer__inner">
+        <nav class="arcus-footer__nav" aria-label="Secondary navigation">
+          <div id="${FOOTER_NAV_ID}" class="arcus-footer-nav"></div>
+        </nav>
+      </div>`;
+    return el;
+  });
+
+  if (tagBand.parentElement !== container || tagBand.nextElementSibling !== footer) {
+    container.insertBefore(tagBand, footer);
+  }
+
+  context.document = doc;
+  context.regions = {
+    container,
+    header,
+    main,
+    content: main,
+    mainview,
+    toc: tocview,
+    footer,
+    footerNav: footer.querySelector(`#${FOOTER_NAV_ID}`),
+    tagBand,
+    toolsPanel: header.querySelector('#toolsPanel')
+  };
+
+  return context;
+}

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -77,6 +77,7 @@ body {
   background: transparent;
   overflow-x: hidden;
   transition: background 0.4s ease;
+  align-items: start;
 }
 
 .arcus-header {
@@ -84,7 +85,8 @@ body {
   position: sticky;
   top: 0;
   align-self: start;
-  height: auto;
+  height: 100vh;
+  max-height: 100vh;
   display: flex;
   align-items: stretch;
   z-index: 5;
@@ -102,7 +104,7 @@ body {
   backdrop-filter: blur(18px);
   position: relative;
   overflow: hidden;
-  min-height: 100vh;
+  min-height: 100%;
 }
 
 .arcus-header__inner::after {
@@ -877,6 +879,7 @@ body {
   .arcus-header {
     position: relative;
     height: auto;
+    max-height: none;
   }
   .arcus-header__inner {
     border-right: none;

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -83,8 +83,8 @@ body {
   grid-area: rail;
   position: sticky;
   top: 0;
-  align-self: stretch;
-  height: 100vh;
+  align-self: start;
+  height: auto;
   display: flex;
   align-items: stretch;
   z-index: 5;
@@ -102,6 +102,7 @@ body {
   backdrop-filter: blur(18px);
   position: relative;
   overflow: hidden;
+  min-height: 100vh;
 }
 
 .arcus-header__inner::after {
@@ -881,6 +882,7 @@ body {
     border-right: none;
     border-bottom: 1px solid var(--arcus-rail-border);
     border-radius: 0 0 var(--arcus-radius-lg) var(--arcus-radius-lg);
+    min-height: 0;
   }
   .arcus-main {
     padding: 2.6rem 1.8rem 2rem;

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -68,16 +68,13 @@ body {
   position: relative;
   display: grid;
   grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
-  grid-template-rows: auto 1fr auto;
-  grid-template-areas:
-    "rail main"
-    "rail tag"
-    "rail footer";
+  grid-template-areas: "rail content";
+  height: 100vh;
   min-height: 100vh;
   background: transparent;
-  overflow-x: hidden;
+  overflow: hidden;
   transition: background 0.4s ease;
-  align-items: start;
+  align-items: stretch;
 }
 
 .arcus-header {
@@ -90,6 +87,17 @@ body {
   display: flex;
   align-items: stretch;
   z-index: 5;
+}
+
+.arcus-rightcol {
+  grid-area: content;
+  height: 100vh;
+  max-height: 100vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  scrollbar-gutter: stable both-edges;
 }
 
 .arcus-header__inner {
@@ -293,11 +301,12 @@ body {
 }
 
 .arcus-main {
-  grid-area: main;
   padding: 3.5rem 4rem 2.5rem;
   background: var(--arcus-main-bg);
   backdrop-filter: blur(20px);
   box-shadow: inset 0 1px 0 var(--arcus-outline);
+  flex: 1 0 auto;
+  min-height: 0;
 }
 
 .arcus-mainview {
@@ -309,7 +318,7 @@ body {
 }
 
 .arcus-tagband {
-  grid-area: tag;
+  flex: 0 0 auto;
   padding: 0 4rem 2rem;
   display: flex;
   justify-content: center;
@@ -344,7 +353,7 @@ body {
 }
 
 .arcus-footer {
-  grid-area: footer;
+  flex: 0 0 auto;
   padding: 1.6rem 4rem 3rem;
   background: transparent;
 }
@@ -855,6 +864,7 @@ body {
 @media (max-width: 1200px) {
   .arcus-shell {
     grid-template-columns: minmax(240px, 320px) 1fr;
+    grid-template-areas: "rail content";
   }
   .arcus-header__inner {
     padding: 2.6rem 2.2rem;
@@ -872,9 +882,9 @@ body {
     grid-template-columns: 1fr;
     grid-template-areas:
       "rail"
-      "main"
-      "tag"
-      "footer";
+      "content";
+    height: auto;
+    overflow: visible;
   }
   .arcus-header {
     position: relative;
@@ -886,6 +896,11 @@ body {
     border-bottom: 1px solid var(--arcus-rail-border);
     border-radius: 0 0 var(--arcus-radius-lg) var(--arcus-radius-lg);
     min-height: 0;
+  }
+  .arcus-rightcol {
+    height: auto;
+    max-height: none;
+    overflow: visible;
   }
   .arcus-main {
     padding: 2.6rem 1.8rem 2rem;

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -140,9 +140,43 @@ body {
   width: 54px;
   height: 54px;
   border-radius: 20px;
-  background: linear-gradient(135deg, var(--arcus-accent), var(--arcus-accent-strong));
-  box-shadow: inset 0 0 0 4px rgba(255, 255, 255, 0.28), 0 10px 20px rgba(123, 139, 255, 0.35);
   flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  position: relative;
+  background: var(--arcus-surface-raised, #f2f4ff);
+  box-shadow: inset 0 0 0 4px rgba(255, 255, 255, 0.18), 0 12px 22px rgba(53, 63, 131, 0.28);
+}
+
+.arcus-brand__mark::after {
+  content: '';
+  position: absolute;
+  inset: -30% -25% 0 -20%;
+  background: linear-gradient(140deg, rgba(123, 139, 255, 0.45), rgba(123, 139, 255, 0));
+  opacity: 0.7;
+  transition: opacity 0.3s ease;
+  z-index: 0;
+}
+
+.arcus-brand__mark--placeholder {
+  background: linear-gradient(135deg, var(--arcus-accent), var(--arcus-accent-strong));
+  box-shadow: inset 0 0 0 4px rgba(255, 255, 255, 0.28), 0 12px 22px rgba(123, 139, 255, 0.35);
+}
+
+.arcus-brand__mark--placeholder::after {
+  opacity: 0;
+}
+
+.arcus-brand__logo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.25);
+  position: relative;
+  z-index: 1;
 }
 
 .arcus-brand__text {

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -1,0 +1,918 @@
+:root {
+  --arcus-font-sans: "Inter", "Source Sans Pro", "Noto Sans SC", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --arcus-font-serif: "Iowan Old Style", "EB Garamond", "Noto Serif SC", serif;
+  --arcus-font-mono: "Fira Code", "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+  --arcus-radius-lg: 28px;
+  --arcus-radius-md: 18px;
+  --arcus-radius-sm: 12px;
+  --arcus-shadow-soft: 0 18px 36px rgba(15, 22, 52, 0.18);
+  --arcus-shadow-subtle: 0 8px 20px rgba(15, 22, 52, 0.12);
+  --arcus-line-height: 1.65;
+  --arcus-accent: #7b8bff;
+  --arcus-accent-soft: rgba(123, 139, 255, 0.12);
+  --arcus-accent-strong: #5f6dff;
+  --arcus-text: #1d2437;
+  --arcus-text-muted: rgba(29, 36, 55, 0.65);
+  --arcus-text-soft: rgba(29, 36, 55, 0.48);
+  --arcus-bg: #f4f5fb;
+  --arcus-rail-bg: linear-gradient(160deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.65));
+  --arcus-rail-border: rgba(123, 139, 255, 0.25);
+  --arcus-main-bg: rgba(255, 255, 255, 0.92);
+  --arcus-surface: rgba(255, 255, 255, 0.82);
+  --arcus-outline: rgba(23, 30, 55, 0.08);
+  --arcus-outline-strong: rgba(23, 30, 55, 0.15);
+  --arcus-code-bg: rgba(19, 23, 37, 0.07);
+  --arcus-code-border: rgba(19, 23, 37, 0.12);
+  --arcus-tag-bg: rgba(123, 139, 255, 0.08);
+  --arcus-tag-text: #414b70;
+  color-scheme: light;
+}
+
+[data-theme="dark"] {
+  --arcus-accent: #9ea7ff;
+  --arcus-accent-soft: rgba(158, 167, 255, 0.18);
+  --arcus-accent-strong: #b5bdff;
+  --arcus-text: #e8ecff;
+  --arcus-text-muted: rgba(232, 236, 255, 0.75);
+  --arcus-text-soft: rgba(232, 236, 255, 0.5);
+  --arcus-bg: radial-gradient(120% 140% at 20% 20%, #1a1f35, #0b101d 68%);
+  --arcus-rail-bg: linear-gradient(180deg, rgba(36, 43, 71, 0.92), rgba(17, 21, 34, 0.9));
+  --arcus-rail-border: rgba(158, 167, 255, 0.22);
+  --arcus-main-bg: rgba(15, 19, 33, 0.92);
+  --arcus-surface: rgba(21, 26, 44, 0.92);
+  --arcus-outline: rgba(158, 167, 255, 0.08);
+  --arcus-outline-strong: rgba(158, 167, 255, 0.2);
+  --arcus-code-bg: rgba(7, 10, 19, 0.75);
+  --arcus-code-border: rgba(158, 167, 255, 0.12);
+  --arcus-tag-bg: rgba(158, 167, 255, 0.16);
+  --arcus-tag-text: #c3cbff;
+  color-scheme: dark;
+}
+
+html, body {
+  background: var(--arcus-bg);
+  color: var(--arcus-text);
+  font-family: var(--arcus-font-sans);
+  line-height: var(--arcus-line-height);
+  min-height: 100%;
+  margin: 0;
+  padding: 0;
+  text-rendering: optimizeLegibility;
+}
+
+body {
+  background-attachment: fixed;
+}
+
+.arcus-shell {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    "rail main"
+    "rail tag"
+    "rail footer";
+  min-height: 100vh;
+  background: transparent;
+  overflow-x: hidden;
+  transition: background 0.4s ease;
+}
+
+.arcus-header {
+  grid-area: rail;
+  position: sticky;
+  top: 0;
+  align-self: stretch;
+  height: 100vh;
+  display: flex;
+  align-items: stretch;
+  z-index: 5;
+}
+
+.arcus-header__inner {
+  background: var(--arcus-rail-bg);
+  box-shadow: var(--arcus-shadow-soft);
+  border-right: 1px solid var(--arcus-rail-border);
+  padding: 3.2rem 2.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.4rem;
+  width: 100%;
+  backdrop-filter: blur(18px);
+  position: relative;
+  overflow: hidden;
+}
+
+.arcus-header__inner::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(120% 150% at 120% -10%, rgba(123, 139, 255, 0.26), transparent 60%);
+  opacity: 0.75;
+  pointer-events: none;
+  transform: translateY(calc(var(--arcus-scroll-offset, 0px) * 0.08)) rotate(calc(var(--arcus-scroll-tilt, 0deg) * 0.4));
+  transition: opacity 0.4s ease;
+}
+
+.arcus-brand {
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 1.2rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.arcus-brand__mark {
+  width: 54px;
+  height: 54px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, var(--arcus-accent), var(--arcus-accent-strong));
+  box-shadow: inset 0 0 0 4px rgba(255, 255, 255, 0.28), 0 10px 20px rgba(123, 139, 255, 0.35);
+  flex-shrink: 0;
+}
+
+.arcus-brand__text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.arcus-brand__title {
+  font-size: 1.55rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.arcus-brand__subtitle {
+  font-size: 0.95rem;
+  color: var(--arcus-text-soft);
+}
+
+.arcus-header__divider {
+  height: 1px;
+  width: 100%;
+  background: linear-gradient(90deg, transparent, var(--arcus-outline-strong), transparent);
+  opacity: 0.75;
+}
+
+.arcus-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.arcus-nav__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.7rem 1.1rem;
+  border-radius: var(--arcus-radius-md);
+  text-decoration: none;
+  font-weight: 600;
+  color: var(--arcus-text-muted);
+  letter-spacing: 0.02em;
+  background: transparent;
+  transition: background 0.25s ease, transform 0.2s ease, color 0.25s ease;
+}
+
+.arcus-nav__item:hover,
+.arcus-nav__item:focus-visible {
+  background: var(--arcus-accent-soft);
+  color: var(--arcus-accent-strong);
+  transform: translateX(4px);
+}
+
+.arcus-nav__item.is-current {
+  background: var(--arcus-accent-soft);
+  color: var(--arcus-accent);
+  box-shadow: inset 0 0 0 1px rgba(123, 139, 255, 0.25);
+}
+
+.arcus-search {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  background: rgba(255, 255, 255, 0.35);
+  padding: 0.75rem 1rem;
+  border-radius: var(--arcus-radius-md);
+  box-shadow: inset 0 0 0 1px rgba(123, 139, 255, 0.16);
+  backdrop-filter: blur(12px);
+}
+
+.arcus-search__icon {
+  font-size: 1rem;
+  color: var(--arcus-accent);
+}
+
+.arcus-search input[type="search"] {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--arcus-text);
+  font-size: 0.95rem;
+  font-weight: 500;
+  outline: none;
+}
+
+.arcus-tools {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.arcus-tool {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  padding: 0.65rem 0.9rem;
+  border-radius: var(--arcus-radius-sm);
+  background: rgba(255, 255, 255, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(123, 139, 255, 0.18);
+}
+
+.arcus-tool--select select {
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--arcus-text);
+  font-size: 0.9rem;
+}
+
+.arcus-tool__icon {
+  font-size: 1.2rem;
+}
+
+.arcus-tool__label {
+  font-size: 0.85rem;
+  color: var(--arcus-text-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+
+.arcus-linklist {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.92rem;
+}
+
+.arcus-linklist li a {
+  color: var(--arcus-text-muted);
+  text-decoration: none;
+  padding-bottom: 0.15rem;
+  border-bottom: 1px solid transparent;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.arcus-linklist li a:hover,
+.arcus-linklist li a:focus-visible {
+  color: var(--arcus-accent);
+  border-color: rgba(123, 139, 255, 0.4);
+}
+
+.arcus-linklist__empty {
+  color: var(--arcus-text-soft);
+  font-style: italic;
+}
+
+.arcus-header__credit {
+  margin-top: auto;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--arcus-text-soft);
+}
+
+.arcus-main {
+  grid-area: main;
+  padding: 3.5rem 4rem 2.5rem;
+  background: var(--arcus-main-bg);
+  backdrop-filter: blur(20px);
+  box-shadow: inset 0 1px 0 var(--arcus-outline);
+}
+
+.arcus-mainview {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2.4rem;
+}
+
+.arcus-tagband {
+  grid-area: tag;
+  padding: 0 4rem 2rem;
+  display: flex;
+  justify-content: center;
+  background: transparent;
+}
+
+.arcus-tagband .tag-list,
+.arcus-tagband .tag-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.arcus-tagband a,
+.arcus-tagband button,
+.arcus-tagband .tag-chip {
+  border-radius: 999px;
+  padding: 0.45rem 1rem;
+  font-size: 0.85rem;
+  background: var(--arcus-tag-bg);
+  color: var(--arcus-tag-text);
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.arcus-tagband a:hover,
+.arcus-tagband button:hover,
+.arcus-tagband .tag-chip:hover {
+  border-color: rgba(123, 139, 255, 0.35);
+  transform: translateY(-2px);
+}
+
+.arcus-footer {
+  grid-area: footer;
+  padding: 1.6rem 4rem 3rem;
+  background: transparent;
+}
+
+.arcus-footer__inner {
+  max-width: 960px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.arcus-footer__nav {
+  display: flex;
+  gap: 1.2rem;
+}
+
+.arcus-footer__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1.4rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.arcus-footer__list a {
+  text-decoration: none;
+  color: var(--arcus-text-soft);
+  transition: color 0.2s ease;
+}
+
+.arcus-footer__list a:hover,
+.arcus-footer__list a:focus-visible {
+  color: var(--arcus-accent);
+}
+
+.arcus-card {
+  position: relative;
+  display: flex;
+  border-radius: var(--arcus-radius-lg);
+  background: var(--arcus-surface);
+  box-shadow: var(--arcus-shadow-subtle);
+  overflow: hidden;
+  border: 1px solid var(--arcus-outline);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.arcus-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(120deg, rgba(123, 139, 255, 0.12), transparent 70%);
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  pointer-events: none;
+}
+
+.arcus-card:hover,
+.arcus-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: var(--arcus-shadow-soft);
+}
+
+.arcus-card:hover::after,
+.arcus-card:focus-within::after {
+  opacity: 1;
+}
+
+.arcus-card__link {
+  display: flex;
+  gap: 1.6rem;
+  width: 100%;
+  color: inherit;
+  text-decoration: none;
+  padding: 1.8rem 2.2rem;
+  align-items: stretch;
+}
+
+.arcus-card__cover {
+  width: 220px;
+  min-width: 220px;
+  height: 160px;
+  border-radius: calc(var(--arcus-radius-lg) - 10px);
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.08);
+  position: relative;
+}
+
+.arcus-card__cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.arcus-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.arcus-card__title {
+  font-size: 1.4rem;
+  font-family: var(--arcus-font-serif);
+  line-height: 1.35;
+  letter-spacing: 0.01em;
+}
+
+.arcus-card__meta {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--arcus-text-soft);
+}
+
+.arcus-card__excerpt {
+  font-size: 1rem;
+  color: var(--arcus-text-muted);
+}
+
+.arcus-card__excerpt-tilt {
+  display: inline-block;
+  transform: skewX(-8deg);
+  transform-origin: left center;
+  font-style: italic;
+  background: linear-gradient(120deg, rgba(123, 139, 255, 0.12), transparent 80%);
+  padding: 0 0.2rem;
+}
+
+.arcus-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.arcus-card__tags .tag,
+.arcus-card__tags a {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--arcus-accent);
+  text-decoration: none;
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  background: var(--arcus-accent-soft);
+}
+
+.arcus-index__grid {
+  display: grid;
+  gap: 1.8rem;
+}
+
+.arcus-index__header {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.85rem;
+  color: var(--arcus-text-soft);
+}
+
+.arcus-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.4rem;
+  margin-top: 1rem;
+}
+
+.arcus-page {
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  text-decoration: none;
+  color: var(--arcus-text-muted);
+  font-size: 0.85rem;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.arcus-page:hover,
+.arcus-page:focus-visible {
+  border-color: rgba(123, 139, 255, 0.3);
+  color: var(--arcus-accent);
+}
+
+.arcus-page.is-current {
+  background: var(--arcus-accent-soft);
+  border-color: rgba(123, 139, 255, 0.35);
+  color: var(--arcus-accent);
+}
+
+.arcus-page.is-disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.arcus-loader {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.2rem;
+  padding: 4rem 2rem;
+}
+
+.arcus-loader__spinner {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 4px solid var(--arcus-accent-soft);
+  border-top-color: var(--arcus-accent);
+  animation: arcus-spin 1s linear infinite;
+}
+
+@keyframes arcus-spin {
+  to { transform: rotate(360deg); }
+}
+
+.arcus-loader__text {
+  font-size: 0.9rem;
+  color: var(--arcus-text-muted);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.arcus-error {
+  border-radius: var(--arcus-radius-lg);
+  padding: 2.8rem;
+  background: rgba(255, 85, 127, 0.1);
+  border: 1px solid rgba(255, 85, 127, 0.45);
+  color: #ffb3c7;
+  box-shadow: var(--arcus-shadow-subtle);
+}
+
+.arcus-error h2 {
+  margin-top: 0;
+  font-size: 1.6rem;
+}
+
+.arcus-error__actions {
+  margin-top: 1.6rem;
+  display: flex;
+  gap: 1rem;
+}
+
+.arcus-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  border: none;
+  text-decoration: none;
+  background: var(--arcus-accent);
+  color: white;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.arcus-btn:hover,
+.arcus-btn:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 26px rgba(123, 139, 255, 0.35);
+}
+
+.arcus-article {
+  background: var(--arcus-surface);
+  border-radius: var(--arcus-radius-lg);
+  box-shadow: var(--arcus-shadow-subtle);
+  border: 1px solid var(--arcus-outline);
+  padding: 3rem 3.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.arcus-article__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.arcus-article__title {
+  font-family: var(--arcus-font-serif);
+  font-size: 2.4rem;
+  line-height: 1.25;
+  margin: 0;
+}
+
+.arcus-article__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem 1.4rem;
+  font-size: 0.88rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--arcus-text-soft);
+}
+
+.arcus-article__hero {
+  border-radius: var(--arcus-radius-md);
+  overflow: hidden;
+  box-shadow: var(--arcus-shadow-subtle);
+}
+
+.arcus-article__hero img {
+  width: 100%;
+  display: block;
+}
+
+.arcus-article__body {
+  font-size: 1.02rem;
+  line-height: 1.72;
+  color: var(--arcus-text);
+}
+
+.arcus-article__body h2,
+.arcus-article__body h3,
+.arcus-article__body h4 {
+  font-family: var(--arcus-font-serif);
+  margin-top: 2.4rem;
+  margin-bottom: 1rem;
+  line-height: 1.3;
+}
+
+.arcus-article__body h2 { font-size: 1.9rem; }
+.arcus-article__body h3 { font-size: 1.45rem; }
+.arcus-article__body h4 { font-size: 1.2rem; }
+
+.arcus-article__body p {
+  margin: 1rem 0;
+}
+
+.arcus-article__body blockquote {
+  margin: 1.6rem 0;
+  padding: 1.2rem 1.6rem;
+  border-left: 4px solid var(--arcus-accent);
+  background: rgba(123, 139, 255, 0.12);
+  border-radius: var(--arcus-radius-sm);
+  color: var(--arcus-text-muted);
+  font-style: italic;
+}
+
+.arcus-article__body pre {
+  margin: 1.6rem 0;
+  padding: 1.4rem 1.6rem;
+  border-radius: var(--arcus-radius-sm);
+  background: var(--arcus-code-bg);
+  border: 1px solid var(--arcus-code-border);
+  overflow-x: auto;
+  font-family: var(--arcus-font-mono);
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.arcus-article__body code {
+  font-family: var(--arcus-font-mono);
+  background: rgba(123, 139, 255, 0.12);
+  padding: 0.05rem 0.3rem;
+  border-radius: 6px;
+}
+
+.arcus-article__body table {
+  border-collapse: separate;
+  border-spacing: 0;
+  width: 100%;
+  margin: 1.8rem 0;
+  border: 1px solid var(--arcus-outline);
+  border-radius: var(--arcus-radius-sm);
+  overflow: hidden;
+}
+
+.arcus-article__body th,
+.arcus-article__body td {
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--arcus-outline);
+}
+
+.arcus-article__body tr:nth-child(even) {
+  background: rgba(123, 139, 255, 0.08);
+}
+
+.arcus-article__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+
+.arcus-article__tags .tag,
+.arcus-article__tags a {
+  text-decoration: none;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: var(--arcus-accent-soft);
+  color: var(--arcus-accent);
+}
+
+.arcus-article__footer {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.arcus-article__nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.arcus-article__meta-line {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+  color: var(--arcus-text-muted);
+}
+
+.arcus-toc {
+  position: sticky;
+  top: 3rem;
+  align-self: flex-start;
+  max-width: 280px;
+  margin: 0 auto;
+  background: var(--arcus-surface);
+  border-radius: var(--arcus-radius-md);
+  padding: 1.4rem;
+  border: 1px solid var(--arcus-outline);
+  box-shadow: var(--arcus-shadow-subtle);
+}
+
+.arcus-toc__inner {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.arcus-toc__title {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--arcus-text-soft);
+}
+
+.arcus-toc ol,
+.arcus-toc ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.arcus-toc a {
+  text-decoration: none;
+  color: var(--arcus-text-muted);
+}
+
+.arcus-toc a:hover,
+.arcus-toc a:focus-visible {
+  color: var(--arcus-accent);
+}
+
+.arcus-index--search .arcus-card__excerpt-tilt {
+  background: rgba(255, 211, 94, 0.32);
+  color: #d0841f;
+}
+
+.arcus-static {
+  background: var(--arcus-surface);
+  border-radius: var(--arcus-radius-lg);
+  box-shadow: var(--arcus-shadow-subtle);
+  border: 1px solid var(--arcus-outline);
+  padding: 3rem;
+}
+
+.arcus-static__header h1 {
+  margin: 0;
+  font-family: var(--arcus-font-serif);
+  font-size: 2rem;
+}
+
+.arcus-static__body {
+  margin-top: 1.4rem;
+  font-size: 1rem;
+}
+
+.arcus-empty {
+  font-style: italic;
+  color: var(--arcus-text-soft);
+  text-align: center;
+  padding: 3rem 1rem;
+}
+
+.arcus-header-sentinel {
+  height: 1px;
+}
+
+@media (max-width: 1200px) {
+  .arcus-shell {
+    grid-template-columns: minmax(240px, 320px) 1fr;
+  }
+  .arcus-header__inner {
+    padding: 2.6rem 2.2rem;
+  }
+  .arcus-main {
+    padding: 3rem 3rem 2rem;
+  }
+  .arcus-tagband {
+    padding: 0 3rem 2rem;
+  }
+}
+
+@media (max-width: 960px) {
+  .arcus-shell {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "rail"
+      "main"
+      "tag"
+      "footer";
+  }
+  .arcus-header {
+    position: relative;
+    height: auto;
+  }
+  .arcus-header__inner {
+    border-right: none;
+    border-bottom: 1px solid var(--arcus-rail-border);
+    border-radius: 0 0 var(--arcus-radius-lg) var(--arcus-radius-lg);
+  }
+  .arcus-main {
+    padding: 2.6rem 1.8rem 2rem;
+  }
+  .arcus-tagband {
+    padding: 0 1.8rem 2rem;
+    justify-content: flex-start;
+  }
+  .arcus-footer {
+    padding: 1.6rem 1.8rem 2.8rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .arcus-card__link {
+    flex-direction: column;
+    padding: 1.6rem 1.4rem;
+  }
+  .arcus-card__cover {
+    width: 100%;
+    min-width: unset;
+    height: 180px;
+  }
+  .arcus-article {
+    padding: 2.2rem 1.6rem;
+  }
+  .arcus-article__title {
+    font-size: 2rem;
+  }
+  .arcus-toc {
+    position: relative;
+    top: 0;
+    max-width: 100%;
+  }
+}

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -130,16 +130,18 @@ body {
   position: relative;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 0.9rem;
+  align-items: center;
+  align-self: center;
+  text-align: center;
+  gap: 1.2rem;
   text-decoration: none;
   color: inherit;
 }
 
 .arcus-brand__mark {
-  width: 54px;
-  height: 54px;
-  border-radius: 20px;
+  width: 88px;
+  height: 88px;
+  border-radius: 28px;
   flex-shrink: 0;
   display: grid;
   place-items: center;

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -129,9 +129,9 @@ body {
 .arcus-brand {
   position: relative;
   display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 1.2rem;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.9rem;
   text-decoration: none;
   color: inherit;
 }

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -107,7 +107,7 @@ body {
   padding: 3.2rem 2.6rem;
   display: flex;
   flex-direction: column;
-  gap: 2.4rem;
+  gap: 1.8rem;
   width: 100%;
   backdrop-filter: blur(18px);
   position: relative;
@@ -292,14 +292,6 @@ body {
   font-style: italic;
 }
 
-.arcus-header__credit {
-  margin-top: auto;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.22em;
-  color: var(--arcus-text-soft);
-}
-
 .arcus-main {
   padding: 3.5rem 4rem 2.5rem;
   background: var(--arcus-main-bg);
@@ -350,6 +342,61 @@ body {
 .arcus-tagband .tag-chip:hover {
   border-color: rgba(123, 139, 255, 0.35);
   transform: translateY(-2px);
+}
+
+.arcus-utility {
+  flex: 0 0 auto;
+  padding: 0 4rem 2.8rem;
+  background: var(--arcus-main-bg);
+  border-top: 1px solid var(--arcus-outline);
+  display: flex;
+  justify-content: center;
+  position: relative;
+}
+
+.arcus-utility::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(140% 120% at 50% 0%, rgba(123, 139, 255, 0.08), transparent 60%);
+  pointer-events: none;
+}
+
+.arcus-utility__inner {
+  position: relative;
+  width: min(960px, 100%);
+  display: grid;
+  gap: 1.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  align-items: start;
+}
+
+.arcus-utility__search,
+.arcus-utility__tools,
+.arcus-utility__links,
+.arcus-utility__credit {
+  position: relative;
+  z-index: 1;
+}
+
+.arcus-utility__links {
+  grid-column: 1 / -1;
+}
+
+.arcus-utility__links .arcus-linklist {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 0.6rem 1.4rem;
+}
+
+.arcus-utility__credit {
+  grid-column: 1 / -1;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--arcus-text-soft);
+  text-align: center;
+  padding-top: 0.6rem;
 }
 
 .arcus-footer {
@@ -875,6 +922,9 @@ body {
   .arcus-tagband {
     padding: 0 3rem 2rem;
   }
+  .arcus-utility {
+    padding: 0 3rem 2.4rem;
+  }
 }
 
 @media (max-width: 960px) {
@@ -908,6 +958,16 @@ body {
   .arcus-tagband {
     padding: 0 1.8rem 2rem;
     justify-content: flex-start;
+  }
+  .arcus-utility {
+    padding: 0 1.8rem 2.4rem;
+  }
+  .arcus-utility__inner {
+    grid-template-columns: 1fr;
+  }
+  .arcus-utility__links .arcus-linklist {
+    flex-direction: column;
+    gap: 0.4rem;
   }
   .arcus-footer {
     padding: 1.6rem 1.8rem 2.8rem;

--- a/assets/themes/arcus/theme.json
+++ b/assets/themes/arcus/theme.json
@@ -1,0 +1,7 @@
+{
+  "name": "Arcus",
+  "modules": [
+    "modules/layout.js",
+    "modules/interactions.js"
+  ]
+}

--- a/assets/themes/packs.json
+++ b/assets/themes/packs.json
@@ -1,4 +1,14 @@
 [
-  { "value": "native", "label": "Native" },
-  { "value": "solstice", "label": "Solstice" }
+  {
+    "value": "native",
+    "label": "Native"
+  },
+  {
+    "value": "solstice",
+    "label": "Solstice"
+  },
+  {
+    "value": "arcus",
+    "label": "Arcus"
+  }
 ]

--- a/site.yaml
+++ b/site.yaml
@@ -41,7 +41,7 @@ contentRoot: wwwroot      # Root directory for content files
 
 # Theme override configurations
 themeMode: user
-themePack: solstice
+themePack: arcus
 themeOverride: true
 
 # Repository information used for internal linking of "report issue" etc.


### PR DESCRIPTION
## Summary
- add the Arcus theme with a dual-column layout, custom interactions, and typography updates
- register the new theme in the theme pack list and set it as the default pack in site.yaml

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68da8e1915348328847104bd5439bd0b