### PR TITLE
Potential fix for code scanning alert no. 44: Client-side cross-site scripting

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -11983,12 +11983,14 @@ function buildSiteUI(root, state) {
         return a.localeCompare(b);
       });
 
-      const available = supported.filter((code) => !used.has(code));
+      // Filter only valid language codes that match LANG_CODE_PATTERN
+      const available = supported.filter((code) => !used.has(code) && LANG_CODE_PATTERN.test(code));
 
       menu.innerHTML = available
-        .map((code) => `<button type="button" role="option" class="ns-menu-item" data-lang="${code}">${escapeHtml(displayLangName(code))}</button>`)
+        .map((code) =>
+          `<button type="button" role="option" class="ns-menu-item" data-lang="${code}">${escapeHtml(displayLangName(code))}</button>`
+        )
         .join('');
-
       if (!available.length) {
         addBtn.setAttribute('disabled', '');
         addWrap.classList.add('is-disabled');


### PR DESCRIPTION
Potential fix for [https://github.com/deemoe404/NanoSite/security/code-scanning/44](https://github.com/deemoe404/NanoSite/security/code-scanning/44)

To prevent DOM-based XSS, we must ensure that any untrusted value incorporated into HTML (whether attribute or text content) is properly sanitized or validated. The best approach is to fully validate all language codes against a strict whitelist or regex, ensuring they conform to expected formats (e.g., `[a-z]{2,3}(?:-[a-z0-9]+)*`). In addition, when generating dynamic HTML, all values rendered as attribute values (such as `data-lang="${code}"`) should be safely escaped—even for well-formed language codes—to prevent edge-case injection.

The fix should be to:
1. Strictly filter the list of available languages (`available`) so that only entries matching `LANG_CODE_PATTERN` are included.
2. Also ensure `code` is properly escaped for safe insertion into attribute values, or only use values that are strictly pattern-checked (which can obviate the need for further escaping).
3. Apply this filter just before rendering the HTML buttons (`menu.innerHTML = ...`).
4. This requires changing the region of `assets/js/composer.js` around the construction of `available` and the rendering in line 11988-11989.
5. If an HTML escaping function for attribute values is not already present, a simple attribute escape can be added (for completeness, though strict validation may suffice).

All changes will be made in `assets/js/composer.js` only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
