### PR TITLE
Adjust Arcus pagination spacing

### DIFF
--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -1442,6 +1442,11 @@ body {
   margin-top: 1rem;
 }
 
+.arcus-page__list {
+  display: flex;
+  gap: 0.5rem;
+}
+
 .arcus-page {
   padding: 0.45rem 0.9rem;
   border-radius: 999px;


### PR DESCRIPTION
## Summary
- add horizontal spacing between Arcus pagination buttons by applying a flexbox gap to the page list

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc1b0f3be0832891c5d1987bfd7410