### PR TITLE
Potential fix for code scanning alert no. 45: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -11988,7 +11988,7 @@ function buildSiteUI(root, state) {
 
       menu.innerHTML = available
         .map((code) =>
-          `<button type="button" role="option" class="ns-menu-item" data-lang="${code}">${escapeHtml(displayLangName(code))}</button>`
+          `<button type="button" role="option" class="ns-menu-item" data-lang="${escapeHtml(code)}">${escapeHtml(displayLangName(code))}</button>`
         )
         .join('');
       if (!available.length) {


### PR DESCRIPTION
Potential fix for [https://github.com/deemoe404/NanoSite/security/code-scanning/45](https://github.com/deemoe404/NanoSite/security/code-scanning/45)

To prevent any possibility of XSS stemming from an unescaped attribute—in this case, the `data-lang` attribute in the dynamically created buttons—the fix is to escape any characters in the language code before injecting it into the HTML attribute. While the current pattern restricts the allowed language codes, defense in depth suggests escaping all values interpolated into HTML, especially attributes. The best fix is to replace `${code}` in the `data-lang` attribute binding with `${escapeHtml(code)}` in the template literal at line 11991. No change in behavior or user experience will result, but this ensures complete safety should the upstream sanitization ever be bypassed or weakened.

If `escapeHtml` is not guaranteed to be imported/defined in this scope, its import/definition should be checked, but do not assume or edit unless shown.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
