### PR TITLE
[codex] Show images during skeleton loading

### DIFF
--- a/assets/js/post-render.js
+++ b/assets/js/post-render.js
@@ -13,7 +13,7 @@ export function applyLazyLoadingIn(container) {
   } catch (_) {}
 }
 
-// Fade-in covers when each image loads; remove placeholder per-card
+// Keep covers visible while the skeleton marks loading; remove placeholder per-card.
 export function hydrateCardCovers(container) {
   try {
     const root = typeof container === 'string' ? document.querySelector(container) : (container || document);
@@ -40,7 +40,7 @@ export function hydrateCardCovers(container) {
   } catch (_) {}
 }
 
-// Enhance post images: wrap with a reserved-ratio container + skeleton, fade-in when loaded
+// Enhance post images: wrap with a reserved-ratio container + skeleton overlay while loading.
 export function hydratePostImages(container) {
   try {
     const root = typeof container === 'string' ? document.querySelector(container) : (container || document);

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -2055,9 +2055,9 @@ body {
   height: 100%;
   object-fit: cover;
   display: block;
-  opacity: 0;
+  opacity: 1;
   transform: scale(1.02);
-  transition: opacity 0.35s ease, transform 0.35s ease;
+  transition: transform 0.35s ease;
 }
 
 .arcus-article__body .link-card .card-cover.is-loaded,
@@ -2071,6 +2071,37 @@ body {
 .arcus-static__body .link-card:hover .card-cover.is-loaded,
 .arcus-static__body .link-card:focus-visible .card-cover.is-loaded {
   transform: scale(1.06);
+}
+
+.arcus-article__body .post-image-wrap .ph-skeleton,
+.arcus-static__body .post-image-wrap .ph-skeleton,
+.arcus-article__body .link-card .ph-skeleton,
+.arcus-static__body .link-card .ph-skeleton {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  overflow: hidden;
+  pointer-events: none;
+  background: rgba(123, 139, 255, 0.14);
+}
+
+.arcus-article__body .post-image-wrap .ph-skeleton::after,
+.arcus-static__body .post-image-wrap .ph-skeleton::after,
+.arcus-article__body .link-card .ph-skeleton::after,
+.arcus-static__body .link-card .ph-skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.28), transparent);
+  animation: arcus-shimmer 1.2s infinite;
+}
+
+[data-theme="dark"] .arcus-article__body .post-image-wrap .ph-skeleton,
+[data-theme="dark"] .arcus-static__body .post-image-wrap .ph-skeleton,
+[data-theme="dark"] .arcus-article__body .link-card .ph-skeleton,
+[data-theme="dark"] .arcus-static__body .link-card .ph-skeleton {
+  background: rgba(158, 167, 255, 0.12);
 }
 
 .arcus-article__body .link-card .card-title,
@@ -2419,6 +2450,12 @@ body {
   object-fit: contain;
   box-shadow: none;
   border-radius: 0;
+}
+
+@keyframes arcus-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
 }
 
 .arcus-article__body figure,

--- a/assets/themes/native/base.css
+++ b/assets/themes/native/base.css
@@ -393,16 +393,16 @@ table tr:hover { background-color: color-mix(in srgb, var(--primary) 8%, transpa
 .index a { display: block; border: 0.0625rem solid var(--border); border-radius: 0.75rem; color: var(--text); background: var(--card); text-decoration: none; box-shadow: var(--shadow); transition: transform .12s ease-out, box-shadow .15s ease, border-color .15s ease; overflow: hidden; will-change: transform, box-shadow; height: auto; align-self: start; margin: 0.65rem 0; }
 .index a:hover { transform: translateY(-0.0625rem); box-shadow: 0 0.375rem 1.25rem rgba(0,0,0,.08); border-color: color-mix(in srgb, var(--primary) 35%, var(--border)); }
 .index .card-cover-wrap { position: relative; width: 100%; aspect-ratio: 16 / 10; height: auto; overflow: hidden; background: color-mix(in srgb, var(--text) 4%, transparent); }
-.index .card-cover { width: 100%; height: 100%; object-fit: cover; display: block; transition: opacity .3s ease, transform .3s ease; will-change: opacity, transform; opacity: 0; }
+.index .card-cover { width: 100%; height: 100%; object-fit: cover; display: block; transition: transform .3s ease; will-change: transform; opacity: 1; }
 .index .card-cover.is-loaded { opacity: 1; }
 /* lightweight shimmer placeholder covering the image area */
-.ph-skeleton { position:absolute; inset:0; overflow:hidden; border-radius: 0; background: color-mix(in srgb, var(--text) 8%, transparent); pointer-events: none; }
+.ph-skeleton { position:absolute; inset:0; overflow:hidden; border-radius: 0; background: color-mix(in srgb, var(--text) 8%, transparent); pointer-events: none; z-index: 1; }
 .ph-skeleton::after { content: ""; position:absolute; inset:0; transform: translateX(-100%); background: linear-gradient(90deg, transparent, rgba(255,255,255,0.28), transparent); animation: skeleton-shimmer 1.1s infinite; opacity: .6; }
 [data-theme="dark"] .ph-skeleton::after { background: linear-gradient(90deg, transparent, rgba(255,255,255,0.12), transparent); }
 
-/* Post content images: reserved space + fade-in */
+/* Post content images: reserved space + skeleton overlay while loading */
 .post-image-wrap { position: relative; aspect-ratio: 16 / 10; width: 100%; margin: 1rem auto; border-radius: 0.5rem; box-shadow: var(--shadow); overflow: hidden; background: var(--bg); }
-.post-image-wrap .post-img { display: block; width: 100%; height: 100%; object-fit: contain; transition: opacity .3s ease; opacity: 0; background: var(--bg); }
+.post-image-wrap .post-img { display: block; width: 100%; height: 100%; object-fit: contain; opacity: 1; background: var(--bg); }
 .post-image-wrap .post-img.is-loaded { opacity: 1; }
 /* Reset default image margins/shadows for wrapped post images */
 #mainview .post-image-wrap .post-img { margin: 0; border-radius: 0; box-shadow: none; }
@@ -671,7 +671,7 @@ table tr:hover { background-color: color-mix(in srgb, var(--primary) 8%, transpa
 #mainview .link-card { display:block; border: 0.0625rem solid var(--border); border-radius: 0.75rem; color: var(--text); background: var(--card); text-decoration: none; box-shadow: var(--shadow); overflow: hidden; transition: transform .12s ease-out, box-shadow .15s ease, border-color .15s ease; }
 #mainview .link-card:hover { transform: translateY(-0.0625rem); box-shadow: 0 0.375rem 1.25rem rgba(0,0,0,.08); border-color: color-mix(in srgb, var(--primary) 35%, var(--border)); text-decoration: none; }
 #mainview .link-card .card-cover-wrap { position: relative; width: 100%; aspect-ratio: 16 / 10; overflow: hidden; background: color-mix(in srgb, var(--text) 4%, transparent); }
-#mainview .link-card .card-cover { width: 100%; height: 100%; object-fit: cover; display: block; transition: opacity .3s ease, transform .3s ease; will-change: opacity, transform; opacity: 0; }
+#mainview .link-card .card-cover { width: 100%; height: 100%; object-fit: cover; display: block; transition: transform .3s ease; will-change: transform; opacity: 1; }
 #mainview .link-card .card-cover.is-loaded { opacity: 1; }
 #mainview .link-card .card-cover { margin: 0; border-radius: 0; box-shadow: none; }
 #mainview .link-card .card-title { padding: 0.75rem 0.875rem 0.25rem; font-weight: 700; font-size: 1.05rem; }

--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -810,8 +810,11 @@ body {
 .solstice-card__cover .ph-skeleton {
   position: absolute;
   inset: 0;
+  z-index: 1;
+  pointer-events: none;
   background: linear-gradient(90deg, rgba(0,0,0,0.06) 0%, rgba(0,0,0,0.02) 50%, rgba(0,0,0,0.06) 100%);
   animation: solstice-shimmer 1.6s infinite;
+  opacity: 0.72;
 }
 
 .solstice-card__cover img {
@@ -819,8 +822,7 @@ body {
   height: 100%;
   object-fit: cover;
   border-radius: inherit;
-  opacity: 0;
-  transition: opacity 0.4s ease;
+  opacity: 1;
 }
 
 .solstice-card__cover img.is-loaded {
@@ -1399,6 +1401,38 @@ body {
   text-decoration: underline;
   text-decoration-thickness: 2px;
   text-decoration-color: currentColor;
+}
+
+.solstice-article__body .post-image-wrap,
+.solstice-static__body .post-image-wrap {
+  position: relative;
+  overflow: hidden;
+  max-width: 100%;
+  margin: clamp(1.5rem, 1rem + 1.4vw, 2.5rem) auto;
+  border-radius: calc(var(--solstice-radius) - 4px);
+  background: rgba(0,0,0,0.05);
+}
+
+.solstice-article__body .post-image-wrap .post-img,
+.solstice-static__body .post-image-wrap .post-img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 0 auto;
+  border-radius: 0;
+  box-shadow: none;
+  opacity: 1;
+}
+
+.solstice-article__body .post-image-wrap .ph-skeleton,
+.solstice-static__body .post-image-wrap .ph-skeleton {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background: linear-gradient(90deg, rgba(0,0,0,0.06) 0%, rgba(0,0,0,0.02) 50%, rgba(0,0,0,0.06) 100%);
+  animation: solstice-shimmer 1.6s infinite;
+  opacity: 0.72;
 }
 
 .solstice-article__body ul,

--- a/scripts/test-progressive-image-visibility.js
+++ b/scripts/test-progressive-image-visibility.js
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+function parseRules(css) {
+  const withoutComments = String(css || '').replace(/\/\*[\s\S]*?\*\//g, '');
+  const rules = [];
+  const rulePattern = /([^{}]+)\{([^{}]*)\}/g;
+  let match;
+  while ((match = rulePattern.exec(withoutComments))) {
+    const selectors = match[1]
+      .split(',')
+      .map(selector => selector.trim().replace(/\s+/g, ' '))
+      .filter(Boolean);
+    const declarations = new Map();
+    match[2].split(';').forEach(part => {
+      const idx = part.indexOf(':');
+      if (idx === -1) return;
+      const property = part.slice(0, idx).trim().toLowerCase();
+      const value = part.slice(idx + 1).trim().toLowerCase();
+      if (property) declarations.set(property, value);
+    });
+    rules.push({ selectors, declarations });
+  }
+  return rules;
+}
+
+function assertSelectorDoesNotHideLoadingImage(file, selector) {
+  const css = readFileSync(file, 'utf8');
+  const rules = parseRules(css).filter(rule => rule.selectors.includes(selector));
+  assert.ok(rules.length > 0, `Missing CSS rule for ${selector} in ${file}`);
+  rules.forEach(rule => {
+    const opacity = rule.declarations.get('opacity');
+    assert.notEqual(opacity, '0', `${selector} in ${file} hides the loading image with opacity: 0`);
+  });
+}
+
+[
+  ['assets/themes/native/base.css', '.index .card-cover'],
+  ['assets/themes/native/base.css', '.post-image-wrap .post-img'],
+  ['assets/themes/native/base.css', '#mainview .link-card .card-cover'],
+  ['assets/themes/arcus/theme.css', '.arcus-article__body .post-image-wrap .post-img'],
+  ['assets/themes/arcus/theme.css', '.arcus-static__body .post-image-wrap .post-img'],
+  ['assets/themes/arcus/theme.css', '.arcus-article__body .link-card .card-cover'],
+  ['assets/themes/arcus/theme.css', '.arcus-static__body .link-card .card-cover'],
+  ['assets/themes/solstice/theme.css', '.solstice-article__body .post-image-wrap .post-img'],
+  ['assets/themes/solstice/theme.css', '.solstice-static__body .post-image-wrap .post-img'],
+  ['assets/themes/solstice/theme.css', '.solstice-card__cover img']
+].forEach(([file, selector]) => assertSelectorDoesNotHideLoadingImage(file, selector));
+
+console.log('ok - loading images remain visible behind skeleton overlays');


### PR DESCRIPTION
## Summary

- Keep loading images visible behind skeleton overlays instead of hiding them with `opacity: 0` until `load` fires.
- Preserve the skeleton/shimmer loading indication while allowing browser progressive image rendering to show partial image data as it arrives.
- Apply the behavior across native, Arcus, and Solstice image surfaces used by cards, link cards, and post images.
- Add a CSS regression test to prevent loading images from being hidden by zero opacity.

## Validation

- `node scripts/test-progressive-image-visibility.js`
- `node scripts/test-native-image-cache.js`
- `node scripts/test-cache-control.js`
- `node scripts/test-i18n-content-raw.js`
- `node scripts/test-frontmatter-roundtrip.js`
- `bash scripts/test-main-guard.sh`
- Local HTTP smoke on `http://127.0.0.1:8123/` and the three theme CSS files