### PR TITLE
Move Arcus theme credit to sidebar footer

### DIFF
--- a/assets/themes/arcus/modules/layout.js
+++ b/assets/themes/arcus/modules/layout.js
@@ -41,6 +41,7 @@ export function mount(context = {}) {
         </a>
         <div class="arcus-header__divider" aria-hidden="true"></div>
         <nav id="${NAV_ID}" class="arcus-nav" aria-label="Primary navigation"></nav>
+        <div class="arcus-header__credit arcus-footer__credit" aria-label="Site credit"></div>
       </div>`;
     return el;
   });
@@ -135,7 +136,6 @@ export function mount(context = {}) {
         <section class="arcus-utility__links" aria-label="Profile links">
           <ul class="arcus-linklist" data-site-links></ul>
         </section>
-        <div class="arcus-utility__credit arcus-footer__credit" aria-label="Site credit"></div>
       </div>`;
     return el;
   });

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -211,6 +211,16 @@ body {
   gap: 0.6rem;
 }
 
+.arcus-header__credit {
+  margin-top: auto;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--arcus-text-soft);
+  text-align: center;
+  padding-top: 1.2rem;
+}
+
 .arcus-nav__item {
   display: flex;
   align-items: center;
@@ -409,8 +419,7 @@ body {
 
 .arcus-utility__search,
 .arcus-utility__tools,
-.arcus-utility__links,
-.arcus-utility__credit {
+.arcus-utility__links {
   position: relative;
   z-index: 1;
 }
@@ -423,16 +432,6 @@ body {
   flex-direction: row;
   flex-wrap: wrap;
   gap: 0.6rem 1.4rem;
-}
-
-.arcus-utility__credit {
-  grid-column: 1 / -1;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.22em;
-  color: var(--arcus-text-soft);
-  text-align: center;
-  padding-top: 0.6rem;
 }
 
 .arcus-footer {


### PR DESCRIPTION
## Summary
- relocate the Arcus theme credit element into the Arcus sidebar so it sits at the bottom of the rail
- update Arcus theme styles after moving the credit and tidy the utility panel markup

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db2ecdf1048328b178f0eced1c39af