### PR TITLE
Add hover glow animation to Arcus cards

### DIFF
--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -1302,33 +1302,35 @@ body {
   position: absolute;
   top: 50%;
   left: 0;
-  width: 10rem;
+  width: 100%;
   aspect-ratio: 1;
   border-radius: 999px;
-  background: radial-gradient(130% 80% at 20% 50%,
-      color-mix(in srgb, var(--arcus-accent) 76%, transparent) 0%,
-      color-mix(in srgb, var(--arcus-accent) 44%, transparent) 42%,
-      color-mix(in srgb, var(--arcus-accent) 16%, transparent) 78%,
+  background: radial-gradient(140% 80% at 8% 50%,
+      color-mix(in srgb, var(--arcus-accent) 54%, transparent) 0%,
+      color-mix(in srgb, var(--arcus-accent) 34%, transparent) 30%,
+      color-mix(in srgb, var(--arcus-accent) 18%, transparent) 62%,
+      color-mix(in srgb, var(--arcus-accent) 10%, transparent) 82%,
       transparent 100%);
   opacity: 0;
-  transform: translate(-80%, -50%) scaleX(0.1) scaleY(0.35);
+  transform: translate(-88%, -50%) scaleX(0.02) scaleY(0.4);
   transform-origin: left center;
   pointer-events: none;
 }
 
 @keyframes arcus-card-glow {
   0% {
-    transform: translate(-80%, -50%) scaleX(0.2) scaleY(0.4);
-    opacity: 0.9;
+    transform: translate(-88%, -50%) scaleX(0.04) scaleY(0.42);
+    opacity: 0.85;
   }
 
   55% {
-    opacity: 0.65;
+    transform: translate(-87%, -50%) scaleX(0.12) scaleY(0.5);
+    opacity: 0.55;
   }
 
   100% {
-    transform: translate(-80%, -50%) scaleX(6.5) scaleY(1.2);
-    opacity: 0.45;
+    transform: translate(-86%, -50%) scaleX(0.18) scaleY(0.58);
+    opacity: 0.35;
   }
 }
 

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -1300,30 +1300,35 @@ body {
 .arcus-card::before {
   content: '';
   position: absolute;
-  inset: 50%;
-  width: 1.5rem;
+  top: 50%;
+  left: 0;
+  width: 10rem;
   aspect-ratio: 1;
   border-radius: 999px;
-  background: radial-gradient(circle, color-mix(in srgb, var(--arcus-accent) 70%, transparent) 0%,
-      color-mix(in srgb, var(--arcus-accent) 35%, transparent) 45%, transparent 70%);
+  background: radial-gradient(130% 80% at 20% 50%,
+      color-mix(in srgb, var(--arcus-accent) 76%, transparent) 0%,
+      color-mix(in srgb, var(--arcus-accent) 44%, transparent) 42%,
+      color-mix(in srgb, var(--arcus-accent) 16%, transparent) 78%,
+      transparent 100%);
   opacity: 0;
-  transform: translate(-50%, -50%) scale(0);
+  transform: translate(-80%, -50%) scaleX(0.1) scaleY(0.35);
+  transform-origin: left center;
   pointer-events: none;
 }
 
 @keyframes arcus-card-glow {
   0% {
-    transform: translate(-50%, -50%) scale(0.2);
-    opacity: 0.8;
+    transform: translate(-80%, -50%) scaleX(0.2) scaleY(0.4);
+    opacity: 0.9;
   }
 
-  60% {
-    opacity: 0.5;
+  55% {
+    opacity: 0.65;
   }
 
   100% {
-    transform: translate(-50%, -50%) scale(12);
-    opacity: 0;
+    transform: translate(-80%, -50%) scaleX(6.5) scaleY(1.2);
+    opacity: 0.45;
   }
 }
 

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -1290,11 +1290,41 @@ body {
   border-radius: 0;
   background: transparent;
   box-shadow: none;
-  overflow: visible;
+  overflow: hidden;
   border: none;
   padding: 1.8rem 0;
   transition: color 0.2s ease;
   border-bottom: 1px solid var(--arcus-outline);
+}
+
+.arcus-card::before {
+  content: '';
+  position: absolute;
+  inset: 50%;
+  width: 1.5rem;
+  aspect-ratio: 1;
+  border-radius: 999px;
+  background: radial-gradient(circle, color-mix(in srgb, var(--arcus-accent) 70%, transparent) 0%,
+      color-mix(in srgb, var(--arcus-accent) 35%, transparent) 45%, transparent 70%);
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(0);
+  pointer-events: none;
+}
+
+@keyframes arcus-card-glow {
+  0% {
+    transform: translate(-50%, -50%) scale(0.2);
+    opacity: 0.8;
+  }
+
+  60% {
+    opacity: 0.5;
+  }
+
+  100% {
+    transform: translate(-50%, -50%) scale(12);
+    opacity: 0;
+  }
 }
 
 .arcus-card:first-child {
@@ -1313,6 +1343,11 @@ body {
 .arcus-card:focus-within {
   transform: none;
   box-shadow: none;
+}
+
+.arcus-card:hover::before,
+.arcus-card:focus-within::before {
+  animation: arcus-card-glow 0.9s ease-out forwards;
 }
 
 .arcus-card__link {


### PR DESCRIPTION
## Summary
- add a radial glow animation that expands across Arcus cards on hover or focus
- ensure the glow is rendered via a pseudo-element while keeping card content clipped

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc13d648f48328878eef4f89ebd15e