### PR TITLE
Remove border from arcus static container

### DIFF
--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -2023,7 +2023,6 @@ body {
   background: var(--arcus-surface);
   border-radius: var(--arcus-radius-lg);
   box-shadow: var(--arcus-shadow-subtle);
-  border: 1px solid var(--arcus-outline);
   padding: 3rem;
 }
 


### PR DESCRIPTION
## Summary
- remove the outline border from the Arcus static content container to match updated styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db8b7e1a2c8328882e552e722af1d1