### PR TITLE
Improve handling of simplified content metadata

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -1696,18 +1696,190 @@ function prepareIndexState(raw) {
 function normalizeIndexEntry(entry) {
   const out = {};
   if (!entry || typeof entry !== 'object') return out;
+
+  const existingMeta = (entry.__meta && typeof entry.__meta === 'object') ? entry.__meta : {};
+  const metaOut = {};
+
+  const cloneMeta = (meta) => {
+    if (!meta || typeof meta !== 'object') return {};
+    const copy = {};
+    if (meta.title != null) copy.title = safeString(meta.title);
+    if (meta.date != null) copy.date = safeString(meta.date);
+    if (meta.excerpt != null) copy.excerpt = safeString(meta.excerpt);
+    if (meta.image != null) copy.image = safeString(meta.image);
+    if (meta.tag != null) {
+      copy.tag = Array.isArray(meta.tag) ? meta.tag.map(item => safeString(item)) : safeString(meta.tag);
+    }
+    if (meta.versionLabel != null) copy.versionLabel = safeString(meta.versionLabel);
+    if (meta.version != null) copy.version = safeString(meta.version);
+    if (meta.ai != null) {
+      const ai = normalizeBoolean(meta.ai, null);
+      if (ai !== null) copy.ai = ai;
+    }
+    if (meta.draft != null) {
+      const draft = normalizeBoolean(meta.draft, null);
+      if (draft !== null) copy.draft = draft;
+    }
+    if (Array.isArray(meta.__versions)) {
+      const versions = meta.__versions
+        .map((item) => {
+          if (!item || typeof item !== 'object') return null;
+          const normalized = {};
+          if (item.location != null) normalized.location = safeString(item.location);
+          if (!normalized.location) return null;
+          if (item.date != null) normalized.date = safeString(item.date);
+          if (item.excerpt != null) normalized.excerpt = safeString(item.excerpt);
+          if (item.image != null) normalized.image = safeString(item.image);
+          if (item.tag != null) {
+            normalized.tag = Array.isArray(item.tag) ? item.tag.map(v => safeString(v)) : safeString(item.tag);
+          }
+          if (item.versionLabel != null) normalized.versionLabel = safeString(item.versionLabel);
+          if (item.version != null) normalized.version = safeString(item.version);
+          if (item.ai != null) {
+            const aiFlag = normalizeBoolean(item.ai, null);
+            if (aiFlag !== null) normalized.ai = aiFlag;
+          }
+          if (item.draft != null) {
+            const draftFlag = normalizeBoolean(item.draft, null);
+            if (draftFlag !== null) normalized.draft = draftFlag;
+          }
+          return normalized;
+        })
+        .filter(Boolean);
+      if (versions.length) copy.__versions = versions;
+    }
+    return copy;
+  };
+
+  const mergeMeta = (target, updates) => {
+    if (!updates || typeof updates !== 'object') return target;
+    if (updates.title != null) target.title = safeString(updates.title);
+    if (updates.date != null) target.date = safeString(updates.date);
+    if (updates.excerpt != null) target.excerpt = safeString(updates.excerpt);
+    if (updates.image != null) target.image = safeString(updates.image);
+    if (updates.tag != null) {
+      target.tag = Array.isArray(updates.tag) ? updates.tag.map(item => safeString(item)) : safeString(updates.tag);
+    } else if (updates.tags != null && target.tag == null) {
+      target.tag = Array.isArray(updates.tags) ? updates.tags.map(item => safeString(item)) : safeString(updates.tags);
+    }
+    if (updates.versionLabel != null) target.versionLabel = safeString(updates.versionLabel);
+    if (updates.version != null && target.versionLabel == null) target.version = safeString(updates.version);
+    if (updates.ai != null) {
+      const ai = normalizeBoolean(updates.ai, null);
+      if (ai !== null) target.ai = ai;
+    }
+    if (updates.aiGenerated != null && target.ai == null) {
+      const ai = normalizeBoolean(updates.aiGenerated, null);
+      if (ai !== null) target.ai = ai;
+    }
+    if (updates.llm != null && target.ai == null) {
+      const ai = normalizeBoolean(updates.llm, null);
+      if (ai !== null) target.ai = ai;
+    }
+    if (updates.draft != null) {
+      const draft = normalizeBoolean(updates.draft, null);
+      if (draft !== null) target.draft = draft;
+    }
+    if (updates.wip != null && target.draft == null) {
+      const draft = normalizeBoolean(updates.wip, null);
+      if (draft !== null) target.draft = draft;
+    }
+    if (updates.unfinished != null && target.draft == null) {
+      const draft = normalizeBoolean(updates.unfinished, null);
+      if (draft !== null) target.draft = draft;
+    }
+    if (updates.inprogress != null && target.draft == null) {
+      const draft = normalizeBoolean(updates.inprogress, null);
+      if (draft !== null) target.draft = draft;
+    }
+    return target;
+  };
+
+  const extractLangMeta = (value) => {
+    const meta = {};
+    mergeMeta(meta, value);
+    return meta;
+  };
+
+  const sanitizeVersionMeta = (value) => {
+    if (!value || typeof value !== 'object') return [];
+    const versions = [];
+    if (Array.isArray(value.versions) && value.versions.length) {
+      value.versions.forEach((item) => {
+        if (typeof item === 'string') return;
+        if (!item || typeof item !== 'object') return;
+        const location = safeString(item.location || item.path || '');
+        if (!location) return;
+        const meta = extractLangMeta(item);
+        if (Object.keys(meta).length) {
+          const clean = cloneMeta(meta);
+          delete clean.title;
+          clean.location = location;
+          versions.push(clean);
+        }
+      });
+    } else {
+      const location = safeString(value.location || value.path || '');
+      if (location) {
+        const meta = extractLangMeta(value);
+        const clean = cloneMeta(meta);
+        delete clean.title;
+        if (Object.keys(clean).length) {
+          clean.location = location;
+          versions.push(clean);
+        }
+      }
+    }
+    return versions;
+  };
+
   Object.keys(entry).forEach(lang => {
-    if (lang === '__order') return;
+    if (lang === '__order' || lang === '__meta') return;
     const value = entry[lang];
+    const existing = cloneMeta(existingMeta[lang]);
+
     if (Array.isArray(value)) {
       out[lang] = value.map(item => safeString(item));
     } else if (value != null && typeof value === 'object') {
-      // Unexpected object -> stringify to keep placeholder
-      out[lang] = safeString(value.location || value.path || '');
+      const arr = [];
+      if (Array.isArray(value.versions) && value.versions.length) {
+        value.versions.forEach((item) => {
+          if (typeof item === 'string') arr.push(safeString(item));
+          else if (item && typeof item === 'object') {
+            const loc = safeString(item.location || item.path || '');
+            if (loc) arr.push(loc);
+          }
+        });
+      }
+      if (!arr.length) {
+        const loc = safeString(value.location || value.path || '');
+        if (loc) arr.push(loc);
+      }
+      if (!arr.length && typeof value.default === 'string') {
+        arr.push(safeString(value.default));
+      }
+      if (!arr.length) out[lang] = '';
+      else if (arr.length === 1) out[lang] = arr[0];
+      else out[lang] = arr;
+
+      const meta = extractLangMeta(value);
+      mergeMeta(existing, meta);
+      const versionMeta = sanitizeVersionMeta(value);
+      if (versionMeta.length) existing.__versions = versionMeta;
     } else {
       out[lang] = safeString(value);
     }
+
+    if (existing && Object.keys(existing).length) metaOut[lang] = existing;
   });
+
+  Object.keys(existingMeta).forEach((lang) => {
+    if (metaOut[lang]) return;
+    const clone = cloneMeta(existingMeta[lang]);
+    if (clone && Object.keys(clone).length) metaOut[lang] = clone;
+  });
+
+  if (Object.keys(metaOut).length) out.__meta = metaOut;
   return out;
 }
 
@@ -9717,7 +9889,7 @@ function slideToggle(el, toOpen) {
 }
 
 function sortLangKeys(obj) {
-  const keys = Object.keys(obj || {});
+  const keys = Object.keys(obj || {}).filter((key) => key !== '__meta');
   return keys.sort((a, b) => {
     const ia = PREFERRED_LANG_ORDER.indexOf(normalizeLangCode(a));
     const ib = PREFERRED_LANG_ORDER.indexOf(normalizeLangCode(b));
@@ -9759,29 +9931,138 @@ function q(s) {
 }
 
 function toIndexYaml(data) {
+  const pushKeyValue = (lines, indent, keyName, value) => {
+    const pad = '  '.repeat(indent);
+    if (value == null) return;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      lines.push(`${pad}${keyName}: ${yamlScalar(value)}`);
+      return;
+    }
+    if (Array.isArray(value) && !value.length) {
+      lines.push(`${pad}${keyName}: []`);
+      return;
+    }
+    lines.push(`${pad}${keyName}:`);
+    writeYamlValue(lines, indent + 1, value);
+  };
+
+  const sanitizeGeneralMeta = (meta) => {
+    const out = {};
+    if (!meta || typeof meta !== 'object') return out;
+    if (meta.title != null && meta.title !== '') out.title = safeString(meta.title);
+    if (meta.date != null && meta.date !== '') out.date = safeString(meta.date);
+    if (meta.excerpt != null && meta.excerpt !== '') out.excerpt = safeString(meta.excerpt);
+    if (meta.image != null && meta.image !== '') out.image = safeString(meta.image);
+    if (meta.tag != null) {
+      out.tag = Array.isArray(meta.tag) ? meta.tag.map(item => safeString(item)) : safeString(meta.tag);
+    }
+    if (meta.versionLabel != null && meta.versionLabel !== '') out.versionLabel = safeString(meta.versionLabel);
+    if (meta.version != null && meta.version !== '') out.version = safeString(meta.version);
+    const ai = normalizeBoolean(meta.ai, null);
+    if (ai !== null) out.ai = ai;
+    const draft = normalizeBoolean(meta.draft, null);
+    if (draft !== null) out.draft = draft;
+    return out;
+  };
+
+  const sanitizeVersionMetaEntries = (meta) => {
+    if (!meta || typeof meta !== 'object' || !Array.isArray(meta.__versions)) return [];
+    return meta.__versions
+      .map((item) => {
+        if (!item || typeof item !== 'object') return null;
+        const location = safeString(item.location || '');
+        if (!location) return null;
+        const entry = { location };
+        if (item.date != null && item.date !== '') entry.date = safeString(item.date);
+        if (item.excerpt != null && item.excerpt !== '') entry.excerpt = safeString(item.excerpt);
+        if (item.image != null && item.image !== '') entry.image = safeString(item.image);
+        if (item.tag != null) {
+          entry.tag = Array.isArray(item.tag) ? item.tag.map(v => safeString(v)) : safeString(item.tag);
+        }
+        if (item.versionLabel != null && item.versionLabel !== '') entry.versionLabel = safeString(item.versionLabel);
+        if (item.version != null && item.version !== '') entry.version = safeString(item.version);
+        const ai = normalizeBoolean(item.ai, null);
+        if (ai !== null) entry.ai = ai;
+        const draft = normalizeBoolean(item.draft, null);
+        if (draft !== null) entry.draft = draft;
+        return Object.keys(entry).length > 1 ? entry : null;
+      })
+      .filter(Boolean);
+  };
+
   const lines = [
     '# yaml-language-server: $schema=../assets/schema/index.json',
     ''
   ];
   const keys = data.__order && Array.isArray(data.__order) ? data.__order.slice() : Object.keys(data).filter(k => k !== '__order');
-  keys.forEach(key => {
+  keys.forEach((key) => {
     const entry = data[key];
     if (!entry || typeof entry !== 'object') return;
     lines.push(`${key}:`);
     const langs = sortLangKeys(entry);
-    langs.forEach(lang => {
-      const v = entry[lang];
-      if (Array.isArray(v)) {
-        if (v.length <= 1) {
-          const one = v[0] ?? '';
-          lines.push(`  ${lang}: ${one ? one : '""'}`);
+    const metaMap = (entry.__meta && typeof entry.__meta === 'object') ? entry.__meta : {};
+    langs.forEach((lang) => {
+      const raw = entry[lang];
+      const meta = metaMap[lang];
+      const paths = Array.isArray(raw)
+        ? raw.map(item => safeString(item))
+        : (raw != null ? [safeString(raw)] : []);
+      const generalMeta = sanitizeGeneralMeta(meta);
+      const versionMeta = sanitizeVersionMetaEntries(meta);
+      const needsObject = Object.keys(generalMeta).length > 0 || versionMeta.length > 0;
+
+      if (!needsObject) {
+        if (paths.length <= 1) {
+          const scalar = paths[0] != null ? paths[0] : '';
+          lines.push(`  ${lang}: ${scalar ? scalar : '""'}`);
         } else {
           lines.push(`  ${lang}:`);
-          v.forEach(p => lines.push(`    - ${p}`));
+          paths.forEach((p) => {
+            const val = p != null ? p : '';
+            lines.push(`    - ${val ? val : '""'}`);
+          });
         }
-      } else if (typeof v === 'string') {
-        lines.push(`  ${lang}: ${v}`);
+        return;
       }
+
+      const langObj = {};
+      if (paths.length <= 1) {
+        const location = paths[0] != null ? paths[0] : '';
+        langObj.location = location;
+        const versionEntry = versionMeta.find((item) => item.location === location);
+        if (versionEntry) {
+          const { location: _loc, ...rest } = versionEntry;
+          Object.assign(langObj, rest);
+        }
+      } else {
+        langObj.versions = paths.map((loc) => {
+          const safeLoc = loc != null ? loc : '';
+          const vm = versionMeta.find((item) => item.location === safeLoc);
+          const payload = { location: safeLoc };
+          if (vm) {
+            const { location: _l, ...rest } = vm;
+            Object.assign(payload, rest);
+          }
+          return payload;
+        });
+      }
+
+      Object.entries(generalMeta).forEach(([field, value]) => {
+        if (value != null) langObj[field] = value;
+      });
+
+      lines.push(`  ${lang}:`);
+      const orderedFields = [];
+      if (Object.prototype.hasOwnProperty.call(langObj, 'location')) orderedFields.push(['location', langObj.location]);
+      if (Object.prototype.hasOwnProperty.call(langObj, 'versions')) orderedFields.push(['versions', langObj.versions]);
+      ['title', 'date', 'excerpt', 'image', 'tag', 'version', 'versionLabel', 'ai', 'draft'].forEach((field) => {
+        if (Object.prototype.hasOwnProperty.call(langObj, field)) {
+          orderedFields.push([field, langObj[field]]);
+        }
+      });
+      orderedFields.forEach(([field, value]) => {
+        pushKeyValue(lines, 2, field, value);
+      });
     });
   });
   return lines.join('\n') + '\n';
@@ -10020,7 +10301,7 @@ function buildIndexUI(root, state) {
     row.className = 'ci-item';
     row.setAttribute('data-key', key);
     row.setAttribute('draggable', 'true');
-    const langCount = Object.keys(entry).length;
+    const langCount = sortLangKeys(entry).length;
     const langCountText = tComposerLang('count', { count: langCount });
     const detailsLabel = tComposerEntryRow('details');
     const deleteLabel = tComposerEntryRow('delete');
@@ -10071,6 +10352,25 @@ function buildIndexUI(root, state) {
         const val = entry[lang];
         // Normalize to array for UI
         const arr = Array.isArray(val) ? val.slice() : (val ? [val] : []);
+        const syncVersionMeta = () => {
+          if (!entry.__meta || !entry.__meta[lang]) return;
+          const meta = entry.__meta[lang];
+          if (!meta || typeof meta !== 'object' || !Array.isArray(meta.__versions)) return;
+          const byLocation = new Map();
+          meta.__versions.forEach((item) => {
+            if (item && item.location) byLocation.set(item.location, item);
+          });
+          const normalized = arr.map((p) => safeString(p)).filter((loc) => !!loc);
+          const next = [];
+          normalized.forEach((loc) => {
+            if (byLocation.has(loc)) next.push(byLocation.get(loc));
+          });
+          meta.__versions = next;
+          if (!meta.__versions.length) delete meta.__versions;
+          const hasOtherMeta = Object.keys(meta).some((k) => k !== '__versions');
+          if (!hasOtherMeta && !meta.__versions) delete entry.__meta[lang];
+          if (entry.__meta && !Object.keys(entry.__meta).length) delete entry.__meta;
+        };
         block.innerHTML = `
           <div class="ci-lang-head">
             <strong>${escapeHtml(lang.toUpperCase())}</strong>
@@ -10127,6 +10427,7 @@ function buildIndexUI(root, state) {
         };
 
         const renderVers = (prevRects = null) => {
+          syncVersionMeta();
           verList.innerHTML = '';
           arr.forEach((p, i) => {
             const id = verIds[i] || (verIds[i] = Math.random().toString(36).slice(2));
@@ -10160,6 +10461,7 @@ function buildIndexUI(root, state) {
               const prevPath = row.dataset.mdPath || '';
               arr[i] = e.target.value;
               entry[lang] = arr.slice();
+              syncVersionMeta();
               row.dataset.value = arr[i] || '';
               const nextPath = normalizeRelPath(arr[i]);
               if (nextPath) row.dataset.mdPath = nextPath;
@@ -10183,6 +10485,7 @@ function buildIndexUI(root, state) {
               [arr[i - 1], arr[i]] = [arr[i], arr[i - 1]];
               [verIds[i - 1], verIds[i]] = [verIds[i], verIds[i - 1]];
               entry[lang] = arr.slice();
+              syncVersionMeta();
               renderVers(prev);
               markDirty();
             });
@@ -10192,6 +10495,7 @@ function buildIndexUI(root, state) {
               [arr[i + 1], arr[i]] = [arr[i], arr[i + 1]];
               [verIds[i + 1], verIds[i]] = [verIds[i], verIds[i + 1]];
               entry[lang] = arr.slice();
+              syncVersionMeta();
               renderVers(prev);
               markDirty();
             });
@@ -10200,6 +10504,7 @@ function buildIndexUI(root, state) {
               arr.splice(i, 1);
               verIds.splice(i, 1);
               entry[lang] = arr.slice();
+              syncVersionMeta();
               renderVers(prev);
               markDirty();
             });
@@ -10214,13 +10519,18 @@ function buildIndexUI(root, state) {
           arr.push('');
           verIds.push(Math.random().toString(36).slice(2));
           entry[lang] = arr.slice();
+          syncVersionMeta();
           renderVers(prev);
           markDirty();
         });
         $('.ci-lang-del', block).addEventListener('click', () => {
           delete entry[lang];
-          const meta = row.querySelector('.ci-meta');
-          if (meta) meta.textContent = tComposerLang('count', { count: Object.keys(entry).length });
+          if (entry.__meta && entry.__meta[lang]) {
+            delete entry.__meta[lang];
+            if (!Object.keys(entry.__meta).length) delete entry.__meta;
+          }
+          const metaLabel = row.querySelector('.ci-meta');
+          if (metaLabel) metaLabel.textContent = tComposerLang('count', { count: sortLangKeys(entry).length });
           renderBody();
           broadcastLanguagePoolChange();
           markDirty();
@@ -10286,8 +10596,8 @@ function buildIndexUI(root, state) {
             const code = String(it.getAttribute('data-lang')||'').trim();
             if (!code || entry[code]) return;
             entry[code] = [''];
-            const meta = row.querySelector('.ci-meta');
-            if (meta) meta.textContent = tComposerLang('count', { count: Object.keys(entry).length });
+            const metaLabel = row.querySelector('.ci-meta');
+            if (metaLabel) metaLabel.textContent = tComposerLang('count', { count: sortLangKeys(entry).length });
             closeMenu();
             renderBody();
             broadcastLanguagePoolChange();

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -40,6 +40,12 @@ let manifestBaseUrl = null;
 // Set to a positive integer to chunk requests; falsy values disable the limit.
 const FRONTMATTER_FETCH_BATCH_SIZE = 6;
 
+const EMBEDDED_METADATA_FIELDS = new Set([
+  'title', 'titles', 'date', 'excerpt', 'summary', 'image', 'cover', 'thumb',
+  'tag', 'tags', 'version', 'versionlabel', 'ai', 'aigenerated', 'llm',
+  'draft', 'wip', 'unfinished', 'inprogress'
+]);
+
 const FALLBACK_LANGUAGE_LABEL = (enLanguageMeta && enLanguageMeta.label) ? enLanguageMeta.label : 'English';
 translations[DEFAULT_LANG] = enTranslations;
 languageNames[DEFAULT_LANG] = FALLBACK_LANGUAGE_LABEL;
@@ -467,8 +473,254 @@ async function loadContentFromFrontMatter(obj, lang) {
       return rest;
     });
     out[title] = meta;
+}
+
+  return { entries: out, availableLangs: Array.from(langsSeen).sort() };
+}
+
+function mergeMetadata(...sources) {
+  const merged = {};
+  for (const src of sources) {
+    if (!src || typeof src !== 'object') continue;
+    if (src.title != null) merged.title = String(src.title);
+    if (src.date != null) merged.date = src.date;
+    if (src.excerpt != null) merged.excerpt = String(src.excerpt);
+    if (src.summary != null && merged.excerpt == null) merged.excerpt = String(src.summary);
+    if (src.image != null) merged.image = src.image;
+    if (merged.image == null && src.cover != null) merged.image = src.cover;
+    if (merged.image == null && src.thumb != null) merged.image = src.thumb;
+    if (src.tag != null) merged.tag = src.tag;
+    if (src.tags != null && merged.tag == null) merged.tag = src.tags;
+    if (src.versionLabel != null) merged.versionLabel = src.versionLabel;
+    if (src.version != null && merged.versionLabel == null) merged.versionLabel = src.version;
+    if (src.ai != null) merged.ai = src.ai;
+    if (src.aiGenerated != null && merged.ai == null) merged.ai = src.aiGenerated;
+    if (src.llm != null && merged.ai == null) merged.ai = src.llm;
+    if (src.draft != null) merged.draft = src.draft;
+    if (src.wip != null && merged.draft == null) merged.draft = src.wip;
+    if (src.unfinished != null && merged.draft == null) merged.draft = src.unfinished;
+    if (src.inprogress != null && merged.draft == null) merged.draft = src.inprogress;
   }
-  
+  return merged;
+}
+
+function normalizeVersionEntries(raw) {
+  if (Array.isArray(raw)) return raw;
+  if (raw == null) return [];
+  return [raw];
+}
+
+function truthyMetaFlag(value) {
+  if (value === true) return true;
+  if (value === false) return false;
+  const s = String(value ?? '').trim().toLowerCase();
+  if (!s) return false;
+  return ['true', '1', 'yes', 'y', 'on', 'enabled'].includes(s);
+}
+
+function resolveImageRelative(location, image) {
+  const src = String(image ?? '').trim();
+  if (!src) return undefined;
+  if (/^(https?:|data:)/i.test(src) || src.startsWith('/')) return src;
+  const loc = String(location || '');
+  const lastSlash = loc.lastIndexOf('/');
+  const baseDir = lastSlash >= 0 ? loc.slice(0, lastSlash + 1) : '';
+  return (baseDir + src).replace(/\\+/g, '/');
+}
+
+function normalizeVersionsWithMeta(raw, baseMeta = {}) {
+  const versions = [];
+  const items = normalizeVersionEntries(raw);
+  for (const item of items) {
+    if (typeof item === 'string') {
+      if (!item) continue;
+      const merged = { ...baseMeta };
+      versions.push({ location: item, ...merged });
+      continue;
+    }
+    if (!item || typeof item !== 'object') continue;
+    const location = String(item.location || item.path || '').trim();
+    if (!location) continue;
+    const merged = mergeMetadata(baseMeta, item);
+    versions.push({ location, ...merged });
+  }
+  return versions;
+}
+
+function pickPreferredBucket(entry, lang) {
+  if (!entry || typeof entry !== 'object') return null;
+  const nlang = normalizeLangKey(lang);
+  if (entry[nlang] != null) return { key: nlang, value: entry[nlang] };
+  if (entry[baseDefaultLang] != null) return { key: baseDefaultLang, value: entry[baseDefaultLang] };
+  if (entry.en != null) return { key: 'en', value: entry.en };
+  if (entry.default != null) return { key: 'default', value: entry.default };
+  const firstKey = Object.keys(entry).find((k) => entry[k] != null);
+  if (!firstKey) return null;
+  return { key: firstKey, value: entry[firstKey] };
+}
+
+function normalizeBucketMetadata(value, fallbackMeta = {}) {
+  if (value == null) return { versions: [] };
+  if (typeof value === 'string') {
+    const merged = { ...fallbackMeta };
+    return { versions: value ? [{ location: value, ...merged }] : [] };
+  }
+  if (Array.isArray(value)) {
+    const versions = value
+      .filter((item) => typeof item === 'string')
+      .map((loc) => ({ location: loc, ...fallbackMeta }));
+    return { versions };
+  }
+  if (typeof value === 'object') {
+    const mergedMeta = mergeMetadata(fallbackMeta, value);
+    if (Array.isArray(value.versions) && value.versions.length) {
+      const versions = normalizeVersionsWithMeta(value.versions, mergedMeta);
+      return { versions, meta: mergedMeta };
+    }
+    const location = String(value.location || value.path || '').trim();
+    if (location) {
+      const meta = mergeMetadata(mergedMeta, value);
+      return { versions: [{ location, ...meta }], meta };
+    }
+    const versions = normalizeVersionsWithMeta(value, mergedMeta);
+    return { versions, meta: mergedMeta };
+  }
+  return { versions: [] };
+}
+
+function wrapMetadataSourceForMerge(key, value) {
+  if (value == null) return null;
+  if (typeof value === 'object' && !Array.isArray(value)) return value;
+  return { [key]: value };
+}
+
+function hasEmbeddedMetadata(candidate) {
+  return candidate && typeof candidate === 'object' && !Array.isArray(candidate);
+}
+
+function deriveSimplifiedEntryFallbackMeta(entry, langKeys, chosen) {
+  const fallbackSources = [];
+  const normalizedLangs = new Set((langKeys || []).map((lk) => normalizeLangKey(lk)));
+
+  for (const [innerKey, innerVal] of Object.entries(entry || {})) {
+    const normalizedInner = normalizeLangKey(innerKey);
+    if (normalizedLangs.has(normalizedInner)) continue;
+    const wrapped = wrapMetadataSourceForMerge(innerKey, innerVal);
+    if (wrapped) fallbackSources.push(wrapped);
+  }
+
+  const chosenValue = chosen ? chosen.value : undefined;
+  if (!hasEmbeddedMetadata(chosenValue)) {
+    const defaultBucket = entry && entry.default;
+    if (hasEmbeddedMetadata(defaultBucket)) {
+      fallbackSources.push(defaultBucket);
+    }
+  }
+
+  return mergeMetadata(...fallbackSources);
+}
+
+function containsEmbeddedMetadataFields(candidate) {
+  if (!candidate || typeof candidate !== 'object') return false;
+  return Object.keys(candidate).some((key) => {
+    const lower = String(key).toLowerCase();
+    if (lower === 'location' || lower === 'path' || lower === 'versions') return false;
+    return EMBEDDED_METADATA_FIELDS.has(lower);
+  });
+}
+
+function bucketProvidesEmbeddedMetadata(entryMeta, bucket) {
+  if (containsEmbeddedMetadataFields(entryMeta)) return true;
+  if (bucket && containsEmbeddedMetadataFields(bucket.meta)) return true;
+  if (bucket && Array.isArray(bucket.versions)) {
+    for (const version of bucket.versions) {
+      if (containsEmbeddedMetadataFields(version)) return true;
+    }
+  }
+  return false;
+}
+
+async function loadContentFromSimplifiedMetadata(obj, lang) {
+  const out = {};
+  const langsSeen = new Set();
+  const entries = Object.entries(obj || {});
+
+  for (const [key, val] of entries) {
+    if (!val || typeof val !== 'object' || Array.isArray(val)) continue;
+
+    const langKeys = Object.keys(val).filter((k) => {
+      const nk = normalizeLangKey(k);
+      if (nk === 'default') return true;
+      if (nk !== k) return true;
+      return /^[a-z]{2,3}(?:-[a-z0-9]+)*$/i.test(String(k || ''));
+    });
+    langKeys.forEach((lk) => {
+      const normalized = normalizeLangKey(lk);
+      if (normalized !== 'default') langsSeen.add(normalized);
+    });
+
+    const chosen = pickPreferredBucket(val, lang);
+    if (!chosen || chosen.value == null) continue;
+
+    const entryMeta = deriveSimplifiedEntryFallbackMeta(val, langKeys, chosen);
+    const bucket = normalizeBucketMetadata(chosen.value, entryMeta);
+    const hasEmbedded = bucketProvidesEmbeddedMetadata(entryMeta, bucket);
+
+    if (!hasEmbedded) {
+      const fallback = await loadContentFromFrontMatter({ [key]: val }, lang);
+      (fallback.availableLangs || []).forEach((lk) => langsSeen.add(lk));
+      for (const [fallbackTitle, meta] of Object.entries(fallback.entries || {})) {
+        out[fallbackTitle] = meta;
+      }
+      continue;
+    }
+    if (!bucket.versions.length) continue;
+
+    const toTime = (d) => {
+      const t = new Date(String(d || '')).getTime();
+      return Number.isFinite(t) ? t : -Infinity;
+    };
+
+    const versions = bucket.versions
+      .map((ver) => {
+        const meta = mergeMetadata(entryMeta, bucket.meta || {}, ver);
+        const normalized = { ...meta };
+        normalized.location = ver.location;
+        normalized.image = resolveImageRelative(ver.location, normalized.image);
+        normalized.tag = normalized.tag != null ? normalized.tag : undefined;
+        normalized.ai = truthyMetaFlag(normalized.ai);
+        normalized.draft = truthyMetaFlag(normalized.draft);
+        return normalized;
+      })
+      .filter((ver) => ver.location);
+
+    if (!versions.length) continue;
+
+    versions.sort((a, b) => toTime(b.date) - toTime(a.date));
+    const primary = versions[0];
+    const title = primary.title || (bucket.meta && bucket.meta.title) || entryMeta.title || key;
+
+    const versionsForUi = versions.map((ver) => {
+      const { title: _t, ...rest } = ver;
+      return rest;
+    });
+
+    const meta = {
+      location: primary.location,
+      image: primary.image || undefined,
+      tag: primary.tag != null ? primary.tag : undefined,
+      date: primary.date || undefined,
+      excerpt: primary.excerpt || undefined,
+      versionLabel: primary.versionLabel || primary.version || undefined,
+      ai: primary.ai ? true : undefined,
+      draft: primary.draft ? true : undefined,
+      title,
+      versions: versionsForUi
+    };
+
+    out[title] = meta;
+  }
+
   return { entries: out, availableLangs: Array.from(langsSeen).sort() };
 }
 
@@ -486,7 +738,73 @@ export async function loadContentJson(basePath, baseName) {
       const keys = Object.keys(obj || {});
       let isUnified = false;
       let isSimplified = false;
-      
+      let simplifiedHasEmbeddedMeta = false;
+
+      const LANG_KEY_PATTERN = /^[a-z]{2,3}(?:-[a-z0-9]+)*$/i;
+      const RESERVED_SIMPLIFIED_KEYS = new Set(['location', 'path', 'versions']);
+      EMBEDDED_METADATA_FIELDS.forEach((field) => RESERVED_SIMPLIFIED_KEYS.add(field));
+      const looksLikeLang = (key) => {
+        if (!key) return false;
+        const normalized = normalizeLangKey(key);
+        const lower = String(normalized || '').toLowerCase();
+        if (lower === 'default') return true;
+        if (RESERVED_SIMPLIFIED_KEYS.has(lower)) return false;
+        if (normalized !== key) return true;
+        return LANG_KEY_PATTERN.test(String(key || ''));
+      };
+
+      const hasMetadataFields = (value) => {
+        if (!value || typeof value !== 'object') return false;
+        return Object.keys(value).some((k) => {
+          if (k === 'location' || k === 'path') return false;
+          if (k === 'versions') return false;
+          if (looksLikeLang(k)) return false;
+          return EMBEDDED_METADATA_FIELDS.has(String(k).toLowerCase());
+        });
+      };
+
+      const isMetadataBucket = (value) => {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+        const keysInBucket = Object.keys(value);
+        if (!keysInBucket.length) return false;
+        let valid = false;
+        for (const key of keysInBucket) {
+          const lower = String(key).toLowerCase();
+          if (looksLikeLang(key)) return false;
+          if (key === 'location' || key === 'path') {
+            if (typeof value[key] === 'string') valid = true;
+            else return false;
+            continue;
+          }
+          if (key === 'versions') {
+            const arr = value[key];
+            if (!Array.isArray(arr)) return false;
+            const ok = arr.every((item) => {
+              if (typeof item === 'string') return true;
+              if (!item || typeof item !== 'object') return false;
+              if (looksLikeLang(Object.keys(item)[0] || '')) return false;
+              if (item.location && typeof item.location === 'string') return true;
+              if (item.path && typeof item.path === 'string') return true;
+              return false;
+            });
+            if (!ok) return false;
+            if (arr.some((item) => item && typeof item === 'object' && hasMetadataFields(item))) {
+              simplifiedHasEmbeddedMeta = true;
+            }
+            valid = true;
+            continue;
+          }
+          if (EMBEDDED_METADATA_FIELDS.has(lower)) {
+            simplifiedHasEmbeddedMeta = true;
+            valid = true;
+            continue;
+          }
+          return false;
+        }
+        if (hasMetadataFields(value)) simplifiedHasEmbeddedMeta = true;
+        return valid;
+      };
+
       // Check if it's a simplified format (just path mappings) or unified format
       for (const k of keys) {
         const v = obj[k];
@@ -494,27 +812,46 @@ export async function loadContentJson(basePath, baseName) {
           // Check for simplified format (language -> path mapping)
           const innerKeys = Object.keys(v);
           const hasOnlyPaths = innerKeys.every(ik => {
+            if (!looksLikeLang(ik) && EMBEDDED_METADATA_FIELDS.has(String(ik).toLowerCase())) {
+              simplifiedHasEmbeddedMeta = true;
+              return true;
+            }
             const val = v[ik];
             if (typeof val === 'string') return true;
             if (Array.isArray(val)) return val.every(item => typeof item === 'string');
+            if (looksLikeLang(ik) && val && typeof val === 'object' && !Array.isArray(val)) {
+              if (isMetadataBucket(val)) return true;
+            }
+            if (!looksLikeLang(ik) && val && typeof val === 'object' && !Array.isArray(val) && isMetadataBucket(val)) {
+              return true;
+            }
             return false;
           });
-          
+
           if (hasOnlyPaths) {
             isSimplified = true;
             break;
           }
-          
+
           // Check for unified format
           if ('default' in v) { isUnified = true; break; }
-          if (innerKeys.some(ik => !['tag','tags','image','date','excerpt','location'].includes(ik))) { isUnified = true; break; }
+          if (innerKeys.some(ik => {
+            if (['tag','tags','image','date','excerpt','location','title','version','versionLabel','ai','draft'].includes(ik)) {
+              simplifiedHasEmbeddedMeta = true;
+              return false;
+            }
+            return !looksLikeLang(ik);
+          })) { isUnified = true; break; }
         }
       }
-      
+
       if (isSimplified) {
         // Handle simplified format - load metadata from front matter
         const current = getCurrentLang();
-        const { entries, availableLangs } = await loadContentFromFrontMatter(obj, current);
+        const handler = simplifiedHasEmbeddedMeta
+          ? loadContentFromSimplifiedMetadata
+          : loadContentFromFrontMatter;
+        const { entries, availableLangs } = await handler(obj, current);
         __setContentLangs(availableLangs);
         return entries;
       }

--- a/wwwroot/index.yaml
+++ b/wwwroot/index.yaml
@@ -1,8 +1,52 @@
 # yaml-language-server: $schema=../assets/schema/index.json
-
 hello_world:
-  en: post/main_en.md
-  zh: post/main_zh.md
-  zh-tw: post/main_zh-tw.md
-  zh-hk: post/main_zh-hk.md
-  ja: post/main_ja.md
+  en:
+    location: post/main_en.md
+    title: Hello, World!
+    date: 2025-08-23
+    excerpt: Hello, World!
+    tag:
+      - NanoSite
+    version: v1.0
+    ai: true
+    draft: true
+  zh:
+    location: post/main_zh.md
+    title: 你好，世界！
+    date: 2025-08-23
+    excerpt: 你好，世界！
+    tag:
+      - NanoSite
+    version: v1.0
+    ai: true
+    draft: true
+  zh-tw:
+    location: post/main_zh-tw.md
+    title: 你好，世界！
+    date: 2025-08-23
+    excerpt: 你好，世界！
+    tag:
+      - NanoSite
+    version: v1.0
+    ai: true
+    draft: true
+  zh-hk:
+    location: post/main_zh-hk.md
+    title: 你好，世界！
+    date: 2025-08-23
+    excerpt: 你好，世界！
+    tag:
+      - NanoSite
+    version: v1.0
+    ai: true
+    draft: true
+  ja:
+    location: post/main_ja.md
+    title: こんにちは、世界！
+    date: 2025-08-23
+    excerpt: こんにちは、世界！
+    tag:
+      - NanoSite
+    version: v1.0
+    ai: true
+    draft: true


### PR DESCRIPTION
This PR introduces and refines support for simplified/embedded metadata in content entries:

- **Support embedded content metadata** – allow entries to carry metadata directly instead of always reading front-matter.  
- **Limit fallback metadata to selected bucket** – avoid merging data across all language buckets before resolving the actual one in use.  
- **Fix per-entry fallback** – when some entries lack embedded metadata, gracefully fall back to their own front-matter rather than disabling it globally.  
- **Correct reserved key detection** – ensure simplified metadata parser distinguishes between real metadata fields and reserved keys.  

Also merges the follow-up update from `codex/update-content-index-con…` branch, cleaning up detection logic for the content index.