### PR TITLE
Move Arcus theme credit block into header

### DIFF
--- a/assets/themes/arcus/modules/layout.js
+++ b/assets/themes/arcus/modules/layout.js
@@ -41,7 +41,8 @@ export function mount(context = {}) {
         </a>
         <div class="arcus-header__divider" aria-hidden="true"></div>
         <nav id="${NAV_ID}" class="arcus-nav" aria-label="Primary navigation"></nav>
-      </div>`;
+      </div>
+      <div class="arcus-utility__credit arcus-footer__credit" aria-label="Site credit"></div>`;
     return el;
   });
 
@@ -135,7 +136,6 @@ export function mount(context = {}) {
         <section class="arcus-utility__links" aria-label="Profile links">
           <ul class="arcus-linklist" data-site-links></ul>
         </section>
-        <div class="arcus-utility__credit arcus-footer__credit" aria-label="Site credit"></div>
       </div>`;
     return el;
   });


### PR DESCRIPTION
## Summary
- move the Arcus theme credit block from the utilities section into the header markup so it renders at the top of the layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db323139f88328bb3f79312693f6a8