### PR TITLE
chore: add local config overrides and main guard

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -1,0 +1,19 @@
+name: Main Guard
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Enforce main safety rules
+        run: |
+          bash scripts/check-main-safety.sh "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .DS_Store
 .vscode/
+
+# Local-only development sandbox
+site.local.yaml
+site.local.yml
+wwwroot.local/

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -1,0 +1,50 @@
+# Branching Strategy
+
+This repository uses a three-layer branch model to keep development and release clean.
+
+## Branch Roles
+
+- `main`: stable and releasable template branch for users to fork.
+- `next`: integration branch for ongoing development (replace the current long-lived `v2` usage).
+- `feat/*`: short-lived feature branches, merged into `next`.
+
+Recommended migration:
+
+1. Keep `main` as the default branch.
+2. Treat current `v2` as `next` (rename when convenient).
+3. Stop using a long-lived `doc` branch for documentation hosting.
+
+## Documentation Rule
+
+- Documentation should live in tracked content folders on `main`, for example:
+  - `wwwroot/post/doc/v1.0.0/*`
+  - `wwwroot/post/doc/v2.1.0/*`
+- This keeps docs versioned with code and removes cross-branch merge complexity.
+
+## Merge Flow
+
+1. Start work from `next` to `feat/<topic>`.
+2. Merge `feat/*` into `next` via PR.
+3. Periodically merge `next` into `main` when ready for release.
+4. Never merge `sandbox/*` branches into `main`.
+
+## Local Testing Data Isolation
+
+Use local-only config and content root:
+
+1. Create `site.local.yaml` (ignored by git).
+   Use `site.local.example.yaml` as a template.
+2. Set `contentRoot: wwwroot.local`.
+3. Put test content under `wwwroot.local/` (ignored by git).
+
+`site.local.yaml` is loaded before `site.yaml`, so local testing does not require editing tracked release config.
+
+## Main Protection Rules
+
+PRs targeting `main` must pass the `Main Guard` workflow:
+
+- Reject local-only files:
+  - `site.local.yaml`
+  - `site.local.yml`
+  - `wwwroot.local/**`
+- Ensure `site.yaml` has `contentRoot: wwwroot`.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Create your own site using **GitHub Template**:
 
 > You can also fork the project, but keep in mind that syncing updates may require resolving conflicts, especially with data files.
 
+## 🌿 Branching & Local Development
+
+- Branching model and merge policy: see [BRANCHING.md](BRANCHING.md).
+- `main` is stable/release-ready; active development should go through `next` + `feat/*`.
+- For local testing data, copy `site.local.example.yaml` to `site.local.yaml`, then use `contentRoot: wwwroot.local` (both are git-ignored).
+
 ## 📝 Roadmap
 
 - [ ] Add HTML tags support  

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -5,6 +5,7 @@ import {
   fetchSiteLocalOverride,
   fetchTrackedSiteConfig,
   mergeYamlConfig,
+  resolveSiteRepoConfig,
   parseYAML
 } from './yaml.js';
 import { t, getAvailableLangs, getLanguageLabel } from './i18n.js';
@@ -5513,25 +5514,10 @@ async function waitForRemotePropagation(files = []) {
 
 function getActiveSiteRepoConfig() {
   const site = getStateSlice('site');
-  const repo = site && typeof site === 'object' && site.repo && typeof site.repo === 'object'
-    ? site.repo
-    : null;
   const fallback = window.__ns_site_repo && typeof window.__ns_site_repo === 'object'
     ? window.__ns_site_repo
     : {};
-  const ownerRaw = repo && Object.prototype.hasOwnProperty.call(repo, 'owner')
-    ? repo.owner
-    : fallback.owner;
-  const nameRaw = repo && Object.prototype.hasOwnProperty.call(repo, 'name')
-    ? repo.name
-    : fallback.name;
-  const branchRaw = repo && Object.prototype.hasOwnProperty.call(repo, 'branch')
-    ? repo.branch
-    : fallback.branch;
-  const owner = String(ownerRaw || '').trim();
-  const name = String(nameRaw || '').trim();
-  const branch = String(branchRaw || '').trim() || 'main';
-  return { owner, name, branch };
+  return resolveSiteRepoConfig(site, composerSiteLocalOverride, fallback);
 }
 
 function applyLocalPostCommitState(files = []) {

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -7609,7 +7609,7 @@ async function handleComposerRefresh(btn) {
     const contentRoot = getContentRootSafe();
     const fileBase = target === 'tabs' ? 'tabs' : target === 'site' ? 'site' : 'index';
     const urls = target === 'site'
-      ? ['site.yaml', 'site.yml']
+      ? ['site.local.yaml', 'site.local.yml', 'site.yaml', 'site.yml']
       : [`${contentRoot}/${fileBase}.yaml`, `${contentRoot}/${fileBase}.yml`];
     const remote = await fetchConfigWithYamlFallback(urls);
     let prepared;
@@ -8297,7 +8297,7 @@ async function handleComposerDiscard(btn) {
       const contentRoot = getContentRootSafe();
       const fileBase = target === 'tabs' ? 'tabs' : target === 'site' ? 'site' : 'index';
       const urls = target === 'site'
-        ? ['site.yaml', 'site.yml']
+        ? ['site.local.yaml', 'site.local.yml', 'site.yaml', 'site.yml']
         : [`${contentRoot}/${fileBase}.yaml`, `${contentRoot}/${fileBase}.yml`];
       const remote = await fetchConfigWithYamlFallback(urls);
       if (remote != null) {
@@ -11442,7 +11442,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const state = { index: {}, tabs: {}, site: {} };
   showStatus(t('editor.composer.statusMessages.loadingConfig'));
   try {
-    const site = await fetchConfigWithYamlFallback(['site.yaml', 'site.yml']);
+    const site = await fetchConfigWithYamlFallback(['site.local.yaml', 'site.local.yml', 'site.yaml', 'site.yml']);
     const root = (site && site.contentRoot) ? String(site.contentRoot) : 'wwwroot';
     window.__ns_content_root = root; // hint for other utils
     try {

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -1,6 +1,12 @@
 import './cache-control.js';
 import { getManualMarkdownSaveState, normalizeMarkdownDraftContent } from './composer-markdown-save.js';
-import { fetchConfigWithYamlFallback, parseYAML } from './yaml.js';
+import {
+  fetchConfigWithYamlFallback,
+  fetchSiteLocalOverride,
+  fetchTrackedSiteConfig,
+  mergeYamlConfig,
+  parseYAML
+} from './yaml.js';
 import { t, getAvailableLangs, getLanguageLabel } from './i18n.js';
 import { generateSitemapData, resolveSiteBaseUrl } from './seo.js';
 import { initSystemUpdates, getSystemUpdateSummaryEntries, getSystemUpdateCommitFiles, clearSystemUpdateState } from './system-updates.js';
@@ -143,6 +149,7 @@ let cachedFineGrainedTokenMemory = '';
 
 let activeComposerState = null;
 let remoteBaseline = { index: null, tabs: null, site: null };
+let composerSiteLocalOverride = {};
 let composerDiffCache = { index: null, tabs: null, site: null };
 let composerDraftMeta = { index: null, tabs: null, site: null };
 let composerAutoSaveTimers = { index: null, tabs: null, site: null };
@@ -164,6 +171,35 @@ const composerListTransitions = new WeakMap();
 const composerOrderMainTransitions = new WeakMap();
 let composerSiteScrollAnimationId = null;
 let composerSiteScrollCleanup = null;
+
+function applyComposerEffectiveSiteConfig(siteConfig) {
+  const tracked = siteConfig && typeof siteConfig === 'object' ? siteConfig : {};
+  const effective = mergeYamlConfig(tracked, composerSiteLocalOverride);
+  const root = (effective && effective.contentRoot) ? String(effective.contentRoot) : 'wwwroot';
+  try {
+    window.__ns_content_root = root;
+  } catch (_) {}
+  try {
+    const repo = (effective && effective.repo) || {};
+    window.__ns_site_repo = {
+      owner: String(repo.owner || ''),
+      name: String(repo.name || ''),
+      branch: String(repo.branch || 'main')
+    };
+  } catch (_) {
+    try {
+      window.__ns_site_repo = { owner: '', name: '', branch: 'main' };
+    } catch (_) {}
+  }
+  return effective;
+}
+
+async function fetchComposerTrackedSiteConfig() {
+  const tracked = await fetchTrackedSiteConfig();
+  composerSiteLocalOverride = await fetchSiteLocalOverride();
+  applyComposerEffectiveSiteConfig(tracked || {});
+  return tracked || {};
+}
 
 const SITE_FIELD_LABEL_MAP = {
   siteTitle: { i18nKey: 'editor.composer.site.fields.siteTitle' },
@@ -5520,15 +5556,12 @@ function applyLocalPostCommitState(files = []) {
       remoteBaseline.site = snapshot;
 
       const previousRoot = getContentRootSafe();
-      const rawNextRoot = snapshot && typeof snapshot === 'object' && Object.prototype.hasOwnProperty.call(snapshot, 'contentRoot')
-        ? safeString(snapshot.contentRoot)
+      const effectiveSnapshot = applyComposerEffectiveSiteConfig(snapshot);
+      const rawNextRoot = effectiveSnapshot && typeof effectiveSnapshot === 'object' && Object.prototype.hasOwnProperty.call(effectiveSnapshot, 'contentRoot')
+        ? safeString(effectiveSnapshot.contentRoot)
         : '';
-      const storedNextRoot = rawNextRoot ? rawNextRoot : 'wwwroot';
-      const normalizedNextRoot = storedNextRoot.trim().replace(/[\\]/g, '/').replace(/\/?$/, '');
+      const normalizedNextRoot = (rawNextRoot ? rawNextRoot : 'wwwroot').trim().replace(/[\\]/g, '/').replace(/\/?$/, '');
       const rootChanged = normalizedNextRoot !== previousRoot;
-      try {
-        window.__ns_content_root = storedNextRoot;
-      } catch (_) { /* noop */ }
 
       notifyComposerChange('site', { skipAutoSave: true });
       clearDraftStorage('site');
@@ -7610,10 +7643,9 @@ async function handleComposerRefresh(btn) {
     }
     const contentRoot = getContentRootSafe();
     const fileBase = target === 'tabs' ? 'tabs' : target === 'site' ? 'site' : 'index';
-    const urls = target === 'site'
-      ? ['site.local.yaml', 'site.local.yml', 'site.yaml', 'site.yml']
-      : [`${contentRoot}/${fileBase}.yaml`, `${contentRoot}/${fileBase}.yml`];
-    const remote = await fetchConfigWithYamlFallback(urls);
+    const remote = target === 'site'
+      ? await fetchComposerTrackedSiteConfig()
+      : await fetchConfigWithYamlFallback([`${contentRoot}/${fileBase}.yaml`, `${contentRoot}/${fileBase}.yml`]);
     let prepared;
     if (target === 'tabs') prepared = prepareTabsState(remote || {});
     else if (target === 'site') prepared = cloneSiteState(prepareSiteState(remote || {}));
@@ -7624,6 +7656,7 @@ async function handleComposerRefresh(btn) {
     const hadLocalChanges = diffBefore && diffBefore.hasChanges;
     if (!hadLocalChanges) {
       setStateSlice(target, deepClone(prepared));
+      if (target === 'site') applyComposerEffectiveSiteConfig(prepared);
       if (target === 'tabs') rebuildTabsUI();
       else if (target === 'site') rebuildSiteUI();
       else rebuildIndexUI();
@@ -8298,10 +8331,9 @@ async function handleComposerDiscard(btn) {
     try {
       const contentRoot = getContentRootSafe();
       const fileBase = target === 'tabs' ? 'tabs' : target === 'site' ? 'site' : 'index';
-      const urls = target === 'site'
-        ? ['site.local.yaml', 'site.local.yml', 'site.yaml', 'site.yml']
-        : [`${contentRoot}/${fileBase}.yaml`, `${contentRoot}/${fileBase}.yml`];
-      const remote = await fetchConfigWithYamlFallback(urls);
+      const remote = target === 'site'
+        ? await fetchComposerTrackedSiteConfig()
+        : await fetchConfigWithYamlFallback([`${contentRoot}/${fileBase}.yaml`, `${contentRoot}/${fileBase}.yml`]);
       if (remote != null) {
         if (target === 'tabs') prepared = prepareTabsState(remote);
         else if (target === 'site') prepared = cloneSiteState(prepareSiteState(remote));
@@ -8321,6 +8353,7 @@ async function handleComposerDiscard(btn) {
     const normalized = target === 'site' ? cloneSiteState(prepared) : deepClone(prepared);
     remoteBaseline[target] = target === 'site' ? cloneSiteState(prepared) : deepClone(prepared);
     setStateSlice(target, normalized);
+    if (target === 'site') applyComposerEffectiveSiteConfig(normalized);
 
     if (composerAutoSaveTimers[target]) {
       clearTimeout(composerAutoSaveTimers[target]);
@@ -11429,13 +11462,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   const state = { index: {}, tabs: {}, site: {} };
   showStatus(t('editor.composer.statusMessages.loadingConfig'));
   try {
-    const site = await fetchConfigWithYamlFallback(['site.local.yaml', 'site.local.yml', 'site.yaml', 'site.yml']);
-    const root = (site && site.contentRoot) ? String(site.contentRoot) : 'wwwroot';
-    window.__ns_content_root = root; // hint for other utils
-    try {
-      const repo = (site && site.repo) || {};
-      window.__ns_site_repo = { owner: String(repo.owner || ''), name: String(repo.name || ''), branch: String(repo.branch || 'main') };
-    } catch(_) { window.__ns_site_repo = { owner: '', name: '', branch: 'main' }; }
+    const site = await fetchComposerTrackedSiteConfig();
+    const effectiveSite = applyComposerEffectiveSiteConfig(site);
+    const root = (effectiveSite && effectiveSite.contentRoot) ? String(effectiveSite.contentRoot) : 'wwwroot';
     updateMarkdownPushButton(getActiveDynamicTab());
     const remoteSite = prepareSiteState(site || {});
     const [idx, tbs] = await Promise.all([
@@ -11463,6 +11492,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   activeComposerState = state;
   const restoredDrafts = loadDraftSnapshotsIntoState(state);
+  applyComposerEffectiveSiteConfig(state.site);
+  updateMarkdownPushButton(getActiveDynamicTab());
 
   if (restoredDrafts.length) {
     const label = restoredDrafts.map(k => (k === 'tabs' ? 'tabs.yaml' : k === 'site' ? 'site.yaml' : 'index.yaml')).join(' & ');

--- a/assets/js/editor-github.js
+++ b/assets/js/editor-github.js
@@ -1,5 +1,5 @@
 import './cache-control.js';
-import { fetchConfigWithYamlFallback } from './yaml.js';
+import { fetchMergedSiteConfig } from './yaml.js';
 import { t } from './i18n.js';
 
 function setStatus(state, repoText, messageText) {
@@ -58,7 +58,7 @@ async function initGithubStatus() {
       t('editor.github.status.loadingRepo'),
       t('editor.github.status.readingConfig')
     );
-    const cfg = await fetchConfigWithYamlFallback(['site.local.yaml', 'site.local.yml', 'site.yaml', 'site.yml']);
+    const cfg = await fetchMergedSiteConfig();
     const repo = (cfg && cfg.repo) || {};
     const owner = String(repo.owner || '').trim();
     const name = String(repo.name || '').trim();

--- a/assets/js/editor-github.js
+++ b/assets/js/editor-github.js
@@ -58,7 +58,7 @@ async function initGithubStatus() {
       t('editor.github.status.loadingRepo'),
       t('editor.github.status.readingConfig')
     );
-    const cfg = await fetchConfigWithYamlFallback(['site.yaml', 'site.yml']);
+    const cfg = await fetchConfigWithYamlFallback(['site.local.yaml', 'site.local.yml', 'site.yaml', 'site.yml']);
     const repo = (cfg && cfg.repo) || {};
     const owner = String(repo.owner || '').trim();
     const name = String(repo.name || '').trim();
@@ -152,4 +152,3 @@ async function initGithubStatus() {
 
 // Kick on load
 try { initGithubStatus(); } catch (_) {}
-

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -16,7 +16,7 @@ import { initSyntaxHighlighting } from './syntax-highlight.js';
 import { applyLazyLoadingIn, hydratePostImages, hydratePostVideos } from './post-render.js';
 import { hydrateInternalLinkCards } from './link-cards.js';
 import { applyLangHints } from './typography.js';
-import { fetchConfigWithYamlFallback } from './yaml.js';
+import { fetchConfigWithYamlFallback, fetchMergedSiteConfig } from './yaml.js';
 import { t, withLangParam, loadContentJson, getCurrentLang, normalizeLangKey } from './i18n.js';
 
 const LS_WRAP_KEY = 'ns_editor_wrap_enabled';
@@ -2693,7 +2693,7 @@ document.addEventListener('DOMContentLoaded', () => {
     (async () => {
       try {
         setStatus('Loading site config…');
-        const site = await fetchConfigWithYamlFallback(['site.local.yaml', 'site.local.yml', 'site.yaml', 'site.yml']);
+        const site = await fetchMergedSiteConfig();
         editorSiteConfig = site || {};
         contentRoot = (site && site.contentRoot) ? String(site.contentRoot) : 'wwwroot';
       } catch (_) {

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -2877,7 +2877,7 @@ document.addEventListener('DOMContentLoaded', () => {
     (async () => {
       try {
         setStatus('Loading site config…');
-        const site = await fetchConfigWithYamlFallback(['site.yaml','site.yml']);
+        const site = await fetchConfigWithYamlFallback(['site.local.yaml', 'site.local.yml', 'site.yaml', 'site.yml']);
         editorSiteConfig = site || {};
         contentRoot = (site && site.contentRoot) ? String(site.contentRoot) : 'wwwroot';
       } catch (_) {

--- a/assets/js/yaml.js
+++ b/assets/js/yaml.js
@@ -229,6 +229,28 @@ export function mergeYamlConfig(base, override) {
   return out;
 }
 
+export function resolveSiteRepoConfig(siteConfig, localOverride = null, fallback = null) {
+  const effective = localOverride && isPlainObject(localOverride)
+    ? mergeYamlConfig(siteConfig, localOverride)
+    : (isPlainObject(siteConfig) ? cloneYamlValue(siteConfig) : {});
+  const repo = isPlainObject(effective.repo) ? effective.repo : {};
+  const fallbackRepo = isPlainObject(fallback) ? fallback : {};
+  const ownerRaw = Object.prototype.hasOwnProperty.call(repo, 'owner')
+    ? repo.owner
+    : fallbackRepo.owner;
+  const nameRaw = Object.prototype.hasOwnProperty.call(repo, 'name')
+    ? repo.name
+    : fallbackRepo.name;
+  const branchRaw = Object.prototype.hasOwnProperty.call(repo, 'branch')
+    ? repo.branch
+    : fallbackRepo.branch;
+  return {
+    owner: String(ownerRaw || '').trim(),
+    name: String(nameRaw || '').trim(),
+    branch: String(branchRaw || '').trim() || 'main'
+  };
+}
+
 export async function fetchTrackedSiteConfig() {
   return await fetchConfigWithYamlFallback(['site.yaml', 'site.yml']);
 }

--- a/assets/js/yaml.js
+++ b/assets/js/yaml.js
@@ -32,6 +32,22 @@ function indentOf(line) {
   return n;
 }
 
+function isPlainObject(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneYamlValue(value) {
+  if (Array.isArray(value)) return value.map(cloneYamlValue);
+  if (isPlainObject(value)) {
+    const out = {};
+    Object.keys(value).forEach((key) => {
+      out[key] = cloneYamlValue(value[key]);
+    });
+    return out;
+  }
+  return value;
+}
+
 function parseScalar(raw) {
   const s = stripInlineComment(String(raw).trim());
   if (s === '' || s === '~' || /^null$/i.test(s)) return null;
@@ -195,4 +211,36 @@ export async function fetchConfigWithYamlFallback(names) {
     } catch (_) { /* try next */ }
   }
   return {};
+}
+
+export function mergeYamlConfig(base, override) {
+  const baseObj = isPlainObject(base) ? base : {};
+  const overrideObj = isPlainObject(override) ? override : {};
+  const out = cloneYamlValue(baseObj);
+  Object.keys(overrideObj).forEach((key) => {
+    const baseValue = out[key];
+    const overrideValue = overrideObj[key];
+    if (isPlainObject(baseValue) && isPlainObject(overrideValue)) {
+      out[key] = mergeYamlConfig(baseValue, overrideValue);
+    } else {
+      out[key] = cloneYamlValue(overrideValue);
+    }
+  });
+  return out;
+}
+
+export async function fetchTrackedSiteConfig() {
+  return await fetchConfigWithYamlFallback(['site.yaml', 'site.yml']);
+}
+
+export async function fetchSiteLocalOverride() {
+  return await fetchConfigWithYamlFallback(['site.local.yaml', 'site.local.yml']);
+}
+
+export async function fetchMergedSiteConfig(baseConfig = null) {
+  const tracked = baseConfig && isPlainObject(baseConfig)
+    ? baseConfig
+    : await fetchTrackedSiteConfig();
+  const localOverride = await fetchSiteLocalOverride();
+  return mergeYamlConfig(tracked, localOverride);
 }

--- a/assets/main.js
+++ b/assets/main.js
@@ -282,7 +282,7 @@ try { window.__ns_posts_enabled = () => postsEnabled(); } catch (_) {}
 async function loadSiteConfig() {
   try {
     // YAML only
-    return await fetchConfigWithYamlFallback(['site.yaml', 'site.yml']);
+    return await fetchConfigWithYamlFallback(['site.local.yaml', 'site.local.yml', 'site.yaml', 'site.yml']);
   } catch (_) { return {}; }
 }
 

--- a/assets/main.js
+++ b/assets/main.js
@@ -20,7 +20,7 @@ import {
 import { updateSEO, extractSEOFromMarkdown } from './js/seo.js';
 import { initErrorReporter, setReporterContext, showErrorOverlay } from './js/errors.js';
 import { initSyntaxHighlighting } from './js/syntax-highlight.js';
-import { fetchConfigWithYamlFallback } from './js/yaml.js';
+import { fetchConfigWithYamlFallback, fetchMergedSiteConfig } from './js/yaml.js';
 import { applyMasonry, updateMasonryItem, calcAndSetSpan, toPx, debounce } from './js/masonry.js';
 import { aggregateTags, renderTagSidebar, setupTagTooltips } from './js/tags.js';
 import { renderPostNav } from './js/post-nav.js';
@@ -282,7 +282,7 @@ try { window.__ns_posts_enabled = () => postsEnabled(); } catch (_) {}
 async function loadSiteConfig() {
   try {
     // YAML only
-    return await fetchConfigWithYamlFallback(['site.local.yaml', 'site.local.yml', 'site.yaml', 'site.yml']);
+    return await fetchMergedSiteConfig();
   } catch (_) { return {}; }
 }
 

--- a/assets/main.js
+++ b/assets/main.js
@@ -20,7 +20,7 @@ import {
 import { updateSEO, extractSEOFromMarkdown } from './js/seo.js';
 import { initErrorReporter, setReporterContext, showErrorOverlay } from './js/errors.js';
 import { initSyntaxHighlighting } from './js/syntax-highlight.js';
-import { fetchConfigWithYamlFallback, fetchMergedSiteConfig } from './js/yaml.js';
+import { fetchConfigWithYamlFallback } from './js/yaml.js';
 import { applyMasonry, updateMasonryItem, calcAndSetSpan, toPx, debounce } from './js/masonry.js';
 import { aggregateTags, renderTagSidebar, setupTagTooltips } from './js/tags.js';
 import { renderPostNav } from './js/post-nav.js';
@@ -282,7 +282,7 @@ try { window.__ns_posts_enabled = () => postsEnabled(); } catch (_) {}
 async function loadSiteConfig() {
   try {
     // YAML only
-    return await fetchMergedSiteConfig();
+    return await fetchConfigWithYamlFallback(['site.yaml', 'site.yml']);
   } catch (_) { return {}; }
 }
 

--- a/scripts/check-main-safety.sh
+++ b/scripts/check-main-safety.sh
@@ -5,12 +5,12 @@ BASE_REF="${1:-}"
 HEAD_REF="${2:-HEAD}"
 
 if [[ -n "$BASE_REF" ]]; then
-  changed_files="$(git diff --name-only "$BASE_REF" "$HEAD_REF")"
+  changed_files="$(git diff --diff-filter=ACMRTUXB --name-only "$BASE_REF" "$HEAD_REF")"
 else
   if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
-    changed_files="$(git diff --name-only HEAD~1 "$HEAD_REF")"
+    changed_files="$(git diff --diff-filter=ACMRTUXB --name-only HEAD~1 "$HEAD_REF")"
   else
-    changed_files="$(git diff --name-only)"
+    changed_files="$(git diff --diff-filter=ACMRTUXB --name-only)"
   fi
 fi
 

--- a/scripts/check-main-safety.sh
+++ b/scripts/check-main-safety.sh
@@ -33,7 +33,7 @@ if [[ ! -f "site.yaml" ]]; then
 else
   content_root="$(
     awk -F: '
-      /^[[:space:]]*contentRoot[[:space:]]*:/ {
+      /^contentRoot[[:space:]]*:/ {
         value=$2;
         sub(/[[:space:]]+#.*/, "", value);
         gsub(/^[[:space:]]+|[[:space:]]+$/, "", value);

--- a/scripts/check-main-safety.sh
+++ b/scripts/check-main-safety.sh
@@ -3,13 +3,38 @@ set -euo pipefail
 
 BASE_REF="${1:-}"
 HEAD_REF="${2:-HEAD}"
+BLOCKED_PATH_PATTERN='^(wwwroot\.local/|site\.local\.ya?ml$)'
+
+list_blocked_history_paths() {
+  local range_base="$1"
+  local range_head="$2"
+  local commit=""
+  while IFS= read -r commit; do
+    [[ -n "${commit}" ]] || continue
+    while IFS=$'\t' read -r status path_a path_b; do
+      [[ -n "${status}" ]] || continue
+      local candidate=""
+      case "${status}" in
+        D*) continue ;;
+        R*|C*) candidate="${path_b:-}" ;;
+        *) candidate="${path_a:-}" ;;
+      esac
+      if [[ -n "${candidate}" ]] && [[ "${candidate}" =~ ${BLOCKED_PATH_PATTERN} ]]; then
+        printf '%s\t%s\t%s\n' "${commit}" "${status}" "${candidate}"
+      fi
+    done < <(git diff-tree --root --no-commit-id --name-status -r -m -M -C "${commit}")
+  done < <(git rev-list --reverse --ancestry-path "${range_base}..${range_head}")
+}
 
 if [[ -n "$BASE_REF" ]]; then
-  changed_files="$(git diff --diff-filter=ACMRTUXB --name-only "$BASE_REF" "$HEAD_REF")"
+  range_base="$(git merge-base "$BASE_REF" "$HEAD_REF")"
+  changed_files="$(git diff --diff-filter=ACMRTUXB --name-only "${range_base}" "$HEAD_REF")"
 else
   if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    range_base="HEAD~1"
     changed_files="$(git diff --diff-filter=ACMRTUXB --name-only HEAD~1 "$HEAD_REF")"
   else
+    range_base=""
     changed_files="$(git diff --diff-filter=ACMRTUXB --name-only)"
   fi
 fi
@@ -18,8 +43,15 @@ echo "Running main safety checks..."
 
 failed=0
 
-if [[ -n "${changed_files}" ]]; then
-  blocked_matches="$(printf '%s\n' "${changed_files}" | grep -E '^(wwwroot\.local/|site\.local\.ya?ml$)' || true)"
+if [[ -n "${range_base}" ]]; then
+  blocked_history="$(list_blocked_history_paths "${range_base}" "$HEAD_REF" || true)"
+  if [[ -n "${blocked_history}" ]]; then
+    echo "ERROR: local-only files were added or modified in this commit range:"
+    printf '%s\n' "${blocked_history}"
+    failed=1
+  fi
+elif [[ -n "${changed_files}" ]]; then
+  blocked_matches="$(printf '%s\n' "${changed_files}" | grep -E "${BLOCKED_PATH_PATTERN}" || true)"
   if [[ -n "${blocked_matches}" ]]; then
     echo "ERROR: local-only files detected in this change set:"
     printf '%s\n' "${blocked_matches}"

--- a/scripts/check-main-safety.sh
+++ b/scripts/check-main-safety.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${1:-}"
+HEAD_REF="${2:-HEAD}"
+
+if [[ -n "$BASE_REF" ]]; then
+  changed_files="$(git diff --name-only "$BASE_REF" "$HEAD_REF")"
+else
+  if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    changed_files="$(git diff --name-only HEAD~1 "$HEAD_REF")"
+  else
+    changed_files="$(git diff --name-only)"
+  fi
+fi
+
+echo "Running main safety checks..."
+
+failed=0
+
+if [[ -n "${changed_files}" ]]; then
+  blocked_matches="$(printf '%s\n' "${changed_files}" | grep -E '^(wwwroot\.local/|site\.local\.ya?ml$)' || true)"
+  if [[ -n "${blocked_matches}" ]]; then
+    echo "ERROR: local-only files detected in this change set:"
+    printf '%s\n' "${blocked_matches}"
+    failed=1
+  fi
+fi
+
+if [[ ! -f "site.yaml" ]]; then
+  echo "ERROR: site.yaml is missing."
+  failed=1
+else
+  content_root="$(
+    awk -F: '
+      /^[[:space:]]*contentRoot[[:space:]]*:/ {
+        value=$2;
+        sub(/[[:space:]]+#.*/, "", value);
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", value);
+        gsub(/^["'"'"']|["'"'"']$/, "", value);
+        print value;
+        exit;
+      }
+    ' site.yaml
+  )"
+
+  if [[ -z "${content_root}" ]]; then
+    echo "ERROR: site.yaml must define contentRoot."
+    failed=1
+  elif [[ "${content_root}" != "wwwroot" ]]; then
+    echo "ERROR: site.yaml contentRoot must be \"wwwroot\" for main releases (current: \"${content_root}\")."
+    failed=1
+  fi
+fi
+
+if [[ "${failed}" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "Main safety checks passed."

--- a/scripts/test-frontmatter-roundtrip.js
+++ b/scripts/test-frontmatter-roundtrip.js
@@ -9,7 +9,7 @@ import {
 import { getManualMarkdownSaveState } from '../assets/js/composer-markdown-save.js';
 import { parseFrontMatter } from '../assets/js/content.js';
 import { insertImageMarkdownAtSelection, normalizeDateInputValue } from '../assets/js/editor-markdown-ops.js';
-import { mergeYamlConfig } from '../assets/js/yaml.js';
+import { mergeYamlConfig, resolveSiteRepoConfig } from '../assets/js/yaml.js';
 
 const ensureKeyOrder = (order = [], key) => {
   if (!key) return order;
@@ -439,5 +439,21 @@ run('local site overrides merge nested config objects recursively', () => {
   assert.deepEqual(merged, {
     repo: { owner: 'deemoe404', name: 'NanoSite', branch: 'dev' },
     seo: { title: 'NanoSite Local', keywords: ['nano', 'site'] }
+  });
+});
+
+run('site repo resolution merges local overrides over tracked composer state', () => {
+  const resolved = resolveSiteRepoConfig(
+    {
+      repo: { owner: 'deemoe404', name: 'NanoSite', branch: 'main' }
+    },
+    {
+      repo: { branch: 'dev' }
+    }
+  );
+  assert.deepEqual(resolved, {
+    owner: 'deemoe404',
+    name: 'NanoSite',
+    branch: 'dev'
   });
 });

--- a/scripts/test-frontmatter-roundtrip.js
+++ b/scripts/test-frontmatter-roundtrip.js
@@ -9,6 +9,7 @@ import {
 import { getManualMarkdownSaveState } from '../assets/js/composer-markdown-save.js';
 import { parseFrontMatter } from '../assets/js/content.js';
 import { insertImageMarkdownAtSelection, normalizeDateInputValue } from '../assets/js/editor-markdown-ops.js';
+import { mergeYamlConfig } from '../assets/js/yaml.js';
 
 const ensureKeyOrder = (order = [], key) => {
   if (!key) return order;
@@ -405,5 +406,38 @@ run('manual markdown save requires dirty non-empty content', () => {
     canSave: true,
     content: 'Body\nparagraph.\n',
     reason: 'default'
+  });
+});
+
+run('local site overrides merge into tracked site config without dropping fields', () => {
+  const merged = mergeYamlConfig(
+    {
+      contentRoot: 'wwwroot',
+      themePack: 'paper',
+      repo: { owner: 'deemoe404', name: 'NanoSite', branch: 'main' }
+    },
+    { contentRoot: 'wwwroot.local' }
+  );
+  assert.deepEqual(merged, {
+    contentRoot: 'wwwroot.local',
+    themePack: 'paper',
+    repo: { owner: 'deemoe404', name: 'NanoSite', branch: 'main' }
+  });
+});
+
+run('local site overrides merge nested config objects recursively', () => {
+  const merged = mergeYamlConfig(
+    {
+      repo: { owner: 'deemoe404', name: 'NanoSite', branch: 'main' },
+      seo: { title: 'NanoSite', keywords: ['nano', 'site'] }
+    },
+    {
+      repo: { branch: 'dev' },
+      seo: { title: 'NanoSite Local' }
+    }
+  );
+  assert.deepEqual(merged, {
+    repo: { owner: 'deemoe404', name: 'NanoSite', branch: 'dev' },
+    seo: { title: 'NanoSite Local', keywords: ['nano', 'site'] }
   });
 });

--- a/scripts/test-main-guard.sh
+++ b/scripts/test-main-guard.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+cd "${tmp_dir}"
+git init -q
+git config user.email "test@example.com"
+git config user.name "NanoSite Test"
+
+cat > site.yaml <<'EOF'
+nested:
+  contentRoot: wrong
+contentRoot: wwwroot
+EOF
+
+"${repo_root}/scripts/check-main-safety.sh" >/dev/null
+
+cat > site.yaml <<'EOF'
+nested:
+  contentRoot: wrong
+contentRoot: wwwroot.local
+EOF
+
+if "${repo_root}/scripts/check-main-safety.sh" >/dev/null 2>&1; then
+  echo "expected main guard to reject non-wwwroot top-level contentRoot" >&2
+  exit 1
+fi

--- a/scripts/test-main-guard.sh
+++ b/scripts/test-main-guard.sh
@@ -50,3 +50,18 @@ git commit -qm "remove forbidden local override"
 base_ref="$(git rev-parse HEAD~1)"
 head_ref="$(git rev-parse HEAD)"
 "${repo_root}/scripts/check-main-safety.sh" "${base_ref}" "${head_ref}" >/dev/null
+
+cat > site.local.yaml <<'EOF'
+contentRoot: wwwroot.local
+EOF
+git add site.local.yaml
+git commit -qm "add forbidden local override again"
+
+git rm -q site.local.yaml
+git commit -qm "remove forbidden local override again"
+range_base="$(git rev-parse HEAD~2)"
+range_head="$(git rev-parse HEAD)"
+if "${repo_root}/scripts/check-main-safety.sh" "${range_base}" "${range_head}" >/dev/null 2>&1; then
+  echo "expected main guard to reject commit ranges that temporarily add forbidden files" >&2
+  exit 1
+fi

--- a/scripts/test-main-guard.sh
+++ b/scripts/test-main-guard.sh
@@ -32,3 +32,21 @@ if "${repo_root}/scripts/check-main-safety.sh" >/dev/null 2>&1; then
   echo "expected main guard to reject non-wwwroot top-level contentRoot" >&2
   exit 1
 fi
+
+cat > site.yaml <<'EOF'
+contentRoot: wwwroot
+EOF
+git add site.yaml
+git commit -qm "restore valid top-level content root"
+
+cat > site.local.yaml <<'EOF'
+contentRoot: wwwroot.local
+EOF
+git add site.local.yaml
+git commit -qm "add forbidden local override"
+
+git rm -q site.local.yaml
+git commit -qm "remove forbidden local override"
+base_ref="$(git rev-parse HEAD~1)"
+head_ref="$(git rev-parse HEAD)"
+"${repo_root}/scripts/check-main-safety.sh" "${base_ref}" "${head_ref}" >/dev/null

--- a/site.local.example.yaml
+++ b/site.local.example.yaml
@@ -1,0 +1,3 @@
+# Local override for development only.
+# Copy this file to `site.local.yaml` and adjust values as needed.
+contentRoot: wwwroot.local


### PR DESCRIPTION
## Summary
- add local-only `site.local.yaml` fallback loading before tracked site config files
- add a `Main Guard` workflow plus `scripts/check-main-safety.sh` to keep local-only files out of `main`
- document the branching/local development workflow and add `site.local.example.yaml`

## Testing
- `./scripts/test-frontmatter-roundtrip.sh`
- `bash -n scripts/check-main-safety.sh`
- `node --experimental-default-type=module --check assets/js/composer.js`
- `node --experimental-default-type=module --check assets/js/editor-main.js`
- `node --experimental-default-type=module --check assets/js/editor-github.js`
- `node --experimental-default-type=module --check assets/main.js`