### PR TITLE
Adjust Arcus search toggle placement

### DIFF
--- a/assets/themes/arcus/modules/layout.js
+++ b/assets/themes/arcus/modules/layout.js
@@ -223,7 +223,7 @@ export function mount(context = {}) {
     }
   }
 
-  const searchToggle = ensureElement(container, '.arcus-search-toggle', () => {
+  const searchToggle = ensureElement(rightColumn, '.arcus-search-toggle', () => {
     const button = doc.createElement('button');
     button.type = 'button';
     button.className = 'arcus-search-toggle';
@@ -234,6 +234,10 @@ export function mount(context = {}) {
       <span class="arcus-search-toggle__label">Search</span>`;
     return button;
   });
+
+  if (searchToggle.parentElement !== rightColumn || searchToggle.nextElementSibling !== searchSection) {
+    rightColumn.insertBefore(searchToggle, searchSection);
+  }
 
   if (!searchSection.dataset.toggleBound) {
     searchSection.dataset.toggleBound = 'true';

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -801,10 +801,9 @@ body {
 }
 
 .arcus-search-toggle {
-  position: fixed;
-  top: 1.25rem;
-  right: 1.5rem;
-  z-index: 20;
+  position: relative;
+  align-self: flex-start;
+  margin-bottom: 0.75rem;
   background: var(--arcus-accent);
   color: #fff;
   border: none;


### PR DESCRIPTION
## Summary
- move the Arcus search toggle button into the right column so it scrolls with the page
- update theme styling to remove the fixed positioning and add spacing within the layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbc13180b083289a01144bd850b980