### PR TITLE
feat(arcus): add floating dock table of contents

### DIFF
--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -2261,7 +2261,8 @@ body {
 
 .arcus-toc-dock {
   position: fixed;
-  inset-block-start: 50%;
+  top: var(--arcus-toc-dock-top, 50%);
+  inset-block-start: var(--arcus-toc-dock-top, 50%);
   inset-inline-end: clamp(0.75rem, 3vw, 3.25rem);
   transform: translateY(-50%);
   display: flex;

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -2227,50 +2227,157 @@ body {
 }
 
 .arcus-toc {
-  position: sticky;
-  top: 3rem;
-  align-self: flex-start;
-  max-width: 280px;
-  margin: 0 auto;
-  background: var(--arcus-surface);
-  border-radius: var(--arcus-radius-md);
-  padding: 1.4rem;
-  border: 1px solid var(--arcus-outline);
-  box-shadow: var(--arcus-shadow-subtle);
+  position: relative;
+  width: 0;
+  height: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  z-index: 40;
+}
+
+.arcus-toc[hidden] {
+  display: none !important;
 }
 
 .arcus-toc__inner {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.arcus-toc__inner--sr {
+  position: absolute;
+}
+
+.arcus-toc-dock {
+  position: fixed;
+  inset-block-start: 50%;
+  inset-inline-end: clamp(0.75rem, 3vw, 3.25rem);
+  transform: translateY(-50%);
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  align-items: flex-end;
+  gap: 0.85rem;
+  padding: 0.75rem 0.35rem;
+  border-radius: 999px;
+  background: var(--arcus-main-bg);
+  background: color-mix(in srgb, var(--arcus-main-bg) 85%, transparent);
+  border: 1px solid var(--arcus-outline);
+  border: 1px solid color-mix(in srgb, var(--arcus-outline) 70%, transparent);
+  box-shadow: var(--arcus-shadow-subtle);
+  pointer-events: auto;
+  min-width: 0;
+  z-index: 60;
+  backdrop-filter: blur(18px);
 }
 
-.arcus-toc__title {
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  color: var(--arcus-text-soft);
-}
-
-.arcus-toc ol,
-.arcus-toc ul {
+.arcus-toc-dock__list {
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 0 0.85rem;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  font-size: 0.9rem;
+  align-items: center;
+  gap: 0.95rem;
 }
 
-.arcus-toc a {
-  text-decoration: none;
-  color: var(--arcus-text-muted);
+.arcus-toc-dock__item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
 }
 
-.arcus-toc a:hover,
-.arcus-toc a:focus-visible {
-  color: var(--arcus-accent);
+.arcus-toc-dock__dot {
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  border: 2px solid var(--arcus-accent);
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.18s ease, background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease, opacity 0.18s ease;
+  outline: none;
+}
+
+.arcus-toc-dock__dot:hover,
+.arcus-toc-dock__dot:focus-visible {
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--arcus-accent) 28%, transparent);
+}
+
+.arcus-toc-dock__item.is-current .arcus-toc-dock__dot {
+  background: var(--arcus-accent);
+  border-color: var(--arcus-accent);
+  box-shadow: 0 12px 28px rgba(15, 22, 52, 0.22);
+  transform: scale(1.1);
+}
+
+.arcus-toc-dock__item.is-hover .arcus-toc-dock__dot {
+  transform: scale(1.65);
+  background: var(--arcus-accent-strong);
+  border-color: var(--arcus-accent-strong);
+  box-shadow: 0 16px 42px rgba(15, 22, 52, 0.32);
+}
+
+.arcus-toc-dock__item.is-near .arcus-toc-dock__dot {
+  transform: scale(1.25);
+  background: color-mix(in srgb, var(--arcus-accent) 45%, transparent);
+  border-color: var(--arcus-accent);
+  border-color: color-mix(in srgb, var(--arcus-accent) 80%, var(--arcus-outline));
+}
+
+.arcus-toc-dock__label {
+  position: absolute;
+  inset-inline-end: 100%;
+  inset-block-start: 50%;
+  transform: translateY(-50%) scale(0.85);
+  transform-origin: right center;
+  margin-inline-end: 0.75rem;
+  padding: 0.35rem 0.75rem;
+  background: var(--arcus-main-bg);
+  background: color-mix(in srgb, var(--arcus-main-bg) 94%, transparent);
+  border-radius: 999px;
+  box-shadow: var(--arcus-shadow-subtle);
+  color: var(--arcus-text);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+  white-space: nowrap;
+  max-width: 16rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.arcus-toc-dock__item.is-hover .arcus-toc-dock__label {
+  opacity: 1;
+  transform: translateY(-50%) scale(1);
+  font-size: 0.82rem;
+}
+
+.arcus-toc-dock__item.is-near .arcus-toc-dock__label {
+  opacity: 0.85;
+  transform: translateY(-50%) scale(0.92);
+  font-size: 0.74rem;
+}
+
+@media (max-width: 1100px) {
+  .arcus-toc {
+    display: none;
+  }
 }
 
 .arcus-index--search .arcus-card__excerpt-tilt {


### PR DESCRIPTION
## Summary
- replace the Arcus article ToC with a floating vertical dock of interactive dots that shows neighboring headings on hover
- wire the post renderer to hydrate the dock for posts and static tabs while cleaning up listeners when the ToC is hidden
- style the dock with translucent backdrop, scale transitions, and responsive behavior so it hides on narrow screens

## Testing
- manual preview in browser (see attached screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68dbd7397efc832898cbcf8db1e94118