### PR TITLE
Move Arcus credit to header sidebar

### DIFF
--- a/assets/themes/arcus/modules/layout.js
+++ b/assets/themes/arcus/modules/layout.js
@@ -43,9 +43,31 @@ export function mount(context = {}) {
         <div class="arcus-nav__scroller" data-overflow="none">
           <nav id="${NAV_ID}" class="arcus-nav" aria-label="Primary navigation"></nav>
         </div>
+        <div class="arcus-utility__credit arcus-footer__credit arcus-header__credit" aria-label="Site credit"></div>
       </div>`;
     return el;
   });
+
+  const headerInner = header.querySelector('.arcus-header__inner');
+  let headerCredit = headerInner.querySelector('.arcus-utility__credit');
+
+  if (!headerCredit) {
+    const existingCredit = container.querySelector('.arcus-utility .arcus-utility__credit');
+    if (existingCredit) {
+      headerCredit = existingCredit;
+      headerCredit.classList.add('arcus-header__credit');
+      headerInner.appendChild(headerCredit);
+    }
+  } else {
+    headerCredit.classList.add('arcus-header__credit');
+  }
+
+  if (!headerCredit) {
+    headerCredit = doc.createElement('div');
+    headerCredit.className = 'arcus-utility__credit arcus-footer__credit arcus-header__credit';
+    headerCredit.setAttribute('aria-label', 'Site credit');
+    headerInner.appendChild(headerCredit);
+  }
 
   const rightColumn = ensureElement(container, '.arcus-rightcol', () => {
     const el = doc.createElement('div');
@@ -137,10 +159,14 @@ export function mount(context = {}) {
         <section class="arcus-utility__links" aria-label="Profile links">
           <ul class="arcus-linklist" data-site-links></ul>
         </section>
-        <div class="arcus-utility__credit arcus-footer__credit" aria-label="Site credit"></div>
       </div>`;
     return el;
   });
+
+  const orphanCredit = utilities.querySelector('.arcus-utility__credit');
+  if (orphanCredit && orphanCredit !== headerCredit) {
+    orphanCredit.remove();
+  }
 
   if (utilities.parentElement !== rightColumn) {
     rightColumn.insertBefore(utilities, footer);

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -122,6 +122,16 @@ body {
   box-sizing: border-box;
 }
 
+.arcus-header__credit {
+  margin-top: auto;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--arcus-text-soft);
+  text-align: center;
+  padding-top: 1.2rem;
+}
+
 .arcus-header__inner::after {
   content: "";
   position: absolute;


### PR DESCRIPTION
## Summary
- relocate the Arcus theme copyright credit into the left header rail
- ensure orphaned footer credit nodes are removed and add sidebar-specific styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db43d90bf083289db4198f9ab110bd