### PR TITLE
Move Arcus site credit to header

### DIFF
--- a/assets/themes/arcus/modules/layout.js
+++ b/assets/themes/arcus/modules/layout.js
@@ -45,6 +45,20 @@ export function mount(context = {}) {
     return el;
   });
 
+  const headerInner = header.querySelector('.arcus-header__inner') || header;
+  let siteCredit = container.querySelector('.arcus-utility__credit.arcus-footer__credit');
+  if (!siteCredit) {
+    siteCredit = doc.createElement('div');
+    siteCredit.className = 'arcus-utility__credit arcus-footer__credit';
+    siteCredit.setAttribute('aria-label', 'Site credit');
+  }
+  siteCredit.classList.add('arcus-header__credit');
+  if (siteCredit.parentElement !== headerInner) {
+    headerInner.appendChild(siteCredit);
+  } else if (siteCredit.nextElementSibling) {
+    headerInner.appendChild(siteCredit);
+  }
+
   const rightColumn = ensureElement(container, '.arcus-rightcol', () => {
     const el = doc.createElement('div');
     el.className = 'arcus-rightcol';
@@ -135,7 +149,6 @@ export function mount(context = {}) {
         <section class="arcus-utility__links" aria-label="Profile links">
           <ul class="arcus-linklist" data-site-links></ul>
         </section>
-        <div class="arcus-utility__credit arcus-footer__credit" aria-label="Site credit"></div>
       </div>`;
     return el;
   });

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -435,6 +435,16 @@ body {
   padding-top: 0.6rem;
 }
 
+.arcus-header__credit {
+  margin-top: auto;
+  padding-top: 2.4rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--arcus-text-soft);
+  text-align: center;
+}
+
 .arcus-footer {
   flex: 0 0 auto;
   padding: 1.6rem 4rem 3rem;


### PR DESCRIPTION
## Summary
- move the Arcus site credit element from the utility panel into the left sidebar header
- style the relocated credit to sit at the bottom of the sidebar while retaining the existing footer credit hook

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68db3315b104832893c728103d7a0061