### PR TITLE
Lazy-load translation bundles on demand

### DIFF
--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -32,83 +32,152 @@ const translations = {};
 const languageNames = {};
 let languageManifest = [];
 let manifestLoadPromise = null;
+const languageModuleUrls = new Map();
+const bundleLoadPromises = new Map();
+let manifestBaseUrl = null;
 
 const FALLBACK_LANGUAGE_LABEL = (enLanguageMeta && enLanguageMeta.label) ? enLanguageMeta.label : 'English';
 translations[DEFAULT_LANG] = enTranslations;
 languageNames[DEFAULT_LANG] = FALLBACK_LANGUAGE_LABEL;
 languageManifest = [{ value: DEFAULT_LANG, label: FALLBACK_LANGUAGE_LABEL }];
 
-async function ensureLanguageBundlesLoaded() {
-  if (manifestLoadPromise) return manifestLoadPromise;
-  manifestLoadPromise = (async () => {
-    const manifestUrl = new URL('../i18n/languages.json', import.meta.url);
-    let manifest = [];
+function emitBundleLoaded(lang) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.dispatchEvent(new CustomEvent('ns:i18n-bundle-loaded', { detail: { lang } }));
+  } catch (_) { /* ignore */ }
+}
+
+function upsertManifestEntry(value, label, { preferFront = false } = {}) {
+  if (!value) return;
+  const normalized = String(value).toLowerCase();
+  const display = label || languageNames[normalized] || normalized;
+  const idx = languageManifest.findIndex((item) => item && item.value === normalized);
+  if (idx >= 0) {
+    const existing = languageManifest[idx];
+    if (!existing || existing.label !== display) {
+      languageManifest[idx] = { value: normalized, label: display };
+    }
+  } else if (preferFront) {
+    languageManifest.unshift({ value: normalized, label: display });
+  } else {
+    languageManifest.push({ value: normalized, label: display });
+  }
+}
+
+async function loadLanguageBundle(langCode) {
+  const code = String(langCode || '').toLowerCase();
+  if (!code) return null;
+  if (translations[code]) return translations[code];
+  if (bundleLoadPromises.has(code)) return bundleLoadPromises.get(code);
+  if (manifestLoadPromise) await manifestLoadPromise;
+  const moduleHref = languageModuleUrls.get(code);
+  if (!moduleHref) {
+    if (code === DEFAULT_LANG) return translations[DEFAULT_LANG] || null;
+    // Attempt implicit fallback to ./<code>.js relative to manifest when not registered
+    if (manifestBaseUrl) {
+      try {
+        const implicitUrl = new URL(`./${code}.js`, manifestBaseUrl);
+        languageModuleUrls.set(code, implicitUrl.href);
+        return loadLanguageBundle(code);
+      } catch (_) {
+        // ignore
+      }
+    }
+    return null;
+  }
+  const loader = (async () => {
     try {
-      const resp = await fetch(manifestUrl, { cache: 'no-store' });
-      if (resp && resp.ok) {
-        const data = await resp.json();
-        if (Array.isArray(data)) manifest = data;
+      const mod = await import(moduleHref);
+      const bundle = (mod && typeof mod.default === 'object') ? mod.default : (mod && typeof mod.translations === 'object' ? mod.translations : null);
+      if (!bundle) {
+        console.warn(`[i18n] Language module ${moduleHref} did not export a translations object`);
+        return null;
       }
+      translations[code] = bundle;
+      const metaLabel = languageNames[code] || mod.languageLabel || (mod.languageMeta && mod.languageMeta.label);
+      if (metaLabel) languageNames[code] = metaLabel;
+      upsertManifestEntry(code, languageNames[code]);
+      emitBundleLoaded(code);
+      return bundle;
     } catch (err) {
-      console.warn('[i18n] Failed to load language manifest', err);
+      console.warn(`[i18n] Failed to load language bundle for ${code}`, err);
+      return null;
     }
-    if (!manifest.length) {
-      manifest = [{ value: DEFAULT_LANG, label: 'English', module: './en.js' }];
-    }
-    const seen = new Set();
-    const sanitized = [];
-    for (const entry of manifest) {
-      if (!entry) continue;
-      const value = String(entry.value || '').toLowerCase().trim();
-      if (!value || seen.has(value)) continue;
-      let moduleUrl;
-      const modulePath = entry.module || `./${value}.js`;
+  })().finally(() => {
+    bundleLoadPromises.delete(code);
+  });
+  bundleLoadPromises.set(code, loader);
+  return loader;
+}
+
+async function ensureLanguageBundlesLoaded(langToEnsure) {
+  if (!manifestLoadPromise) {
+    manifestLoadPromise = (async () => {
+      const manifestUrl = new URL('../i18n/languages.json', import.meta.url);
+      manifestBaseUrl = manifestUrl;
+      let manifest = [];
       try {
-        moduleUrl = new URL(modulePath, manifestUrl);
+        const resp = await fetch(manifestUrl, { cache: 'no-store' });
+        if (resp && resp.ok) {
+          const data = await resp.json();
+          if (Array.isArray(data)) manifest = data;
+        }
       } catch (err) {
-        console.warn(`[i18n] Invalid module path for ${value}`, err);
-        continue;
+        console.warn('[i18n] Failed to load language manifest', err);
       }
-      try {
-        const mod = await import(moduleUrl.href);
-        const bundle = (mod && typeof mod.default === 'object') ? mod.default : (mod && typeof mod.translations === 'object' ? mod.translations : null);
-        if (!bundle) {
-          console.warn(`[i18n] Language module ${moduleUrl.href} did not export a translations object`);
+      if (!manifest.length) {
+        manifest = [{ value: DEFAULT_LANG, label: 'English', module: './en.js' }];
+      }
+      const seen = new Set();
+      languageManifest = [];
+      for (const entry of manifest) {
+        if (!entry) continue;
+        const value = String(entry.value || '').toLowerCase().trim();
+        if (!value || seen.has(value)) continue;
+        const modulePath = entry.module || `./${value}.js`;
+        let moduleUrl = null;
+        try {
+          moduleUrl = new URL(modulePath, manifestUrl);
+        } catch (err) {
+          console.warn(`[i18n] Invalid module path for ${value}`, err);
           continue;
         }
-        translations[value] = bundle;
-        const metaLabel = entry.label || mod.languageLabel || (mod.languageMeta && mod.languageMeta.label);
-        if (metaLabel) languageNames[value] = metaLabel;
-        sanitized.push({ value, label: languageNames[value] || metaLabel || value });
+        languageModuleUrls.set(value, moduleUrl.href);
+        if (entry.label) languageNames[value] = entry.label;
+        upsertManifestEntry(value, entry.label || value);
         seen.add(value);
-      } catch (err) {
-        console.warn(`[i18n] Failed to load language bundle for ${value}`, err);
       }
-    }
-    if (!translations[DEFAULT_LANG]) {
-      try {
-        const fallbackUrl = new URL('./en.js', manifestUrl);
-        const mod = await import(fallbackUrl.href);
-        const bundle = (mod && typeof mod.default === 'object') ? mod.default : (mod && typeof mod.translations === 'object' ? mod.translations : null);
-        if (bundle) {
-          translations[DEFAULT_LANG] = bundle;
-          const label = mod.languageLabel || (mod.languageMeta && mod.languageMeta.label) || 'English';
-          languageNames[DEFAULT_LANG] = label;
-          if (!seen.has(DEFAULT_LANG)) {
-            sanitized.unshift({ value: DEFAULT_LANG, label });
-            seen.add(DEFAULT_LANG);
-          }
+      if (!languageModuleUrls.has(DEFAULT_LANG)) {
+        try {
+          const fallbackUrl = new URL('./en.js', manifestUrl);
+          languageModuleUrls.set(DEFAULT_LANG, fallbackUrl.href);
+        } catch (err) {
+          console.warn('[i18n] Unable to register fallback English bundle', err);
         }
-      } catch (err) {
-        console.error('[i18n] Unable to load fallback English bundle', err);
       }
-    }
-    if (!sanitized.length) {
-      sanitized.push({ value: DEFAULT_LANG, label: languageNames[DEFAULT_LANG] || FALLBACK_LANGUAGE_LABEL || DEFAULT_LANG });
-    }
-    languageManifest = sanitized;
+      if (!languageNames[DEFAULT_LANG]) languageNames[DEFAULT_LANG] = FALLBACK_LANGUAGE_LABEL;
+      upsertManifestEntry(DEFAULT_LANG, languageNames[DEFAULT_LANG] || FALLBACK_LANGUAGE_LABEL || DEFAULT_LANG, { preferFront: true });
+      languageManifest = languageManifest.reduce((acc, entry) => {
+        if (!entry || !entry.value) return acc;
+        if (acc.find((item) => item.value === entry.value)) return acc;
+        acc.push(entry);
+        return acc;
+      }, []);
   })();
-  return manifestLoadPromise;
+}
+  await manifestLoadPromise;
+
+  if (!translations[DEFAULT_LANG]) {
+    await loadLanguageBundle(DEFAULT_LANG);
+  }
+
+  const target = String(langToEnsure || currentLang || DEFAULT_LANG).toLowerCase();
+  if (target && !translations[target]) {
+    await loadLanguageBundle(target);
+  }
+
+  return translations[target] || translations[DEFAULT_LANG] || null;
 }
 
 
@@ -129,10 +198,11 @@ function detectLang() {
 }
 
 export async function initI18n(opts = {}) {
-  await ensureLanguageBundlesLoaded();
-  const desired = (opts.lang || detectLang() || '').toLowerCase();
+  const desiredInput = (opts.lang || detectLang() || '').toLowerCase();
   const def = (opts.defaultLang || DEFAULT_LANG).toLowerCase();
-  currentLang = desired || def;
+  const desired = desiredInput || def;
+  await ensureLanguageBundlesLoaded(desired);
+  currentLang = desiredInput || def;
   baseDefaultLang = def || DEFAULT_LANG;
   // If translation bundle missing, fall back to default bundle for UI
   if (!translations[currentLang]) currentLang = def;
@@ -150,6 +220,16 @@ export async function initI18n(opts = {}) {
 }
 
 export function getCurrentLang() { return currentLang; }
+
+export async function ensureLanguageBundle(langCode) {
+  const code = String(langCode || '').toLowerCase();
+  if (code) {
+    await ensureLanguageBundlesLoaded(code);
+    if (translations[code]) return translations[code];
+  }
+  await ensureLanguageBundlesLoaded(baseDefaultLang || DEFAULT_LANG);
+  return translations[code] || translations[currentLang] || translations[DEFAULT_LANG] || null;
+}
 
 // Translate helper: fetches a nested value from the current language bundle,
 // with graceful fallback to the default language.
@@ -558,6 +638,10 @@ function __setContentLangs(list) {
 }
 export function getAvailableLangs() {
   // Prefer languages discovered from content (unified index), else manifest order, else loaded bundle keys
+  const current = getCurrentLang();
+  if (current && !translations[current]) {
+    ensureLanguageBundle(current).catch(() => {});
+  }
   if (__contentLangs && __contentLangs.length) return __contentLangs;
   if (languageManifest && languageManifest.length) return languageManifest.map((entry) => entry.value);
   return Object.keys(translations);


### PR DESCRIPTION
## Summary
- refactor the i18n bootstrap to fetch the manifest and load only the active language bundle, deferring other bundles until requested
- expose helpers and events so the theme and editor language selectors can lazy-load bundles and refresh their UI when translations arrive
- ensure selectors verify the chosen language bundle exists before switching and update labels when new bundles finish loading

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcbeb9601083288211ee68f6cc3a55