### PR TITLE
[codex] Remove native image no-store fetches

### DIFF
--- a/assets/themes/native/modules/interactions.js
+++ b/assets/themes/native/modules/interactions.js
@@ -587,7 +587,7 @@ function sequentialLoadCoversNative(containerSelector, documentRef = defaultDocu
         };
         img.addEventListener('load', done, { once: true });
         img.addEventListener('error', done, { once: true });
-        setImageSrcNoStore(img, src, windowRef);
+        setImageSrcWithBrowserCache(img, src);
       }
     };
     startNext();
@@ -743,26 +743,14 @@ function handleDocumentClickNative(params = {}, documentRef = defaultDocument, w
   return true;
 }
 
-function setImageSrcNoStore(img, src, windowRef = defaultWindow) {
+function setImageSrcWithBrowserCache(img, src) {
   try {
     if (!img) return;
     const val = String(src || '').trim();
     if (!val) return;
     const safeVal = sanitizeImageUrl(val);
     if (!safeVal) return;
-    if (/^(data:|blob:)/i.test(safeVal)) { img.setAttribute('src', safeVal); return; }
-    if (/^[a-z][a-z0-9+.-]*:/i.test(safeVal)) { img.setAttribute('src', safeVal); return; }
-    let abs = safeVal;
-    try { abs = new URL(safeVal, windowRef && windowRef.location ? windowRef.location.href : undefined).toString(); } catch (_) {}
-    fetch(abs, { cache: 'no-store' })
-      .then(r => { if (!r.ok) throw new Error('HTTP ' + r.status); return r.blob(); })
-      .then(b => {
-        const url = URL.createObjectURL(b);
-        try { const prev = img.dataset.blobUrl; if (prev) URL.revokeObjectURL(prev); } catch (_) {}
-        img.dataset.blobUrl = url;
-        img.setAttribute('src', url);
-      })
-      .catch(() => { img.setAttribute('src', safeVal); });
+    img.setAttribute('src', safeVal);
   } catch (_) {
     try { img.setAttribute('src', sanitizeImageUrl(src)); } catch (__) {}
   }
@@ -818,7 +806,7 @@ function renderSiteIdentityNative(params = {}, documentRef = defaultDocument, wi
   }
   if (avatar) {
     const img = documentRef.querySelector('.site-card .avatar');
-    if (img) setImageSrcNoStore(img, avatar, windowRef);
+    if (img) setImageSrcWithBrowserCache(img, avatar);
   }
   return true;
 }

--- a/scripts/test-native-image-cache.js
+++ b/scripts/test-native-image-cache.js
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+
+const attrs = new Map();
+const fetchCalls = [];
+
+const avatarImg = {
+  dataset: {},
+  setAttribute(name, value) {
+    attrs.set(name, String(value));
+  },
+  getAttribute(name) {
+    return attrs.get(name) || '';
+  }
+};
+
+const documentRef = {
+  documentElement: {
+    setAttribute() {},
+    getAttribute() { return 'en'; }
+  },
+  body: {
+    appendChild() {},
+    removeChild() {}
+  },
+  createElement() {
+    return {
+      className: '',
+      classList: { add() {}, remove() {}, contains() { return false; } },
+      dataset: {},
+      style: {},
+      appendChild() {},
+      setAttribute() {},
+      getAttribute() { return ''; },
+      querySelector() { return null; },
+      querySelectorAll() { return []; }
+    };
+  },
+  createTextNode(value) {
+    return { textContent: String(value || '') };
+  },
+  getElementById() {
+    return null;
+  },
+  querySelector(selector) {
+    if (selector === '.site-card .avatar') return avatarImg;
+    return {
+      textContent: '',
+      appendChild() {},
+      setAttribute() {},
+      getAttribute() { return ''; },
+      querySelector() { return null; },
+      querySelectorAll() { return []; }
+    };
+  },
+  querySelectorAll() {
+    return [];
+  }
+};
+
+const windowRef = {
+  __ns_themeHooks: {},
+  location: { href: 'https://example.test/', pathname: '/' },
+  addEventListener() {},
+  removeEventListener() {},
+  requestAnimationFrame(callback) {
+    return setTimeout(callback, 0);
+  },
+  cancelAnimationFrame(id) {
+    clearTimeout(id);
+  }
+};
+
+globalThis.window = windowRef;
+globalThis.document = documentRef;
+globalThis.localStorage = {
+  getItem() { return null; },
+  setItem() {},
+  removeItem() {}
+};
+globalThis.fetch = async (url, init) => {
+  fetchCalls.push({ url: String(url), init: init ? { ...init } : init });
+  return { ok: true, blob: async () => new Blob(['image']) };
+};
+
+const { mount } = await import('../assets/themes/native/modules/interactions.js?native-image-cache-test');
+
+mount({ window: windowRef, document: documentRef });
+windowRef.__ns_themeHooks.renderSiteIdentity({
+  config: { siteTitle: 'NanoSite', siteSubtitle: 'Fast images', avatar: 'assets/avatar.jpeg' }
+});
+
+assert.equal(fetchCalls.length, 0);
+assert.equal(attrs.get('src'), 'assets/avatar.jpeg');
+
+console.log('ok - native local images use browser image cache instead of no-store fetch');


### PR DESCRIPTION
## Summary

- Stop the native theme from fetching local images through `fetch(..., { cache: 'no-store' })` and blob URLs.
- Let native theme avatar and card covers use normal `<img src>` loading so browser and GitHub Pages image caching can work.
- Add a regression test for the native image path to ensure it does not bypass the browser cache.

## Validation

- `node scripts/test-native-image-cache.js`
- `node scripts/test-cache-control.js`
- `node scripts/test-i18n-content-raw.js`
- `node scripts/test-frontmatter-roundtrip.js`
- `bash scripts/test-main-guard.sh`