### PR TITLE
Adjust Arcus search toggle positioning

### DIFF
--- a/assets/themes/arcus/modules/layout.js
+++ b/assets/themes/arcus/modules/layout.js
@@ -223,7 +223,7 @@ export function mount(context = {}) {
     }
   }
 
-  const searchToggle = ensureElement(container, '.arcus-search-toggle', () => {
+  const searchToggle = ensureElement(rightColumn, '.arcus-search-toggle', () => {
     const button = doc.createElement('button');
     button.type = 'button';
     button.className = 'arcus-search-toggle';
@@ -234,6 +234,12 @@ export function mount(context = {}) {
       <span class="arcus-search-toggle__label">Search</span>`;
     return button;
   });
+
+  if (searchToggle.parentElement !== rightColumn) {
+    rightColumn.insertBefore(searchToggle, searchSection);
+  } else if (searchToggle.nextElementSibling !== searchSection) {
+    rightColumn.insertBefore(searchToggle, searchSection);
+  }
 
   if (!searchSection.dataset.toggleBound) {
     searchSection.dataset.toggleBound = 'true';

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -801,10 +801,9 @@ body {
 }
 
 .arcus-search-toggle {
-  position: fixed;
-  top: 1.25rem;
-  right: 1.5rem;
-  z-index: 20;
+  position: relative;
+  align-self: flex-end;
+  margin: 1.5rem 1.5rem 0 auto;
   background: var(--arcus-accent);
   color: #fff;
   border: none;


### PR DESCRIPTION
## Summary
- move the Arcus theme search toggle into the scrollable right column so it scrolls with the page
- update the search toggle styling to remove fixed positioning and align it with the layout margins

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbc13180b083289a01144bd850b980