### PR TITLE
Refine Arcus utility panel styling

### DIFF
--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -714,29 +714,36 @@ body {
 
 .arcus-utility {
   flex: 0 0 auto;
-  padding: 0 4rem 2.8rem;
-  background: var(--arcus-main-bg);
+  padding: 2.4rem 4rem 3.2rem;
+  margin-top: clamp(2rem, 6vw, 4rem);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 60%),
+    var(--arcus-main-bg);
   border-top: 1px solid var(--arcus-outline);
   display: flex;
   justify-content: center;
   position: relative;
+  overflow: hidden;
+  border-radius: var(--arcus-radius-lg) var(--arcus-radius-lg) 0 0;
+  box-shadow: 0 -18px 40px rgba(17, 20, 45, 0.18);
 }
 
 .arcus-utility::before {
   content: "";
   position: absolute;
   inset: 0;
-  background: radial-gradient(140% 120% at 50% 0%, rgba(123, 139, 255, 0.08), transparent 60%);
+  background: radial-gradient(120% 120% at 50% 0%, rgba(123, 139, 255, 0.12), transparent 65%);
   pointer-events: none;
+  opacity: 0.85;
 }
 
 .arcus-utility__inner {
   position: relative;
   width: min(960px, 100%);
   display: grid;
-  gap: 1.8rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  align-items: start;
+  gap: 2.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: stretch;
+  padding: 0 0.6rem;
 }
 
 .arcus-utility__search,
@@ -747,14 +754,27 @@ body {
   z-index: 1;
 }
 
+.arcus-utility__search,
+.arcus-utility__tools,
+.arcus-utility__links {
+  background: rgba(18, 22, 60, 0.24);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: var(--arcus-radius-md);
+  padding: 1.4rem 1.6rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(6px);
+}
+
 .arcus-utility__links {
   grid-column: 1 / -1;
+  padding: 1.6rem;
 }
 
 .arcus-utility__links .arcus-linklist {
   flex-direction: row;
   flex-wrap: wrap;
-  gap: 0.6rem 1.4rem;
+  gap: 0.8rem 1.8rem;
+  justify-content: center;
 }
 
 .arcus-utility__credit {
@@ -764,7 +784,7 @@ body {
   letter-spacing: 0.22em;
   color: var(--arcus-text-soft);
   text-align: center;
-  padding-top: 0.6rem;
+  padding-top: 0.8rem;
 }
 
 .arcus-footer {
@@ -2068,7 +2088,9 @@ body {
     padding: 0 3rem 2rem;
   }
   .arcus-utility {
-    padding: 0 3rem 2.4rem;
+    padding: 2rem 3rem 2.6rem;
+    margin-top: 2.4rem;
+    border-radius: var(--arcus-radius-lg);
   }
 }
 
@@ -2111,14 +2133,19 @@ body {
     justify-content: flex-start;
   }
   .arcus-utility {
-    padding: 0 1.8rem 2.4rem;
+    padding: 1.8rem 1.8rem 2.6rem;
+    margin-top: 2rem;
+    border-radius: var(--arcus-radius-lg);
   }
   .arcus-utility__inner {
     grid-template-columns: 1fr;
+    gap: 1.6rem;
+    padding: 0;
   }
   .arcus-utility__links .arcus-linklist {
     flex-direction: column;
-    gap: 0.4rem;
+    gap: 0.6rem;
+    align-items: stretch;
   }
   .arcus-footer {
     padding: 1.6rem 1.8rem 2.8rem;


### PR DESCRIPTION
## Summary
- refresh the Arcus utility panel with gradient background, rounded edges, and subtle elevation
- add translucent cards for search, tools, and links with centered spacing adjustments
- tune responsive breakpoints so the utility layout maintains breathing room on medium and small screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db8c64872c8328b5efc16d3b4cd482