### PR TITLE
Fix Arcus code block layout

### DIFF
--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -2322,6 +2322,11 @@ body {
   overflow: hidden;
 }
 
+.arcus-article__body pre.code-block.with-code-scroll,
+.arcus-static__body pre.code-block.with-code-scroll {
+  padding: 0;
+}
+
 .arcus-article__body pre.with-code-scroll .code-scroll,
 .arcus-static__body pre.with-code-scroll .code-scroll {
   display: flex;


### PR DESCRIPTION
## Summary
- adjust Arcus theme code block styles to support the injected scroll wrapper
- style the line-number gutter and language label so they render correctly in the Arcus theme

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dc1c122064832882ed94c52130a048