### PR TITLE
Potential fix for code scanning alert no. 42: Client-side cross-site scripting

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -10238,7 +10238,7 @@ function buildIndexUI(root, state) {
         addLangWrap.innerHTML = `
           <button type="button" class="btn-secondary ci-add-lang-btn" aria-haspopup="listbox" aria-expanded="false">${escapeHtml(addLangLabel)}</button>
           <div class="ci-lang-menu ns-menu" role="listbox" hidden>
-            ${available.map(l => `<button type="button" role="option" class="ns-menu-item" data-lang="${l}">${displayLangName(l)}</button>`).join('')}
+            ${available.map(l => `<button type="button" role="option" class="ns-menu-item" data-lang="${l}">${escapeHtml(displayLangName(l))}</button>`).join('')}
           </div>
         `;
         const btn = $('.ci-add-lang-btn', addLangWrap);


### PR DESCRIPTION
Potential fix for [https://github.com/deemoe404/NanoSite/security/code-scanning/42](https://github.com/deemoe404/NanoSite/security/code-scanning/42)

To fix the issue, we need to ensure that any user input or data that eventually becomes part of the HTML via `.innerHTML` is sanitized or escaped according to the context in which it is used. Here, the danger is in the label text used within the language selection dropdown:

- The vulnerable code constructs HTML using `available.map(l => <button...>${displayLangName(l)}</button>)`, where `displayLangName(l)` produces a string that may include user-controlled content.
- The correct fix is to escape the output of `displayLangName(l)` before adding it to the HTML.
- There is already an `escapeHtml` function (as shown in the call to escape `addLangLabel` on line 10239), so we should use it for the label HTML as well.
- The patch should update the relevant map call (line 10241), so that `${displayLangName(l)}` is replaced by `${escapeHtml(displayLangName(l))}`.
- If contextually appropriate, ensure `escapeHtml` is imported or in scope, but from context it exists and is used elsewhere in the file.

No changes to imports or additional libraries are required, as the escaping utility appears in the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
