### PR TITLE
Add dock-style floating ToC for Arcus theme

### DIFF
--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -2227,50 +2227,147 @@ body {
 }
 
 .arcus-toc {
-  position: sticky;
-  top: 3rem;
-  align-self: flex-start;
-  max-width: 280px;
-  margin: 0 auto;
-  background: var(--arcus-surface);
-  border-radius: var(--arcus-radius-md);
-  padding: 1.4rem;
-  border: 1px solid var(--arcus-outline);
-  box-shadow: var(--arcus-shadow-subtle);
+  position: fixed;
+  inset-inline-end: clamp(0.75rem, 3vw, 3.5rem);
+  inset-block-start: 50%;
+  transform: translateY(-50%) scale(0.94);
+  z-index: 15;
+  pointer-events: none;
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  display: block;
 }
 
-.arcus-toc__inner {
+.arcus-toc.is-visible {
+  opacity: 1;
+  transform: translateY(-50%) scale(1);
+}
+
+.arcus-toc__dock {
+  pointer-events: auto;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  align-items: center;
+  gap: 1.1rem;
 }
 
-.arcus-toc__title {
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  color: var(--arcus-text-soft);
-}
-
-.arcus-toc ol,
-.arcus-toc ul {
+.arcus-toc__dock-list {
   list-style: none;
   margin: 0;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  font-size: 0.9rem;
+  gap: 0.85rem;
 }
 
-.arcus-toc a {
+.arcus-toc__dock-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.arcus-toc__dock-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-direction: row-reverse;
+  gap: 0.75rem;
+  min-height: 1.5rem;
   text-decoration: none;
-  color: var(--arcus-text-muted);
+  color: inherit;
 }
 
-.arcus-toc a:hover,
-.arcus-toc a:focus-visible {
-  color: var(--arcus-accent);
+.arcus-toc__dock-dot:focus-visible {
+  outline: 2px solid var(--arcus-accent);
+  outline-offset: 4px;
+}
+
+.arcus-toc__dock-circle {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 999px;
+  border: 2px solid var(--arcus-outline-strong);
+  background: transparent;
+  box-shadow: 0 0 0 3px var(--arcus-main-bg);
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  transform-origin: center;
+}
+
+.arcus-toc__dock-title {
+  opacity: 0;
+  transform: translateX(0.5rem) scale(0.94);
+  transition: opacity 0.2s ease, transform 0.2s ease, font-size 0.2s ease;
+  pointer-events: none;
+  background: var(--arcus-main-bg);
+  border-radius: 999px;
+  border: 1px solid var(--arcus-outline);
+  box-shadow: var(--arcus-shadow-subtle);
+  padding: 0.35rem 0.75rem;
+  white-space: nowrap;
+  color: var(--arcus-text);
+  font-size: 0.75rem;
+  line-height: 1;
+  text-align: right;
+  max-width: 18rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.arcus-toc__dock-item.is-current .arcus-toc__dock-circle {
+  background: var(--arcus-accent);
+  border-color: var(--arcus-accent);
+  box-shadow: 0 0 0 4px var(--arcus-main-bg);
+  transform: scale(1.25);
+}
+
+.arcus-toc__dock-item.is-hovered .arcus-toc__dock-circle {
+  transform: scale(1.6);
+  background: var(--arcus-accent);
+  border-color: var(--arcus-accent);
+  box-shadow: 0 0 0 6px var(--arcus-accent-soft);
+}
+
+.arcus-toc__dock-item.is-adjacent .arcus-toc__dock-circle {
+  transform: scale(1.35);
+  background: var(--arcus-accent-soft);
+  border-color: var(--arcus-accent);
+  box-shadow: 0 0 0 5px var(--arcus-main-bg);
+}
+
+.arcus-toc__dock-item.is-hovered .arcus-toc__dock-title {
+  opacity: 1;
+  transform: translateX(0) scale(1);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.arcus-toc__dock-item.is-adjacent .arcus-toc__dock-title {
+  opacity: 0.8;
+  transform: translateX(0) scale(0.96);
+  font-size: 0.78rem;
+}
+
+.arcus-toc__dock-dot:focus-visible .arcus-toc__dock-title {
+  opacity: 1;
+  transform: translateX(0) scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .arcus-toc {
+    transition-duration: 0.01ms;
+  }
+
+  .arcus-toc__dock-circle,
+  .arcus-toc__dock-title {
+    transition-duration: 0.01ms;
+  }
+}
+
+@media (max-width: 1024px) {
+  .arcus-toc {
+    display: none !important;
+  }
 }
 
 .arcus-index--search .arcus-card__excerpt-tilt {


### PR DESCRIPTION
## Summary
- replace the Arcus article table of contents rendering with a dock-style dot navigator that tracks the active heading and cleans up listeners when hidden
- restyle the table of contents so it floats mid-screen on the right with hover and focus labels plus responsive fallbacks

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dbd40fb5608328a7bb23394c685861