### PR TITLE
Adjust Arcus tag layout

### DIFF
--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -651,6 +651,7 @@ body {
   background: var(--arcus-main-bg);
   border-top: 1px solid var(--arcus-outline);
   display: flex;
+  flex-direction: column;
   justify-content: center;
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- stack the Arcus tag view header above the tag list by switching the container to a column flex layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc099b197c8328936a064c1c49b5ca