### PR TITLE
Remove Arcus article cards styling

### DIFF
--- a/assets/themes/arcus/modules/interactions.js
+++ b/assets/themes/arcus/modules/interactions.js
@@ -289,14 +289,22 @@ function buildCard({ title, meta, translate, link, siteConfig }) {
   const coverHtml = renderCardCover(meta, title, siteConfig);
   const hasCover = Boolean(coverHtml);
   const cardClasses = `arcus-card${hasCover ? ' arcus-card--with-cover' : ''}`;
+  const metaLine = () => {
+    if (!date && !tags) return '';
+    let html = '<div class="arcus-card__meta-line">';
+    if (date) html += `<span class="arcus-card__meta-date">${escapeHtml(date)}</span>`;
+    if (date && tags) html += '<span class="arcus-card__meta-separator" aria-hidden="true">·</span>';
+    if (tags) html += `<div class="arcus-card__tags">${tags}</div>`;
+    html += '</div>';
+    return html;
+  };
   return `<article class="${cardClasses}">
     <a class="arcus-card__link" href="${escapeHtml(link)}">
       ${coverHtml}
       <div class="arcus-card__body">
+        ${metaLine()}
         <h3 class="arcus-card__title">${safeTitle}</h3>
-        ${date ? `<div class="arcus-card__meta">${escapeHtml(date)}</div>` : ''}
         ${excerpt ? `<p class="arcus-card__excerpt"><span class="arcus-card__excerpt-tilt">${excerpt}</span></p>` : ''}
-        ${tags ? `<div class="arcus-card__tags">${tags}</div>` : ''}
       </div>
     </a>
   </article>`;

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -610,7 +610,7 @@ body {
 .arcus-card__body {
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.3rem;
   justify-content: center;
 }
 
@@ -618,10 +618,10 @@ body {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 0.45rem;
-  font-size: 0.85rem;
+  gap: 0.35rem;
+  font-size: 0.78rem;
   text-transform: uppercase;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.14em;
   color: var(--arcus-text-soft);
 }
 
@@ -634,7 +634,7 @@ body {
 }
 
 .arcus-card__title {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
   font-family: var(--arcus-font-serif);
   line-height: 1.35;
   letter-spacing: 0.01em;
@@ -643,7 +643,7 @@ body {
 .arcus-card__excerpt {
   font-size: 1rem;
   color: var(--arcus-text-muted);
-  margin-top: 0.2rem;
+  margin-top: 0.4rem;
 }
 
 .arcus-card__excerpt-tilt {
@@ -670,9 +670,9 @@ body {
 
 .arcus-card__tags .tag,
 .arcus-card__tags a {
-  font-size: 0.78rem;
+  font-size: 0.72rem;
   text-transform: uppercase;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.14em;
   color: var(--arcus-accent);
   text-decoration: none;
   padding: 0.3rem 0.6rem;

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -638,6 +638,7 @@ body {
   font-family: var(--arcus-font-serif);
   line-height: 1.35;
   letter-spacing: 0.01em;
+  margin-top: 0;
 }
 
 .arcus-card__excerpt {

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -545,55 +545,58 @@ body {
 
 .arcus-card {
   position: relative;
-  display: flex;
-  border-radius: var(--arcus-radius-lg);
-  background: var(--arcus-surface);
-  box-shadow: var(--arcus-shadow-subtle);
-  overflow: hidden;
-  border: 1px solid var(--arcus-outline);
-  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  display: block;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  overflow: visible;
+  border: none;
+  padding: 1.8rem 0;
+  transition: color 0.2s ease;
+  border-bottom: 1px solid var(--arcus-outline);
+}
+
+.arcus-card:first-child {
+  padding-top: 0;
+}
+
+.arcus-card:last-child {
+  border-bottom: none;
 }
 
 .arcus-card::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  background: linear-gradient(120deg, rgba(123, 139, 255, 0.12), transparent 70%);
-  opacity: 0;
-  transition: opacity 0.25s ease;
-  pointer-events: none;
+  content: none;
 }
 
 .arcus-card:hover,
 .arcus-card:focus-within {
-  transform: translateY(-6px);
-  box-shadow: var(--arcus-shadow-soft);
-}
-
-.arcus-card:hover::after,
-.arcus-card:focus-within::after {
-  opacity: 1;
+  transform: none;
+  box-shadow: none;
 }
 
 .arcus-card__link {
   display: flex;
-  gap: 1.6rem;
+  flex-direction: column;
+  gap: 0.75rem;
   width: 100%;
   color: inherit;
   text-decoration: none;
-  padding: 1.8rem 2.2rem;
-  align-items: stretch;
+  padding: 0;
+  align-items: flex-start;
+}
+
+.arcus-card__link:focus-visible {
+  outline: 2px solid var(--arcus-accent);
+  outline-offset: 4px;
+}
+
+.arcus-card__link:hover .arcus-card__title,
+.arcus-card__link:focus-visible .arcus-card__title {
+  color: var(--arcus-accent);
 }
 
 .arcus-card__cover {
-  width: 220px;
-  min-width: 220px;
-  height: 160px;
-  border-radius: calc(var(--arcus-radius-lg) - 10px);
-  overflow: hidden;
-  background: rgba(0, 0, 0, 0.08);
-  position: relative;
+  display: none;
 }
 
 .arcus-card__cover img {
@@ -657,8 +660,8 @@ body {
 }
 
 .arcus-index__grid {
-  display: grid;
-  gap: 1.8rem;
+  display: flex;
+  flex-direction: column;
 }
 
 .arcus-index__header {
@@ -1079,13 +1082,10 @@ body {
 
 @media (max-width: 720px) {
   .arcus-card__link {
-    flex-direction: column;
-    padding: 1.6rem 1.4rem;
+    padding: 0;
   }
   .arcus-card__cover {
-    width: 100%;
-    min-width: unset;
-    height: 180px;
+    display: none;
   }
   .arcus-article {
     padding: 2.2rem 1.6rem;

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -610,7 +610,7 @@ body {
 .arcus-card__body {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.45rem;
   justify-content: center;
 }
 
@@ -643,6 +643,7 @@ body {
 .arcus-card__excerpt {
   font-size: 1rem;
   color: var(--arcus-text-muted);
+  margin-top: 0.2rem;
 }
 
 .arcus-card__excerpt-tilt {

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -639,6 +639,7 @@ body {
   line-height: 1.35;
   letter-spacing: 0.01em;
   margin-top: 0;
+  margin-bottom: 0;
 }
 
 .arcus-card__excerpt {

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -606,6 +606,7 @@ body {
   display: block;
 }
 
+
 .arcus-card__body {
   display: flex;
   flex-direction: column;
@@ -613,18 +614,30 @@ body {
   justify-content: center;
 }
 
+.arcus-card__meta-line {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--arcus-text-soft);
+}
+
+.arcus-card__meta-date {
+  white-space: nowrap;
+}
+
+.arcus-card__meta-separator {
+  color: var(--arcus-text-soft);
+}
+
 .arcus-card__title {
   font-size: 1.4rem;
   font-family: var(--arcus-font-serif);
   line-height: 1.35;
   letter-spacing: 0.01em;
-}
-
-.arcus-card__meta {
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
-  color: var(--arcus-text-soft);
 }
 
 .arcus-card__excerpt {
@@ -643,8 +656,15 @@ body {
 
 .arcus-card__tags {
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
   gap: 0.45rem;
+}
+
+.arcus-card__tags .tags {
+  display: flex;
+  gap: 0.45rem;
+  flex-wrap: wrap;
 }
 
 .arcus-card__tags .tag,


### PR DESCRIPTION
## Summary
- simplify Arcus article listings by removing the card layout styling and associated hover effects
- hide article card cover images and adjust the list container to render as a vertical list

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db4a97bb348328be367876d72f66b8