### PR TITLE
Potential fix for code scanning alert no. 43: Client-side cross-site scripting

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -4,6 +4,15 @@ import { generateSitemapData, resolveSiteBaseUrl } from './seo.js';
 import { initSystemUpdates, getSystemUpdateSummaryEntries, getSystemUpdateCommitFiles, clearSystemUpdateState } from './system-updates.js';
 
 // Utility helpers
+// Escapes an arbitrary string for safe HTML output as text node
+function escapeHtml(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
 const $ = (s, r = document) => r.querySelector(s);
 const $$ = (s, r = document) => Array.from(r.querySelectorAll(s));
 
@@ -10473,7 +10482,7 @@ function buildTabsUI(root, state) {
         addLangWrap.innerHTML = `
           <button type="button" class="btn-secondary ct-add-lang-btn" aria-haspopup="listbox" aria-expanded="false">${escapeHtml(addLangLabel)}</button>
           <div class="ct-lang-menu ns-menu" role="listbox" hidden>
-            ${available.map(l => `<button type=\"button\" role=\"option\" class=\"ns-menu-item\" data-lang=\"${l}\">${displayLangName(l)}</button>`).join('')}
+            ${available.map(l => `<button type="button" role="option" class="ns-menu-item" data-lang="${escapeHtml(l)}">${escapeHtml(displayLangName(l))}</button>`).join('')}
           </div>
         `;
         const btn = $('.ct-add-lang-btn', addLangWrap);


### PR DESCRIPTION
Potential fix for [https://github.com/deemoe404/NanoSite/security/code-scanning/43](https://github.com/deemoe404/NanoSite/security/code-scanning/43)

**General fix approach:**  
- Escape/encode all dynamic text placed into `innerHTML`, especially values derived from untrusted or user-modifiable sources, such as language labels. Use a proper HTML-escaping function for anything not intended as markup.

**Best detailed fix:**  
- Ensure that the dynamic content (`displayLangName(l)`, and possibly other interpolations: `addLangLabel`) is run through a robust HTML-escaping function before being interpolated into the `innerHTML` string for the dropdown.
- Confirm there is an `escapeHtml` utility available (as already used for `addLangLabel`). If not, define or import a robust escaping utility.
- Edit only the relevant code region: the string interpolation building the menu options (`${displayLangName(l)}` in line 10476) should be replaced with `${escapeHtml(displayLangName(l))}`.
- Also, for belt-and-suspenders safety, ensure that any dynamic value influencing the `data-lang` attribute (currently `${l}`) is also HTML-escaped, although the language code is most likely sanitized elsewhere.
- All changes must occur in `assets/js/composer.js`, in the affected menu rendering code.

**Requirements:**  
- If not available, add a robust `escapeHtml()` function to `assets/js/composer.js`.
- Import nothing but can define small local utility escapes as needed.
- Only touch the code blocks around the affected region and new utility (avoid touching unrelated lines).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
