### PR TITLE
Move Arcus search form to top of sidebar

### DIFF
--- a/assets/themes/arcus/modules/layout.js
+++ b/assets/themes/arcus/modules/layout.js
@@ -223,6 +223,63 @@ export function mount(context = {}) {
     }
   }
 
+  const searchToggle = ensureElement(container, '.arcus-search-toggle', () => {
+    const button = doc.createElement('button');
+    button.type = 'button';
+    button.className = 'arcus-search-toggle';
+    button.setAttribute('aria-expanded', 'false');
+    button.setAttribute('aria-controls', 'searchInput');
+    button.innerHTML = `
+      <span class="arcus-search-toggle__icon" aria-hidden="true">🔍</span>
+      <span class="arcus-search-toggle__label">Search</span>`;
+    return button;
+  });
+
+  if (!searchSection.dataset.toggleBound) {
+    searchSection.dataset.toggleBound = 'true';
+
+    const getInput = () => searchSection.querySelector('input[type="search"]');
+    const setOpen = (open) => {
+      const isOpen = Boolean(open);
+      searchSection.classList.toggle('is-open', isOpen);
+      searchToggle.classList.toggle('is-active', isOpen);
+      searchToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+      if (isOpen) {
+        const input = getInput();
+        if (input) {
+          input.focus({ preventScroll: true });
+        }
+      } else if (doc.activeElement && searchSection.contains(doc.activeElement)) {
+        doc.activeElement.blur();
+      }
+    };
+
+    searchToggle.addEventListener('click', (event) => {
+      event.preventDefault();
+      const nextState = !searchSection.classList.contains('is-open');
+      setOpen(nextState);
+    });
+
+    searchSection.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+        searchToggle.focus({ preventScroll: true });
+      }
+    });
+
+    searchSection.addEventListener('focusin', () => {
+      setOpen(true);
+    });
+
+    doc.addEventListener('click', (event) => {
+      if (!searchSection.classList.contains('is-open')) return;
+      const target = event.target;
+      if (searchSection.contains(target)) return;
+      if (searchToggle.contains(target)) return;
+      setOpen(false);
+    });
+  }
+
   const orphanCredit = utilities.querySelector('.arcus-utility__credit');
   if (orphanCredit && orphanCredit !== headerCredit) {
     orphanCredit.remove();

--- a/assets/themes/arcus/modules/layout.js
+++ b/assets/themes/arcus/modules/layout.js
@@ -187,18 +187,41 @@ export function mount(context = {}) {
     el.setAttribute('aria-label', 'Site utilities');
     el.innerHTML = `
       <div class="arcus-utility__inner">
-        <section class="arcus-utility__search" aria-label="Search">
-          <label class="arcus-search" for="searchInput">
-            <span class="arcus-search__icon" aria-hidden="true">🔍</span>
-            <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
-          </label>
-        </section>
         <section class="arcus-utility__tools" aria-label="Quick tools">
           <div id="toolsPanel" class="arcus-tools"></div>
         </section>
       </div>`;
     return el;
   });
+
+  const searchSection = ensureElement(rightColumn, '.arcus-utility__search', () => {
+    const el = doc.createElement('section');
+    el.className = 'arcus-utility__search';
+    el.setAttribute('aria-label', 'Search');
+    el.innerHTML = `
+      <label class="arcus-search" for="searchInput">
+        <span class="arcus-search__icon" aria-hidden="true">🔍</span>
+        <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
+      </label>`;
+    return el;
+  });
+
+  if (!searchSection.querySelector('.arcus-search')) {
+    searchSection.innerHTML = `
+      <label class="arcus-search" for="searchInput">
+        <span class="arcus-search__icon" aria-hidden="true">🔍</span>
+        <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
+      </label>`;
+  }
+
+  if (searchSection.parentElement !== rightColumn) {
+    rightColumn.insertBefore(searchSection, rightColumn.firstElementChild);
+  } else {
+    const firstElement = rightColumn.firstElementChild;
+    if (firstElement && firstElement !== searchSection) {
+      rightColumn.insertBefore(searchSection, firstElement);
+    }
+  }
 
   const orphanCredit = utilities.querySelector('.arcus-utility__credit');
   if (orphanCredit && orphanCredit !== headerCredit) {

--- a/assets/themes/arcus/modules/layout.js
+++ b/assets/themes/arcus/modules/layout.js
@@ -198,16 +198,17 @@ export function mount(context = {}) {
     const el = doc.createElement('section');
     el.className = 'arcus-utility__search';
     el.setAttribute('aria-label', 'Search');
-    el.innerHTML = `
-      <label class="arcus-search" for="searchInput">
-        <span class="arcus-search__icon" aria-hidden="true">🔍</span>
-        <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
-      </label>`;
     return el;
   });
 
-  if (!searchSection.querySelector('.arcus-search')) {
-    searchSection.innerHTML = `
+  const searchPanel = ensureElement(searchSection, '.arcus-search__panel', () => {
+    const panel = doc.createElement('div');
+    panel.className = 'arcus-search__panel';
+    return panel;
+  });
+
+  if (!searchPanel.querySelector('.arcus-search')) {
+    searchPanel.innerHTML = `
       <label class="arcus-search" for="searchInput">
         <span class="arcus-search__icon" aria-hidden="true">🔍</span>
         <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
@@ -223,7 +224,12 @@ export function mount(context = {}) {
     }
   }
 
-  const searchToggle = ensureElement(container, '.arcus-search-toggle', () => {
+  const strayToggle = container.querySelector('.arcus-search-toggle');
+  if (strayToggle && !searchSection.contains(strayToggle)) {
+    strayToggle.remove();
+  }
+
+  const searchToggle = ensureElement(searchSection, '.arcus-search-toggle', () => {
     const button = doc.createElement('button');
     button.type = 'button';
     button.className = 'arcus-search-toggle';
@@ -235,10 +241,14 @@ export function mount(context = {}) {
     return button;
   });
 
+  if (searchPanel.nextElementSibling !== searchToggle) {
+    searchSection.insertBefore(searchToggle, searchPanel.nextSibling);
+  }
+
   if (!searchSection.dataset.toggleBound) {
     searchSection.dataset.toggleBound = 'true';
 
-    const getInput = () => searchSection.querySelector('input[type="search"]');
+    const getInput = () => searchPanel.querySelector('input[type="search"]');
     const setOpen = (open) => {
       const isOpen = Boolean(open);
       searchSection.classList.toggle('is-open', isOpen);

--- a/assets/themes/arcus/modules/layout.js
+++ b/assets/themes/arcus/modules/layout.js
@@ -198,17 +198,16 @@ export function mount(context = {}) {
     const el = doc.createElement('section');
     el.className = 'arcus-utility__search';
     el.setAttribute('aria-label', 'Search');
+    el.innerHTML = `
+      <label class="arcus-search" for="searchInput">
+        <span class="arcus-search__icon" aria-hidden="true">🔍</span>
+        <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
+      </label>`;
     return el;
   });
 
-  const searchPanel = ensureElement(searchSection, '.arcus-search__panel', () => {
-    const panel = doc.createElement('div');
-    panel.className = 'arcus-search__panel';
-    return panel;
-  });
-
-  if (!searchPanel.querySelector('.arcus-search')) {
-    searchPanel.innerHTML = `
+  if (!searchSection.querySelector('.arcus-search')) {
+    searchSection.innerHTML = `
       <label class="arcus-search" for="searchInput">
         <span class="arcus-search__icon" aria-hidden="true">🔍</span>
         <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
@@ -224,12 +223,7 @@ export function mount(context = {}) {
     }
   }
 
-  const strayToggle = container.querySelector('.arcus-search-toggle');
-  if (strayToggle && !searchSection.contains(strayToggle)) {
-    strayToggle.remove();
-  }
-
-  const searchToggle = ensureElement(searchSection, '.arcus-search-toggle', () => {
+  const searchToggle = ensureElement(container, '.arcus-search-toggle', () => {
     const button = doc.createElement('button');
     button.type = 'button';
     button.className = 'arcus-search-toggle';
@@ -241,14 +235,10 @@ export function mount(context = {}) {
     return button;
   });
 
-  if (searchPanel.nextElementSibling !== searchToggle) {
-    searchSection.insertBefore(searchToggle, searchPanel.nextSibling);
-  }
-
   if (!searchSection.dataset.toggleBound) {
     searchSection.dataset.toggleBound = 'true';
 
-    const getInput = () => searchPanel.querySelector('input[type="search"]');
+    const getInput = () => searchSection.querySelector('input[type="search"]');
     const setOpen = (open) => {
       const isOpen = Boolean(open);
       searchSection.classList.toggle('is-open', isOpen);

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -749,29 +749,18 @@ body {
 }
 
 .arcus-utility__search {
-  position: sticky;
-  top: 0;
-  z-index: 30;
-  flex: 0 0 auto;
-  width: 100%;
-  display: grid;
-  gap: 0;
-  margin: 0;
-  pointer-events: auto;
-}
-
-.arcus-search__panel {
   position: relative;
   overflow: hidden;
   max-height: 0;
   padding: 0;
   margin: 0;
   box-sizing: border-box;
-  transition: max-height 0.32s ease, padding 0.32s ease;
+  pointer-events: none;
+  transition: max-height 0.32s ease, padding 0.32s ease, margin 0.32s ease;
+  flex: 0 0 auto;
+  width: 100%;
   display: flex;
   justify-content: center;
-  width: 100%;
-  pointer-events: none;
 }
 
 .arcus-utility__search .arcus-search {
@@ -783,14 +772,15 @@ body {
   opacity: 0;
   transform: translateY(-0.75rem);
   transition: opacity 0.24s ease, transform 0.28s ease;
-  pointer-events: none;
+  pointer-events: auto;
 }
 
-.arcus-utility__search.is-open .arcus-search__panel,
-.arcus-utility__search:focus-within .arcus-search__panel {
-  max-height: 9rem;
-  padding: 0.75rem 4rem 0;
+.arcus-utility__search.is-open,
+.arcus-utility__search:focus-within {
   pointer-events: auto;
+  max-height: 9rem;
+  padding: 0.75rem 4rem;
+  margin-bottom: 0;
 }
 
 .arcus-utility__search.is-open .arcus-search,
@@ -798,19 +788,22 @@ body {
 .arcus-utility__search:hover .arcus-search {
   opacity: 1;
   transform: translateY(0);
-  pointer-events: auto;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .arcus-search__panel,
+  .arcus-utility__search {
+    transition: none;
+  }
+
   .arcus-utility__search .arcus-search {
     transition: none;
   }
 }
 
 .arcus-search-toggle {
-  justify-self: end;
-  margin: 0 1.5rem 1.5rem;
+  position: fixed;
+  top: 1.25rem;
+  right: 1.5rem;
   z-index: 20;
   background: var(--arcus-accent);
   color: #fff;

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -756,12 +756,18 @@ body {
   margin: 0;
   pointer-events: none;
   transition: max-height 0.32s ease, padding 0.32s ease, margin 0.32s ease;
+  flex: 0 0 auto;
+  width: 100%;
+  display: flex;
+  justify-content: center;
 }
 
 .arcus-utility__search .arcus-search {
   width: 100%;
+  max-width: min(960px, 100%);
   box-sizing: border-box;
   padding: 0.75rem 4rem;
+  margin: 0 auto;
   opacity: 0;
   transform: translateY(-0.75rem);
   transition: opacity 0.24s ease, transform 0.28s ease;

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -754,6 +754,7 @@ body {
   max-height: 0;
   padding: 0;
   margin: 0;
+  box-sizing: border-box;
   pointer-events: none;
   transition: max-height 0.32s ease, padding 0.32s ease, margin 0.32s ease;
   flex: 0 0 auto;

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -749,18 +749,29 @@ body {
 }
 
 .arcus-utility__search {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  flex: 0 0 auto;
+  width: 100%;
+  display: grid;
+  gap: 0;
+  margin: 0;
+  pointer-events: auto;
+}
+
+.arcus-search__panel {
   position: relative;
   overflow: hidden;
   max-height: 0;
   padding: 0;
   margin: 0;
   box-sizing: border-box;
-  pointer-events: none;
-  transition: max-height 0.32s ease, padding 0.32s ease, margin 0.32s ease;
-  flex: 0 0 auto;
-  width: 100%;
+  transition: max-height 0.32s ease, padding 0.32s ease;
   display: flex;
   justify-content: center;
+  width: 100%;
+  pointer-events: none;
 }
 
 .arcus-utility__search .arcus-search {
@@ -772,15 +783,14 @@ body {
   opacity: 0;
   transform: translateY(-0.75rem);
   transition: opacity 0.24s ease, transform 0.28s ease;
-  pointer-events: auto;
+  pointer-events: none;
 }
 
-.arcus-utility__search.is-open,
-.arcus-utility__search:focus-within {
-  pointer-events: auto;
+.arcus-utility__search.is-open .arcus-search__panel,
+.arcus-utility__search:focus-within .arcus-search__panel {
   max-height: 9rem;
-  padding: 0.75rem 4rem;
-  margin-bottom: 0;
+  padding: 0.75rem 4rem 0;
+  pointer-events: auto;
 }
 
 .arcus-utility__search.is-open .arcus-search,
@@ -788,22 +798,19 @@ body {
 .arcus-utility__search:hover .arcus-search {
   opacity: 1;
   transform: translateY(0);
+  pointer-events: auto;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .arcus-utility__search {
-    transition: none;
-  }
-
+  .arcus-search__panel,
   .arcus-utility__search .arcus-search {
     transition: none;
   }
 }
 
 .arcus-search-toggle {
-  position: fixed;
-  top: 1.25rem;
-  right: 1.5rem;
+  justify-self: end;
+  margin: 0 1.5rem 1.5rem;
   z-index: 20;
   background: var(--arcus-accent);
   color: #fff;

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -780,7 +780,7 @@ body {
   pointer-events: auto;
   max-height: 9rem;
   padding: 0.75rem 4rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 0;
 }
 
 .arcus-utility__search.is-open .arcus-search,

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -756,6 +756,7 @@ body {
   margin: 0;
   overflow: visible;
   z-index: 3;
+  pointer-events: none;
 }
 
 .arcus-utility__search .arcus-search {
@@ -764,8 +765,15 @@ body {
   padding: 0.75rem 4rem;
   transform: translateY(calc(-100% - 1.5rem));
   transition: transform 0.28s ease;
+  pointer-events: auto;
 }
 
+.arcus-utility__search.is-open,
+.arcus-utility__search:focus-within {
+  pointer-events: auto;
+}
+
+.arcus-utility__search.is-open .arcus-search,
 .arcus-utility__search:focus-within .arcus-search,
 .arcus-utility__search:hover .arcus-search {
   transform: translateY(0);
@@ -775,6 +783,53 @@ body {
   .arcus-utility__search .arcus-search {
     transition: none;
   }
+}
+
+.arcus-search-toggle {
+  position: fixed;
+  top: 1.25rem;
+  right: 1.5rem;
+  z-index: 20;
+  background: var(--arcus-accent);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.4rem 1.2rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: 0 8px 18px rgba(15, 22, 52, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.arcus-search-toggle:hover,
+.arcus-search-toggle:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(15, 22, 52, 0.24);
+}
+
+.arcus-search-toggle:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.65);
+  outline-offset: 2px;
+}
+
+.arcus-search-toggle.is-active {
+  background: var(--arcus-accent-strong);
+}
+
+.arcus-search-toggle__icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.arcus-search-toggle__label {
+  line-height: 1;
 }
 
 .arcus-utility__links {

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -778,7 +778,7 @@ body {
 .arcus-utility__search:focus-within {
   pointer-events: auto;
   max-height: 9rem;
-  padding: 0.75rem 0;
+  padding: 0.75rem 4rem;
   margin-bottom: 1.5rem;
 }
 

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -747,6 +747,10 @@ body {
   z-index: 1;
 }
 
+.arcus-utility__search {
+  padding: 0.75rem 4rem;
+}
+
 .arcus-utility__links {
   grid-column: 1 / -1;
 }

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -119,6 +119,7 @@ body {
   overflow-x: hidden;
   display: flex;
   flex-direction: column;
+  position: relative;
   scrollbar-gutter: stable both-edges;
 }
 
@@ -748,7 +749,32 @@ body {
 }
 
 .arcus-utility__search {
+  position: sticky;
+  top: 0;
+  height: 0;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  z-index: 3;
+}
+
+.arcus-utility__search .arcus-search {
+  width: 100%;
+  box-sizing: border-box;
   padding: 0.75rem 4rem;
+  transform: translateY(calc(-100% - 1.5rem));
+  transition: transform 0.28s ease;
+}
+
+.arcus-utility__search:focus-within .arcus-search,
+.arcus-utility__search:hover .arcus-search {
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .arcus-utility__search .arcus-search {
+    transition: none;
+  }
 }
 
 .arcus-utility__links {

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -749,37 +749,45 @@ body {
 }
 
 .arcus-utility__search {
-  position: sticky;
-  top: 0;
-  height: 0;
+  position: relative;
+  overflow: hidden;
+  max-height: 0;
   padding: 0;
   margin: 0;
-  overflow: visible;
-  z-index: 3;
   pointer-events: none;
+  transition: max-height 0.32s ease, padding 0.32s ease, margin 0.32s ease;
 }
 
 .arcus-utility__search .arcus-search {
   width: 100%;
   box-sizing: border-box;
   padding: 0.75rem 4rem;
-  transform: translateY(calc(-100% - 1.5rem));
-  transition: transform 0.28s ease;
+  opacity: 0;
+  transform: translateY(-0.75rem);
+  transition: opacity 0.24s ease, transform 0.28s ease;
   pointer-events: auto;
 }
 
 .arcus-utility__search.is-open,
 .arcus-utility__search:focus-within {
   pointer-events: auto;
+  max-height: 9rem;
+  padding: 0.75rem 0;
+  margin-bottom: 1.5rem;
 }
 
 .arcus-utility__search.is-open .arcus-search,
 .arcus-utility__search:focus-within .arcus-search,
 .arcus-utility__search:hover .arcus-search {
+  opacity: 1;
   transform: translateY(0);
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .arcus-utility__search {
+    transition: none;
+  }
+
   .arcus-utility__search .arcus-search {
     transition: none;
   }


### PR DESCRIPTION
## Summary
- move the Arcus theme search utility outside the tools group so it can sit at the top of the sidebar
- ensure the search markup is created when missing and normalize its structure when relocating

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dbb0e19c208328b155122c06ee6c37