### PR TITLE
Enhance Arcus theme tag view

### DIFF
--- a/assets/js/tags.js
+++ b/assets/js/tags.js
@@ -32,14 +32,15 @@ export function renderTagSidebar(indexMap) {
   const currentTag = (getQueryVariable('tag') || '').trim().toLowerCase();
   const total = items.reduce((s, x) => s + x.count, 0);
   const allHref = withLangParam('?tab=search');
-  if (!items.length) { root.innerHTML = `<div class="muted">${t('ui.allTags')}</div>`; return; }
+  const header = `<div class="section-title">${t('ui.tags')}</div>`;
+  if (!items.length) { root.innerHTML = header + `<div class="muted">${t('ui.allTags')}</div>`; return; }
   const lis = items.map(({ label, count }) => {
     const isActive = label.trim().toLowerCase() === currentTag;
     const href = withLangParam(`?tab=search&tag=${encodeURIComponent(label)}`);
     return `<li><a class="tag-link${isActive ? ' active' : ''}" href="${href}"><span class="tag-name">${escapeHtml(label)}</span><span class="tag-count">${count}</span></a></li>`;
   }).join('');
   const allItem = `<li><a class="tag-link all${currentTag ? '' : ' active'}" href="${allHref}"><span class="tag-name">${t('ui.allTags')}</span><span class="tag-count">${total}</span></a></li>`;
-  root.innerHTML = `
+  root.innerHTML = header + `
     <div class="tagbox">
       <ul class="tag-list compact" data-collapsed="true">
         ${allItem}


### PR DESCRIPTION
## Summary
- style the Arcus theme tag view with a dedicated layout, hover states, and active styling
- add Arcus-themed tooltip visuals for truncated tag names
- tune responsive spacing and grid behavior for the tag list across breakpoints

## Testing
- manual via `python -m http.server 8000` and visiting `http://127.0.0.1:8000/index.html?tab=search`


------
https://chatgpt.com/codex/tasks/task_e_68db8297c20c83289305ba92fc539f94