### PR TITLE
Remove card styling from Arcus main view

### DIFF
--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -410,6 +410,11 @@ body {
   display: flex;
   flex-direction: column;
   gap: 2.4rem;
+  --arcus-radius-lg: 0;
+  --arcus-radius-md: 0;
+  --arcus-radius-sm: 0;
+  --arcus-shadow-subtle: none;
+  --arcus-shadow-soft: none;
 }
 
 .arcus-tagband {


### PR DESCRIPTION
## Summary
- reset Arcus main view radius and shadow variables to remove the card appearance

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68db51b0e35083289aa77aa2b822098e