### PR TITLE
Add hover glow effect to Arcus cards

### DIFF
--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -1286,6 +1286,7 @@ body {
 
 .arcus-card {
   position: relative;
+  z-index: 0;
   display: block;
   border-radius: 0;
   background: transparent;
@@ -1309,6 +1310,30 @@ body {
   content: none;
 }
 
+.arcus-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: var(--arcus-radius-lg, 1.25rem);
+  background: radial-gradient(
+    circle at center,
+    color-mix(in srgb, var(--arcus-accent) 92%, white 25%) 0%,
+    color-mix(in srgb, var(--arcus-accent) 68%, transparent) 38%,
+    transparent 72%
+  );
+  opacity: 0;
+  transform: scale(0.35);
+  filter: blur(0.25rem);
+  pointer-events: none;
+  z-index: -1;
+  animation: none;
+}
+
+.arcus-card:hover::before,
+.arcus-card:focus-within::before {
+  animation: arcus-card-glow 0.75s ease-out forwards;
+}
+
 .arcus-card:hover,
 .arcus-card:focus-within {
   transform: none;
@@ -1329,6 +1354,22 @@ body {
 .arcus-card__link:focus-visible {
   outline: 2px solid var(--arcus-accent);
   outline-offset: 4px;
+}
+
+@keyframes arcus-card-glow {
+  0% {
+    opacity: 0.7;
+    transform: scale(0.3);
+  }
+
+  55% {
+    opacity: 0.45;
+  }
+
+  100% {
+    opacity: 0;
+    transform: scale(1.2);
+  }
 }
 
 .arcus-card__link:hover .arcus-card__title,


### PR DESCRIPTION
## Summary
- add a pseudo-element driven radial glow that animates when hovering or focusing Arcus cards
- keep existing card layout while defining keyframes for the new glow pulse

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc13d648f48328878eef4f89ebd15e