### PR TITLE
[codex] Remove Markdown HTML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,13 @@
 
 ![hero](assets/hero.jpeg)
 
-<p align="center">
-  <b>A zero-build static site system powered by Markdown.</b><br/>
-  This repository is the NanoSite source, official documentation site, and Markdown rendering regression corpus.
-</p>
+**A zero-build static site system powered by Markdown.**
 
-<p align="center">
-  <a href="https://github.com/deemoe404/NanoSite/stargazers">
-    <img src="https://img.shields.io/github/stars/deemoe404/NanoSite?style=social" alt="GitHub stars"/>
-  </a>
-  <a href="https://github.com/deemoe404/NanoSite/blob/main/LICENSE">
-    <img src="https://img.shields.io/github/license/deemoe404/NanoSite" alt="License"/>
-  </a>
-  <a href="https://nano.dee.moe/">
-    <img src="https://img.shields.io/website?url=https%3A%2F%2Fnano.dee.moe&label=docs" alt="Documentation site"/>
-  </a>
-</p>
+This repository is the NanoSite source, official documentation site, and Markdown rendering regression corpus.
+
+[![GitHub stars](https://img.shields.io/github/stars/deemoe404/NanoSite?style=social)](https://github.com/deemoe404/NanoSite/stargazers)
+[![License](https://img.shields.io/github/license/deemoe404/NanoSite)](https://github.com/deemoe404/NanoSite/blob/main/LICENSE)
+[![Documentation site](https://img.shields.io/website?url=https%3A%2F%2Fnano.dee.moe&label=docs)](https://nano.dee.moe/)
 
 ## What This Repository Is
 
@@ -81,7 +72,6 @@ Want to list your site here? Open a PR with the site URL and a one-line descript
 
 ## Roadmap
 
-- Add HTML tag support.
 - Add LaTeX support.
 - Implement comments backed by GitHub Discussions.
 - Publish the minimal `NanoSite-Starter` template repository.

--- a/assets/js/markdown.js
+++ b/assets/js/markdown.js
@@ -1,4 +1,4 @@
-import { escapeHtml, escapeMarkdown, sanitizeUrl, resolveImageSrc, allowUserHtml } from './utils.js';
+import { escapeHtml, escapeMarkdown, sanitizeUrl, resolveImageSrc } from './utils.js';
 import { stripFrontMatter } from './content.js';
 
 function isPipeTableSeparator(line) {
@@ -116,6 +116,10 @@ function replaceInline(text, baseDir) {
   return result
     .replace(/\`(.*?)\`/g, '<code class="inline">$1</code>')
     .replace(/^\s*$/g, '<br>');
+}
+
+function renderInlineText(text, baseDir) {
+  return replaceInline(escapeHtml(String(text || '')), baseDir);
 }
 
 function tocParser(titleLevels, liTags) {
@@ -279,7 +283,7 @@ export function mdParse(markdown, baseDir) {
         }
       } catch (_) {
         // Fallback to plain blockquote rendering on any parsing error
-        try { html += `<blockquote>${mdParse(quote, baseDir).post}</blockquote>`; } catch (_) { html += `<blockquote>${allowUserHtml(quote, baseDir)}</blockquote>`; }
+        try { html += `<blockquote>${mdParse(quote, baseDir).post}</blockquote>`; } catch (_) { html += `<blockquote>${escapeHtml(quote)}</blockquote>`; }
       }
       i = j - 1;
       continue;
@@ -301,7 +305,7 @@ export function mdParse(markdown, baseDir) {
         } else {
           // Not a valid table header, treat as regular paragraph text
           if (!isInPara) { html += '<p>'; isInPara = true; }
-          html += `${replaceInline(allowUserHtml(rawLine, baseDir), baseDir)}`;
+          html += `${renderInlineText(rawLine, baseDir)}`;
           if (i + 1 < lines.length && escapeMarkdown(lines[i + 1]).trim() !== '') html += '<br>';
         }
       } else {
@@ -328,7 +332,7 @@ export function mdParse(markdown, baseDir) {
       closeAllLists();
       closePara();
       if (!isInTodo) { isInTodo = true; html += '<ul class="todo">'; }
-      const taskText = replaceInline(allowUserHtml(rawLine.slice(5).trim(), baseDir), baseDir);
+      const taskText = renderInlineText(rawLine.slice(5).trim(), baseDir);
       html += match[1] === 'x'
         ? `<li><input type="checkbox" id="todo${i}" disabled checked><label for="todo${i}">${taskText}</label></li>`
         : `<li><input type="checkbox" id="todo${i}" disabled><label for="todo${i}">${taskText}</label></li>`;
@@ -377,7 +381,7 @@ export function mdParse(markdown, baseDir) {
         }
       }
       // List item content
-      html += `<li>${replaceInline(allowUserHtml(String(content).trim(), baseDir), baseDir)}</li>`;
+      html += `<li>${renderInlineText(String(content).trim(), baseDir)}</li>`;
       // Continue to next line; we'll close lists when pattern breaks
       const next = (i + 1 < lines.length) ? escapeMarkdown(lines[i + 1]) : '';
       if (!next || (!next.match(/^(\s*)[-*+]\s+(.+)$/) && !next.match(/^(\s*)\d{1,9}[\.)]\s+(.+)$/))) {
@@ -395,7 +399,7 @@ export function mdParse(markdown, baseDir) {
       closeAllLists();
       closePara();
       const level = rawLine.match(/^#+/)[0].length;
-      const text = replaceInline(allowUserHtml(rawLine.slice(level).trim(), baseDir), baseDir);
+      const text = renderInlineText(rawLine.slice(level).trim(), baseDir);
       html += `<h${level} id="${i}"><a class="anchor" href="#${i}" aria-label="Permalink">#</a>${text}</h${level}>`;
       if (level >= 2 && level <= 3) {
         tochtml.push(`<a href="#${i}">${text}</a>`);
@@ -404,69 +408,21 @@ export function mdParse(markdown, baseDir) {
       continue;
     }
 
-    // Treat raw HTML block elements as standalone blocks (and capture their full content until closing tag)
-    {
-      const raw = escapeMarkdown(line);
-      const t = raw.trim();
-      const m = t.match(/^<\/?([a-zA-Z][\w:-]*)\b(.*)>?$/);
-      if (m) {
-        const tag = (m[1] || '').toLowerCase();
-        const isClosing = /^<\//.test(t);
-        const singletons = new Set(['hr','br','img','source','col','meta','link','input']);
-        const blockOpenTags = new Set(['div','section','article','p','blockquote','pre','code','figure','details','table','ul','ol','video','picture','iframe']);
-        const blockAnyTags = new Set(['div','section','article','p','blockquote','pre','code','figure','figcaption','details','summary','table','thead','tbody','tfoot','tr','td','th','ul','ol','li','video','picture','iframe','hr','br','h1','h2','h3','h4','h5','h6']);
-
-        if (blockAnyTags.has(tag)) {
-          // If it's a closing tag or a known singleton, treat as a single line element
-          if (isClosing || singletons.has(tag) || /\/>\s*$/.test(t)) {
-            closeAllLists();
-            closePara();
-            html += allowUserHtml(t, baseDir);
-            continue;
-          }
-          // For open block tags like <table>, <figure>, <details>, <video>, <iframe> — capture until the corresponding closing tag
-          if (blockOpenTags.has(tag)) {
-            let chunk = raw;
-            let j = i + 1;
-            // Search for matching closing tag on subsequent lines (allow nesting of other tags inside)
-            const endRe = new RegExp(`^\\s*<\\/${tag}\\s*>\\s*$`, 'i');
-            for (; j < lines.length; j++) {
-              const nxt = escapeMarkdown(lines[j]);
-              chunk += '\n' + nxt;
-              if (endRe.test(nxt.trim())) { break; }
-            }
-            i = j;
-            closeAllLists();
-            closePara();
-            html += allowUserHtml(chunk, baseDir);
-            continue;
-          } else {
-            // Other block-level tags (thead/tbody/tr/td/etc.) — treat line-by-line without wrapping
-            closeAllLists();
-            closePara();
-            html += allowUserHtml(t, baseDir);
-            continue;
-          }
-        }
-      }
-    }
-
     // Blank line => close paragraph
     if (rawLine.trim() === '') { closeAllLists(); closePara(); continue; }
 
     // Regular paragraph text
     {
-      const lineHtmlRaw = replaceInline(allowUserHtml(rawLine, baseDir), baseDir);
+      const lineHtmlRaw = renderInlineText(rawLine, baseDir);
       const lineHtml = String(lineHtmlRaw || '').trim();
       // Skip lines that render to empty or a single <br>
       if (lineHtml && lineHtml !== '<br>') {
         if (!isInPara) { html += '<p>'; isInPara = true; }
         html += lineHtml;
-        // Add soft line break only when the next line is true text (not blank, not an HTML block start)
+        // Add soft line break when the next line is also paragraph text.
         if (i + 1 < lines.length) {
           const nextTrim = escapeMarkdown(lines[i + 1]).trim();
-          const isNextHtml = /^<([a-zA-Z][\w:-]*)\b/.test(nextTrim);
-          if (nextTrim !== '' && !isNextHtml) html += '<br>';
+          if (nextTrim !== '') html += '<br>';
         }
       }
     }

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -24,7 +24,7 @@ export function escapeMarkdown(text) {
   let result = '';
   for (let i = 0; i < parts.length; i++) {
     if (i % 2 === 0) {
-      let seg = parts[i]
+      const seg = parts[i]
         .replace(/\\\\/g, '&#092;')
         .replace(/\\\*/g, '&#042;')
         .replace(/\\_/g, '&#095;')
@@ -37,15 +37,6 @@ export function escapeMarkdown(text) {
         .replace(/\\\./g, '&#046;')
         .replace(/\\!/g, '&#033;')
         .replace(/\\\|/g, '&#124;');
-      // Robustly strip HTML comments by repeating until stable
-      seg = (function removeHtmlComments(input) {
-        let prev, out = String(input || '');
-        do {
-          prev = out;
-          out = out.replace(/<!--[\s\S]*?-->/g, '');
-        } while (out !== prev);
-        return out;
-      })(seg);
       result += seg;
     } else {
       result += parts[i];
@@ -117,39 +108,40 @@ export function resolveImageSrc(src, baseDir) {
   }
 }
 
-// Allow a safe subset of HTML tags within Markdown content.
-// - Escapes all text outside tags
-// - Keeps only allowlisted tags/attributes
-// - Rewrites relative href/src/srcset relative to the markdown file's folder (baseDir)
-const __NS_ALLOWED_TAGS = new Set([
-  'b','strong','i','em','u','mark','small','sub','sup','kbd','abbr','ins','del',
-  'span','div','section','article','p','br','hr',
-  'blockquote','pre','code','figure','figcaption',
-  'a','img','video','source','picture',
-  'ul','ol','li','table','thead','tbody','tfoot','tr','td','th','colgroup','col',
-  'details','summary',
-  'h1','h2','h3','h4','h5','h6',
-  'iframe'
+// Tags and attributes emitted by the Markdown renderer itself. User-authored
+// tags are escaped before rendering and are not admitted through this path.
+const __NS_RENDERED_MARKDOWN_TAGS = new Set([
+  'a','blockquote','br','code','del','div','em','h1','h2','h3','h4','h5','h6',
+  'hr','img','input','label','li','ol','p','pre','source','span','strong',
+  'table','tbody','td','th','thead','tr','ul','video'
 ]);
-const __NS_VOID_TAGS = new Set(['br','hr','img','source','col','input','meta','link']);
-const __NS_GLOBAL_ATTRS = new Set(['id','class','title','style','role','lang','dir']);
-const __NS_TAG_ATTRS = {
-  a: new Set(['href','target','rel','download']),
-  img: new Set(['src','alt','width','height','loading','decoding','srcset','sizes','referrerpolicy']),
-  video: new Set(['src','controls','autoplay','loop','muted','poster','preload','playsinline','width','height']),
-  source: new Set(['src','type','media','sizes','srcset']),
-  table: new Set(['border','summary']),
-  td: new Set(['colspan','rowspan','headers','scope','align','valign']),
-  th: new Set(['colspan','rowspan','headers','scope','align','valign']),
-  iframe: new Set(['src','width','height','allow','allowfullscreen','loading','referrerpolicy','title'])
+const __NS_RENDERED_MARKDOWN_VOID_TAGS = new Set(['br','hr','img','input','source']);
+const __NS_RENDERED_MARKDOWN_GLOBAL_ATTRS = new Set(['aria-hidden','aria-label','class','data-callout','for','id','role','title']);
+const __NS_RENDERED_MARKDOWN_TAG_ATTRS = {
+  a: new Set(['href']),
+  code: new Set(['class']),
+  div: new Set(['class','data-callout','role']),
+  h1: new Set(['id']),
+  h2: new Set(['id']),
+  h3: new Set(['id']),
+  h4: new Set(['id']),
+  h5: new Set(['id']),
+  h6: new Set(['id']),
+  img: new Set(['alt','src','title']),
+  input: new Set(['checked','disabled','id','type']),
+  label: new Set(['for']),
+  ol: new Set(['start']),
+  pre: new Set(['class']),
+  source: new Set(['src','type']),
+  span: new Set(['aria-hidden','class']),
+  video: new Set(['aria-label','class','controls','playsinline','poster','preload','title'])
 };
 function __ns_isAllowedAttr(tag, attr) {
   if (!attr) return false;
   const a = String(attr).toLowerCase();
-  if (a.startsWith('on')) return false; // no inline handlers
-  if (a.startsWith('data-') || a.startsWith('aria-')) return true;
-  if (__NS_GLOBAL_ATTRS.has(a)) return true;
-  const spec = __NS_TAG_ATTRS[tag];
+  if (a.startsWith('on')) return false;
+  if (__NS_RENDERED_MARKDOWN_GLOBAL_ATTRS.has(a)) return true;
+  const spec = __NS_RENDERED_MARKDOWN_TAG_ATTRS[tag];
   return !!(spec && spec.has(a));
 }
 function __ns_rewriteHref(val, baseDir) {
@@ -168,74 +160,6 @@ function __ns_rewriteSrc(val, baseDir) {
   if (s.startsWith('/')) return s;
   return resolveImageSrc(s, baseDir);
 }
-function __ns_rewriteSrcset(val, baseDir) {
-  const s = String(val || '');
-  if (!s.trim()) return s;
-  try {
-    return s.split(',').map(part => {
-      const seg = part.trim();
-      if (!seg) return '';
-      const bits = seg.split(/\s+/);
-      const url = bits.shift();
-      const rewritten = __ns_rewriteSrc(url, baseDir);
-      return [rewritten, ...bits].join(' ');
-    }).filter(Boolean).join(', ');
-  } catch (_) { return s; }
-}
-function __ns_sanitizeAttrs(tag, rawAttrs, baseDir) {
-  const s = String(rawAttrs || '');
-  let out = '';
-  const re = /([a-zA-Z_:][\w:.-]*)(?:\s*=\s*("([^"]*)"|'([^']*)'|([^\s"'<>`]+)))?/g;
-  let m;
-  while ((m = re.exec(s))) {
-    const name = m[1];
-    const hasVal = m[2] != null;
-    let val = m[3] ?? m[4] ?? m[5] ?? '';
-    if (!__ns_isAllowedAttr(tag, name)) continue;
-    const low = String(name).toLowerCase();
-    if (hasVal) {
-      if (low === 'href') val = __ns_rewriteHref(val, baseDir);
-      else if (low === 'src') val = __ns_rewriteSrc(val, baseDir);
-      else if (low === 'srcset') val = __ns_rewriteSrcset(val, baseDir);
-      out += ` ${low}="${escapeHtml(val)}"`;
-    } else {
-      out += ` ${low}`;
-    }
-  }
-  return out;
-}
-export function allowUserHtml(input, baseDir) {
-  const str = String(input || '');
-  if (!str) return '';
-  const tagRe = /<\/?([a-zA-Z][a-zA-Z0-9:-]*)\b([^>]*)>/g;
-  let out = '';
-  let last = 0;
-  let m;
-  while ((m = tagRe.exec(str))) {
-    // Text before the tag
-    out += escapeHtml(str.slice(last, m.index));
-    last = tagRe.lastIndex;
-    const full = m[0];
-    const name = (m[1] || '').toLowerCase();
-    const attrs = m[2] || '';
-    const isClosing = /^<\//.test(full);
-    const isSelfClosing = /\/>$/.test(full) || __NS_VOID_TAGS.has(name);
-    if (!__NS_ALLOWED_TAGS.has(name)) {
-      out += escapeHtml(full);
-      continue;
-    }
-    if (isClosing) {
-      out += `</${name}>`;
-    } else {
-      const safeAttrs = __ns_sanitizeAttrs(name, attrs, baseDir);
-      out += `<${name}${safeAttrs}${isSelfClosing ? ' />' : '>'}`;
-    }
-  }
-  // Remainder after last tag
-  out += escapeHtml(str.slice(last));
-  return out;
-}
-
 export function getQueryVariable(variable) {
   const params = new URLSearchParams(window.location.search);
   const value = params.get(variable);
@@ -285,13 +209,15 @@ export function renderTags(tagVal) {
   return `<div class=\"tags\">${tags.map(t => `<span class=\"tag\">${escapeHtml(t)}</span>`).join('')}</div>`;
 }
 
-// Safely set sanitized HTML into a target element without using innerHTML.
-// - Prefers the native Sanitizer API when available
-// - Falls back to parsing into a safe DocumentFragment with our allowlist
+// Safely set controlled renderer markup into a target element without using innerHTML.
 export function setSafeHtml(target, html, baseDir, options = {}) {
   if (!target) return;
   const input = String(html || '');
   const opts = options && typeof options === 'object' ? options : {};
+  if (!opts.alreadySanitized) {
+    try { target.textContent = input; } catch (_) {}
+    return;
+  }
   try {
     // Prefer native Sanitizer API when available
     if (typeof window !== 'undefined' && 'Sanitizer' in window && typeof Element.prototype.setHTML === 'function') {
@@ -301,11 +227,10 @@ export function setSafeHtml(target, html, baseDir, options = {}) {
     }
   } catch (_) { /* fall through to manual sanitizer */ }
 
-  // Manual sanitizer (no HTML re-interpretation via innerHTML/DOMParser):
-  // 1) First, reduce to an allowlisted HTML string using our string-level sanitizer.
-  // 2) Then, build a DOM fragment by tokenizing tags and creating elements/attributes programmatically.
+  // Build a DOM fragment by tokenizing the renderer output and creating
+  // elements/attributes programmatically.
   try {
-    const safeHtml = opts.alreadySanitized ? input : allowUserHtml(input, baseDir);
+    const safeHtml = input;
 
     // Minimal HTML entity unescape for attribute values we set via setAttribute.
     const unescapeHtml = (s) => String(s || '')
@@ -358,7 +283,7 @@ export function setSafeHtml(target, html, baseDir, options = {}) {
       parent.appendChild(node);
     };
 
-    // Tokenize tags. All disallowed tags should already be escaped by allowUserHtml.
+    // Tokenize tags. Any unexpected tag is preserved as text.
     const tagRe = /<\/?([a-zA-Z][\w:-]*)\b([^>]*)>/g;
     let last = 0;
     let m;
@@ -372,7 +297,7 @@ export function setSafeHtml(target, html, baseDir, options = {}) {
       const tag = (m[1] || '').toLowerCase();
       const attrs = m[2] || '';
       const isClose = /^<\//.test(raw);
-      const isVoid = __NS_VOID_TAGS.has(tag);
+      const isVoid = __NS_RENDERED_MARKDOWN_VOID_TAGS.has(tag);
 
       if (isClose) {
         // Pop to the nearest matching tag if present
@@ -385,8 +310,7 @@ export function setSafeHtml(target, html, baseDir, options = {}) {
         continue;
       }
 
-      if (!__NS_ALLOWED_TAGS.has(tag)) {
-        // Shouldn't happen (already escaped), but keep as text just in case
+      if (!__NS_RENDERED_MARKDOWN_TAGS.has(tag)) {
         appendNode(document.createTextNode(raw));
         continue;
       }
@@ -404,7 +328,6 @@ export function setSafeHtml(target, html, baseDir, options = {}) {
         let val = unescapeHtml(rawVal);
         if (name === 'href') val = __ns_rewriteHref(val, baseDir);
         else if (name === 'src') val = __ns_rewriteSrc(val, baseDir);
-        else if (name === 'srcset') val = __ns_rewriteSrcset(val, baseDir);
         try { el.setAttribute(name, val); } catch (_) {}
       }
 

--- a/scripts/test-frontmatter-roundtrip.js
+++ b/scripts/test-frontmatter-roundtrip.js
@@ -11,6 +11,10 @@ import { parseFrontMatter } from '../assets/js/content.js';
 import { insertImageMarkdownAtSelection, normalizeDateInputValue } from '../assets/js/editor-markdown-ops.js';
 import { mergeYamlConfig, resolveSiteRepoConfig } from '../assets/js/yaml.js';
 
+globalThis.document = globalThis.document || { title: 'NanoSite' };
+
+const { mdParse } = await import('../assets/js/markdown.js');
+
 const ensureKeyOrder = (order = [], key) => {
   if (!key) return order;
   if (!order.includes(key)) order.push(key);
@@ -407,6 +411,30 @@ run('manual markdown save requires dirty non-empty content', () => {
     content: 'Body\nparagraph.\n',
     reason: 'default'
   });
+});
+
+run('markdown parser treats inline HTML tags as literal text', () => {
+  const output = mdParse('Hello <span class="raw">HTML</span>.').post;
+  assert.equal(output, '<p>Hello &lt;span class=&quot;raw&quot;&gt;HTML&lt;/span&gt;.</p>');
+});
+
+run('markdown parser treats block HTML tags as literal text', () => {
+  const output = mdParse([
+    '<div class="raw">',
+    '**Not a live tag block**',
+    '</div>',
+    ''
+  ].join('\n')).post;
+  assert.ok(!output.includes('<div class="raw">'));
+  assert.ok(!output.includes('</div>'));
+  assert.match(output, /&lt;div class=&quot;raw&quot;&gt;/);
+  assert.match(output, /<strong>Not a live tag block<\/strong>/);
+  assert.match(output, /&lt;\/div&gt;/);
+});
+
+run('markdown parser treats HTML comments as literal text', () => {
+  const output = mdParse('Before <!-- hidden --> after.').post;
+  assert.equal(output, '<p>Before &lt;!-- hidden --&gt; after.</p>');
 });
 
 run('local site overrides merge into tracked site config without dropping fields', () => {


### PR DESCRIPTION
## Summary
- Remove the Markdown renderer path that admitted user-authored tags.
- Treat inline tags, block tags, and comments in Markdown as literal escaped text.
- Remove repository-facing documentation traces that advertised tag support.

## Validation
- bash scripts/test-main-guard.sh
- bash scripts/test-frontmatter-roundtrip.sh
- Parsed all 32 Markdown files under wwwroot with mdParse
