### PR TITLE
[codex] Optimize content cache policy

### DIFF
--- a/assets/js/cache-control.js
+++ b/assets/js/cache-control.js
@@ -1,5 +1,15 @@
 let fetchPatched = false;
 
+const SUPPORTED_CACHE_MODES = new Set(['default', 'no-cache', 'no-store']);
+const MAIN_CONTENT_CACHE_MODE = 'default';
+const EDITOR_CONTENT_CACHE_MODE = 'no-store';
+
+const policyState = {
+  context: detectCacheContext(),
+  content: MAIN_CONTENT_CACHE_MODE,
+  editorContent: EDITOR_CONTENT_CACHE_MODE
+};
+
 function extractUrl(input) {
   if (!input) return '';
   if (typeof input === 'string') return input;
@@ -41,6 +51,44 @@ function shouldPreferCache(ext) {
   return ext === 'js' || ext === 'mjs' || ext === 'cjs' || ext === 'json';
 }
 
+function detectCacheContext() {
+  try {
+    const href = typeof window !== 'undefined' && window.location ? window.location.href : '';
+    const parsed = href ? new URL(href, 'https://example.invalid/') : null;
+    const pathname = parsed && parsed.pathname ? parsed.pathname : '';
+    if (/\/index_editor\.html$/i.test(pathname)) return 'editor';
+  } catch (_) {
+    try {
+      const pathname = typeof window !== 'undefined' && window.location ? String(window.location.pathname || '') : '';
+      if (/\/index_editor\.html$/i.test(pathname)) return 'editor';
+    } catch (__) {}
+  }
+  return 'site';
+}
+
+function normalizeCacheMode(value, fallback) {
+  const mode = String(value || '').trim().toLowerCase();
+  return SUPPORTED_CACHE_MODES.has(mode) ? mode : fallback;
+}
+
+function getContentCacheMode() {
+  return policyState.context === 'editor'
+    ? normalizeCacheMode(policyState.editorContent, EDITOR_CONTENT_CACHE_MODE)
+    : normalizeCacheMode(policyState.content, MAIN_CONTENT_CACHE_MODE);
+}
+
+export function configureFetchCachePolicy(config = {}, options = {}) {
+  const policy = config && typeof config === 'object' && config.cachePolicy && typeof config.cachePolicy === 'object'
+    ? config.cachePolicy
+    : {};
+  const nextContext = options && options.context ? String(options.context).trim().toLowerCase() : '';
+  if (nextContext === 'editor' || nextContext === 'site') {
+    policyState.context = nextContext;
+  }
+  policyState.content = normalizeCacheMode(policy.content, MAIN_CONTENT_CACHE_MODE);
+  policyState.editorContent = normalizeCacheMode(policy.editorContent, EDITOR_CONTENT_CACHE_MODE);
+}
+
 export function ensureFetchCachePolicyPatched() {
   if (fetchPatched) return;
   fetchPatched = true;
@@ -56,7 +104,7 @@ export function ensureFetchCachePolicyPatched() {
     const requestedCache = hasExplicitCache ? finalInit.cache : undefined;
 
     if (shouldBypassCache(ext)) {
-      finalInit.cache = 'no-cache';
+      finalInit.cache = getContentCacheMode();
     } else if (shouldPreferCache(ext)) {
       if (!hasExplicitCache || requestedCache === 'no-cache' || requestedCache == null) {
         finalInit.cache = 'default';
@@ -78,7 +126,7 @@ ensureFetchCachePolicyPatched();
 
 export function getCacheModeForUrl(url, fallback = undefined) {
   const ext = getExtension(url);
-  if (shouldBypassCache(ext)) return 'no-cache';
+  if (shouldBypassCache(ext)) return getContentCacheMode();
   if (shouldPreferCache(ext)) return 'default';
   return fallback;
 }

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -1,4 +1,4 @@
-import './cache-control.js';
+import { configureFetchCachePolicy } from './cache-control.js';
 import { createHiEditor } from './hieditor.js';
 import { mdParse } from './markdown.js';
 import { insertImageMarkdownAtSelection, normalizeDateInputValue } from './editor-markdown-ops.js';
@@ -17,7 +17,7 @@ import { applyLazyLoadingIn, hydratePostImages, hydratePostVideos } from './post
 import { hydrateInternalLinkCards } from './link-cards.js';
 import { applyLangHints } from './typography.js';
 import { fetchConfigWithYamlFallback, fetchMergedSiteConfig } from './yaml.js';
-import { t, withLangParam, loadContentJson, getCurrentLang, normalizeLangKey } from './i18n.js';
+import { t, withLangParam, loadContentJsonWithRaw, getCurrentLang, normalizeLangKey } from './i18n.js';
 
 const LS_WRAP_KEY = 'ns_editor_wrap_enabled';
 
@@ -2695,6 +2695,7 @@ document.addEventListener('DOMContentLoaded', () => {
         setStatus('Loading site config…');
         const site = await fetchMergedSiteConfig();
         editorSiteConfig = site || {};
+        try { configureFetchCachePolicy(editorSiteConfig, { context: 'editor' }); } catch (_) {}
         contentRoot = (site && site.contentRoot) ? String(site.contentRoot) : 'wwwroot';
       } catch (_) {
         editorSiteConfig = {};
@@ -2706,17 +2707,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
       try {
         setStatus('Loading index…');
-        const [idxResult, postsResult] = await Promise.allSettled([
-          fetchConfigWithYamlFallback([`${contentRoot}/index.yaml`, `${contentRoot}/index.yml`]),
-          loadContentJson(contentRoot, 'index')
-        ]);
-        const rawIndex = idxResult.status === 'fulfilled' ? (idxResult.value || {}) : {};
-        const posts = postsResult.status === 'fulfilled' ? (postsResult.value || {}) : {};
+        const indexResult = await loadContentJsonWithRaw(contentRoot, 'index');
+        const rawIndex = (indexResult && indexResult.raw) || {};
+        const posts = (indexResult && indexResult.entries) || {};
         renderGroupedIndex(listIndex, rawIndex);
         rebuildLinkCardContext(posts, rawIndex);
         if (linkCardReady) refreshPreview();
-        if (idxResult.status === 'rejected') console.warn('Failed to load index.yaml', idxResult.reason);
-        if (postsResult.status === 'rejected') console.warn('Failed to load index metadata', postsResult.reason);
       } catch (err) {
         console.warn('Failed to load index data', err);
       }

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -14,7 +14,7 @@ import { getContentRoot } from './utils.js';
 import { fetchConfigWithYamlFallback } from './yaml.js';
 import enTranslations, { languageMeta as enLanguageMeta } from '../i18n/en.js';
 
-// Fetch of content files uses { cache: 'no-store' } to avoid stale data
+// Content fetch cache modes are normalized by cache-control.js.
 
 // Default language fallback when no user/browser preference is available.
 const DEFAULT_LANG = 'en';
@@ -601,14 +601,16 @@ async function loadContentFromFrontMatter(obj, lang) {
 
 // Try to load unified YAML (`base.yaml`) first; if not unified or missing, fallback to legacy
 // per-language files (base.<currentLang>.yaml -> base.<default>.yaml -> base.yaml)
-export async function loadContentJson(basePath, baseName) {
+export async function loadContentJsonWithRaw(basePath, baseName) {
   // YAML only (unified or simplified)
+  let raw = null;
   try {
     const obj = await fetchConfigWithYamlFallback([
       `${basePath}/${baseName}.yaml`,
       `${basePath}/${baseName}.yml`
     ]);
     if (obj && typeof obj === 'object' && Object.keys(obj).length) {
+      raw = obj;
       // Heuristic: if any entry contains a `default` or a non-reserved language-like key, treat as unified
       const keys = Object.keys(obj || {});
       let isUnified = false;
@@ -643,7 +645,7 @@ export async function loadContentJson(basePath, baseName) {
         const current = getCurrentLang();
         const { entries, availableLangs } = await loadContentFromFrontMatter(obj, current);
         __setContentLangs(availableLangs);
-        return entries;
+        return { entries, raw };
       }
       
       if (isUnified) {
@@ -651,14 +653,19 @@ export async function loadContentJson(basePath, baseName) {
         const { entries, availableLangs } = transformUnifiedContent(obj, current);
         // Record available content languages so the dropdown can reflect them
         __setContentLangs(availableLangs);
-        return entries;
+        return { entries, raw };
       }
       // Not unified; fall through to legacy handling below
     }
   } catch (_) { /* fall back */ }
 
   // Legacy per-language YAML chain
-  return loadLangJson(basePath, baseName);
+  return { entries: await loadLangJson(basePath, baseName), raw };
+}
+
+export async function loadContentJson(basePath, baseName) {
+  const result = await loadContentJsonWithRaw(basePath, baseName);
+  return (result && result.entries) || {};
 }
 
 // Transform unified tabs YAML into a flat map: title -> { location }

--- a/assets/main.js
+++ b/assets/main.js
@@ -1,4 +1,4 @@
-import './js/cache-control.js';
+import { configureFetchCachePolicy } from './js/cache-control.js';
 import { mdParse } from './js/markdown.js';
 import { setupAnchors, setupTOC } from './js/toc.js';
 import { applySavedTheme, bindThemeToggle, bindThemePackPicker, mountThemeControls, refreshLanguageSelector, applyThemeConfig, bindPostEditor } from './js/theme.js';
@@ -11,7 +11,7 @@ import {
   t,
   withLangParam,
   loadLangJson,
-  loadContentJson,
+  loadContentJsonWithRaw,
   loadTabsJson,
   getCurrentLang,
   normalizeLangKey,
@@ -30,7 +30,7 @@ import { applyLangHints } from './js/typography.js';
 import { applyLazyLoadingIn, hydratePostImages, hydratePostVideos, hydrateCardCovers } from './js/post-render.js';
 import { hydrateInternalLinkCards } from './js/link-cards.js';
 
-// Lightweight fetch helper (bypass caches without version params)
+// Lightweight content fetch helper; cache mode is normalized by cache-control.js.
 const getFile = (filename) => fetch(String(filename || ''), { cache: 'no-store' })
   .then(resp => { if (!resp.ok) throw new Error(`HTTP ${resp.status}`); return resp.text(); });
 
@@ -1233,6 +1233,7 @@ try {
   siteConfigResult = {};
 }
 siteConfig = siteConfigResult || {};
+try { configureFetchCachePolicy(siteConfig); } catch (_) {}
 
 // Apply content root override early so subsequent loads honor it
 try {
@@ -1328,13 +1329,13 @@ async function softResetToSiteDefaultLanguage() {
   // Reload localized content and tabs for the new language, then rerender
   try {
     const results = await Promise.allSettled([
-      loadContentJson(getContentRoot(), 'index'),
-      loadTabsJson(getContentRoot(), 'tabs'),
-      (async () => { try { const cr = getContentRoot(); const obj = await fetchConfigWithYamlFallback([`${cr}/index.yaml`,`${cr}/index.yml`]); return (obj && typeof obj === 'object') ? obj : null; } catch (_) { return null; } })()
+      loadContentJsonWithRaw(getContentRoot(), 'index'),
+      loadTabsJson(getContentRoot(), 'tabs')
     ]);
-    const posts = results[0].status === 'fulfilled' ? (results[0].value || {}) : {};
+    const contentResult = results[0].status === 'fulfilled' ? (results[0].value || {}) : {};
+    const posts = contentResult.entries || {};
     const tabs = results[1].status === 'fulfilled' ? (results[1].value || {}) : {};
-    const rawIndex = results[2] && results[2].status === 'fulfilled' ? (results[2].value || null) : null;
+    const rawIndex = contentResult.raw || null;
     // Cache raw index for stable ordering
     rawIndexCache = rawIndex && typeof rawIndex === 'object' ? rawIndex : null;
 
@@ -1474,21 +1475,15 @@ try { window.__ns_softResetLang = () => softResetToSiteDefaultLanguage(); } catc
 
 // Now fetch localized content and tabs for the (possibly updated) language
 const loadResults = await Promise.allSettled([
-  loadContentJson(getContentRoot(), 'index'),
-  loadTabsJson(getContentRoot(), 'tabs'),
-  (async () => {
-    try {
-      const cr = getContentRoot();
-      const obj = await fetchConfigWithYamlFallback([`${cr}/index.yaml`, `${cr}/index.yml`]);
-      return (obj && typeof obj === 'object') ? obj : null;
-    } catch (_) { return null; }
-  })()
+  loadContentJsonWithRaw(getContentRoot(), 'index'),
+  loadTabsJson(getContentRoot(), 'tabs')
 ]);
 
 try {
-  const posts = loadResults[0].status === 'fulfilled' ? (loadResults[0].value || {}) : {};
+  const contentResult = loadResults[0].status === 'fulfilled' ? (loadResults[0].value || {}) : {};
+  const posts = contentResult.entries || {};
   const tabs = loadResults[1].status === 'fulfilled' ? (loadResults[1].value || {}) : {};
-  const rawIndex = loadResults[2] && loadResults[2].status === 'fulfilled' ? (loadResults[2].value || null) : null;
+  const rawIndex = contentResult.raw || null;
   // Cache raw index for stable ordering
   rawIndexCache = rawIndex && typeof rawIndex === 'object' ? rawIndex : null;
     tabsBySlug = {};

--- a/assets/schema/site.json
+++ b/assets/schema/site.json
@@ -117,6 +117,25 @@
       "type": "boolean",
       "description": "Show error overlay in UI when enabled."
     },
+    "cachePolicy": {
+      "type": "object",
+      "description": "Browser fetch cache policy for author-managed content files.",
+      "properties": {
+        "content": {
+          "$ref": "#/$defs/cacheMode",
+          "description": "Cache mode for Markdown/YAML content on the public site. Defaults to browser cache behavior."
+        },
+        "editorContent": {
+          "$ref": "#/$defs/cacheMode",
+          "description": "Cache mode for Markdown/YAML content in the editor and preview. Defaults to no-store for freshness."
+        }
+      },
+      "additionalProperties": false,
+      "default": {
+        "content": "default",
+        "editorContent": "no-store"
+      }
+    },
     "pageSize": {
       "type": "integer",
       "minimum": 1,
@@ -207,6 +226,14 @@
             "type": "string"
           }
         }
+      ]
+    },
+    "cacheMode": {
+      "type": "string",
+      "enum": [
+        "default",
+        "no-cache",
+        "no-store"
       ]
     }
   }

--- a/scripts/test-cache-control.js
+++ b/scripts/test-cache-control.js
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+
+let moduleSeq = 0;
+
+async function loadCacheControl({ pathname = '/' } = {}) {
+  const calls = [];
+  globalThis.window = {
+    location: { href: `https://example.test${pathname}`, pathname },
+    fetch: async (input, init) => {
+      calls.push({ input, init: init ? { ...init } : init });
+      return { ok: true, text: async () => '', json: async () => ({}) };
+    }
+  };
+  globalThis.Request = class Request {
+    constructor(url) {
+      this.url = url;
+    }
+  };
+
+  const mod = await import(`../assets/js/cache-control.js?cache-test=${moduleSeq++}`);
+  return { mod, calls };
+}
+
+async function run(name, fn) {
+  try {
+    await fn();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    console.error(`not ok - ${name}`);
+    throw error;
+  } finally {
+    delete globalThis.window;
+    delete globalThis.Request;
+  }
+}
+
+await run('main site downgrades explicit no-store content fetches to browser default', async () => {
+  const { calls } = await loadCacheControl({ pathname: '/' });
+
+  await window.fetch('/wwwroot/index.yaml', { cache: 'no-store' });
+
+  assert.equal(calls[0].init.cache, 'default');
+});
+
+await run('editor pages keep content fetches on no-store by default', async () => {
+  const { calls } = await loadCacheControl({ pathname: '/index_editor.html' });
+
+  await window.fetch('/wwwroot/post/demo.md', { cache: 'default' });
+
+  assert.equal(calls[0].init.cache, 'no-store');
+});
+
+await run('site cachePolicy.content can force no-cache on main site content', async () => {
+  const { mod, calls } = await loadCacheControl({ pathname: '/' });
+
+  mod.configureFetchCachePolicy({ cachePolicy: { content: 'no-cache' } });
+  await window.fetch('/wwwroot/tabs.yml', { cache: 'no-store' });
+
+  assert.equal(calls[0].init.cache, 'no-cache');
+});
+
+await run('invalid site cache policy values fall back to defaults', async () => {
+  const { mod, calls } = await loadCacheControl({ pathname: '/' });
+
+  mod.configureFetchCachePolicy({ cachePolicy: { content: 'reload', editorContent: 'force-cache' } });
+  await window.fetch('/wwwroot/post/demo.md', { cache: 'no-store' });
+
+  assert.equal(calls[0].init.cache, 'default');
+});
+
+await run('non-content resources keep their existing cache behavior', async () => {
+  const { calls } = await loadCacheControl({ pathname: '/' });
+
+  await window.fetch('/assets/main.js', { cache: 'no-cache' });
+  await window.fetch('/assets/i18n/languages.json', { cache: 'no-store' });
+  await window.fetch('/assets/hero.jpeg', { cache: 'no-store' });
+
+  assert.equal(calls[0].init.cache, 'default');
+  assert.equal(calls[1].init.cache, 'no-store');
+  assert.equal(calls[2].init.cache, 'no-store');
+});

--- a/scripts/test-i18n-content-raw.js
+++ b/scripts/test-i18n-content-raw.js
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+
+globalThis.document = globalThis.document || {
+  documentElement: { setAttribute() {}, getAttribute() { return 'en'; } },
+  getElementById() { return null; },
+  querySelectorAll() { return []; }
+};
+globalThis.window = globalThis.window || {
+  location: { href: 'https://example.test/', pathname: '/' },
+  dispatchEvent() {}
+};
+try {
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { language: 'en-US' },
+    configurable: true
+  });
+} catch (_) {}
+globalThis.localStorage = globalThis.localStorage || {
+  getItem() { return null; },
+  setItem() {},
+  removeItem() {}
+};
+
+const requests = [];
+
+globalThis.fetch = async (url) => {
+  const textUrl = String(url);
+  requests.push(textUrl);
+  if (textUrl.endsWith('/index.yaml')) {
+    return {
+      ok: true,
+      text: async () => [
+        'demo:',
+        '  en:',
+        '    - post/demo.md',
+        ''
+      ].join('\n')
+    };
+  }
+  if (textUrl.endsWith('/post/demo.md')) {
+    return {
+      ok: true,
+      text: async () => [
+        '---',
+        'title: Demo Title',
+        'date: 2026-04-27',
+        '---',
+        'Demo body.',
+        ''
+      ].join('\n')
+    };
+  }
+  return { ok: false, status: 404, text: async () => '' };
+};
+
+const { initI18n, loadContentJsonWithRaw } = await import('../assets/js/i18n.js');
+
+await initI18n({ lang: 'en', persist: false });
+const result = await loadContentJsonWithRaw('wwwroot', 'index');
+
+assert.equal(requests.filter(url => url.endsWith('/index.yaml')).length, 1);
+assert.deepEqual(result.raw, { demo: { en: ['post/demo.md'] } });
+assert.equal(result.entries.demo.location, 'post/demo.md');
+
+console.log('ok - loadContentJsonWithRaw returns raw index without a duplicate index fetch');

--- a/site.yaml
+++ b/site.yaml
@@ -42,6 +42,10 @@ cardCoverFallback: false
 
 errorOverlay: true
 
+cachePolicy:
+  content: default
+  editorContent: no-store
+
 pageSize: 8
 
 defaultLanguage: en


### PR DESCRIPTION
## Summary
- Add a configurable content fetch cache policy so public pages can use browser-default caching while editor flows keep fresh Markdown/YAML reads.
- Reuse the raw index result from content loading to avoid duplicate `index.yaml` fetches in the public site and editor flows.
- Document the new `cachePolicy` shape in `site.yaml` and the site schema.

## Test Plan
- `node scripts/test-cache-control.js`
- `node scripts/test-i18n-content-raw.js`
- `node scripts/test-frontmatter-roundtrip.js`
- `bash scripts/test-main-guard.sh`

## Browser Verification
- Served the site locally on a fresh origin and confirmed the public homepage requested `wwwroot/index.yaml` once during startup.
- Opened the editor page locally and confirmed it still loads with content requests kept fresh.