### PR TITLE
Remove background from Arcus card excerpt tilt

### DIFF
--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -1393,7 +1393,7 @@ body {
   display: inline-block;
   transform: none;
   font-style: normal;
-  background: linear-gradient(120deg, rgba(123, 139, 255, 0.12), transparent 80%);
+  background: none;
   padding: 0 0.2rem;
 }
 


### PR DESCRIPTION
## Summary
- remove the gradient background styling from `.arcus-card__excerpt-tilt`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc1304f5f883288685077c208ad1e7