### PR TITLE
[codex] Unify native cover image loading

### DIFF
--- a/assets/js/post-render.js
+++ b/assets/js/post-render.js
@@ -27,9 +27,17 @@ export function hydrateCardCovers(container) {
         img.classList.add('is-loaded');
         if (ph && ph.parentNode) ph.parentNode.removeChild(ph);
       };
-      if (img.complete && img.naturalWidth > 0) { done(); return; }
+      const fail = () => {
+        if (ph && ph.parentNode) ph.parentNode.removeChild(ph);
+        img.style.opacity = '1';
+      };
+      if (img.complete) {
+        if (img.naturalWidth > 0) done();
+        else fail();
+        return;
+      }
       img.addEventListener('load', done, { once: true });
-      img.addEventListener('error', () => { if (ph && ph.parentNode) ph.parentNode.removeChild(ph); img.style.opacity = '1'; }, { once: true });
+      img.addEventListener('error', fail, { once: true });
       const inIndex = !!wrap.closest('.index');
       if (!inIndex) {
         // Link-card covers load immediately; nothing extra needed here

--- a/assets/themes/native/modules/interactions.js
+++ b/assets/themes/native/modules/interactions.js
@@ -562,38 +562,6 @@ function initializeSyntaxHighlightingNative(params = {}) {
   return true;
 }
 
-function sequentialLoadCoversNative(containerSelector, documentRef = defaultDocument, windowRef = defaultWindow, maxConcurrent = 1) {
-  try {
-    const root = typeof containerSelector === 'string'
-      ? (documentRef ? documentRef.querySelector(containerSelector) : null)
-      : containerSelector;
-    if (!root) return;
-    const imgs = Array.from(root.querySelectorAll('.index img.card-cover'));
-    let idx = 0;
-    let active = 0;
-    const limit = Math.max(1, maxConcurrent || 1);
-    const startNext = () => {
-      while (active < limit && idx < imgs.length) {
-        const img = imgs[idx++];
-        if (!img || !img.isConnected) continue;
-        const src = img.getAttribute('data-src');
-        if (!src) continue;
-        active++;
-        const done = () => {
-          active--;
-          img.removeEventListener('load', done);
-          img.removeEventListener('error', done);
-          startNext();
-        };
-        img.addEventListener('load', done, { once: true });
-        img.addEventListener('error', done, { once: true });
-        setImageSrcWithBrowserCache(img, src);
-      }
-    };
-    startNext();
-  } catch (_) {}
-}
-
 function enhanceIndexLayoutNative(params = {}, documentRef = defaultDocument, windowRef = defaultWindow) {
   const containerEl = params.containerElement || getContainerByRole('main', documentRef);
   const indexEl = params.indexElement || (containerEl ? containerEl.querySelector('.index') : null);
@@ -609,7 +577,6 @@ function enhanceIndexLayoutNative(params = {}, documentRef = defaultDocument, wi
     const cfg = (params.siteConfig && params.siteConfig.assetWarnings && params.siteConfig.assetWarnings.largeImage) || {};
     warnLargeImagesInNative(containerEl || containerSelector, cfg, documentRef, windowRef).catch(() => {});
   } catch (_) {}
-  sequentialLoadCoversNative(containerEl || containerSelector, documentRef, windowRef, 1);
   if (typeof params.setupSearch === 'function') {
     try { params.setupSearch(Array.isArray(params.allEntries) ? params.allEntries : []); } catch (_) {}
   }
@@ -1174,7 +1141,7 @@ function renderIndexViewNative(params = {}, documentRef = defaultDocument, windo
     const tag = value ? renderTags(value.tag) : '';
     const { coverSrc, useFallbackCover } = resolveCoverSource(value, siteConfig);
     const cover = (value && coverSrc)
-      ? `<div class="card-cover-wrap"><div class="ph-skeleton" aria-hidden="true"></div><img class="card-cover" alt="${escapeHtml(String(key || ''))}" data-src="${escapeHtml(cardImageSrc(coverSrc))}" loading="lazy" decoding="async" fetchpriority="low" width="1600" height="1000"></div>`
+      ? `<div class="card-cover-wrap"><div class="ph-skeleton" aria-hidden="true"></div><img class="card-cover" alt="${escapeHtml(String(key || ''))}" src="${escapeHtml(cardImageSrc(coverSrc))}" loading="lazy" decoding="async" fetchpriority="low" width="1600" height="1000"></div>`
       : (useFallbackCover ? fallbackCover(key) : '');
     const hasDate = value && value.date;
     const dateHtml = hasDate ? `<span class="card-date">${escapeHtml(formatDisplayDate(value.date))}</span>` : '';
@@ -1302,7 +1269,7 @@ function renderSearchResultsNative(params = {}, documentRef = defaultDocument, w
     const tag = value ? renderTags(value.tag) : '';
     const { coverSrc, useFallbackCover } = resolveCoverSource(value, siteConfig);
     const cover = (value && coverSrc)
-      ? `<div class="card-cover-wrap"><div class="ph-skeleton" aria-hidden="true"></div><img class="card-cover" alt="${escapeHtml(String(key || ''))}" data-src="${escapeHtml(cardImageSrc(coverSrc))}" loading="lazy" decoding="async" fetchpriority="low" width="1600" height="1000"></div>`
+      ? `<div class="card-cover-wrap"><div class="ph-skeleton" aria-hidden="true"></div><img class="card-cover" alt="${escapeHtml(String(key || ''))}" src="${escapeHtml(cardImageSrc(coverSrc))}" loading="lazy" decoding="async" fetchpriority="low" width="1600" height="1000"></div>`
       : (useFallbackCover ? fallbackCover(key) : '');
     const hasDate = value && value.date;
     const dateHtml = hasDate ? `<span class="card-date">${escapeHtml(formatDisplayDate(value.date))}</span>` : '';

--- a/scripts/test-card-cover-error-state.js
+++ b/scripts/test-card-cover-error-state.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+
+globalThis.document = { title: 'NanoSite' };
+globalThis.window = { location: { search: '', href: 'https://example.test/' } };
+
+let removed = false;
+const listeners = [];
+
+const ph = {
+  parentNode: {
+    removeChild(node) {
+      if (node === ph) removed = true;
+    }
+  }
+};
+
+const img = {
+  complete: true,
+  naturalWidth: 0,
+  style: {},
+  classList: {
+    add() {}
+  },
+  addEventListener(type) {
+    listeners.push(type);
+  }
+};
+
+const wrap = {
+  querySelector(selector) {
+    if (selector === 'img.card-cover') return img;
+    if (selector === '.ph-skeleton') return ph;
+    return null;
+  }
+};
+
+const root = {
+  querySelectorAll(selector) {
+    assert.equal(selector, '.index .card-cover-wrap, .link-card .card-cover-wrap');
+    return [wrap];
+  }
+};
+
+const { hydrateCardCovers } = await import('../assets/js/post-render.js?card-cover-error-state-test');
+
+hydrateCardCovers(root);
+
+assert.equal(removed, true);
+assert.equal(img.style.opacity, '1');
+assert.deepEqual(listeners, []);
+
+console.log('ok - completed failed card covers clear skeleton immediately');

--- a/scripts/test-native-cover-loading-unified.js
+++ b/scripts/test-native-cover-loading-unified.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync('assets/themes/native/modules/interactions.js', 'utf8');
+
+assert.ok(
+  !source.includes('function sequentialLoadCoversNative'),
+  'Native index covers should not use a theme-specific serial loading queue'
+);
+assert.ok(
+  !source.includes('sequentialLoadCoversNative('),
+  'Native index cover loading should be delegated to browser image scheduling'
+);
+assert.ok(
+  !source.includes('data-src="${escapeHtml(cardImageSrc(coverSrc))}"'),
+  'Native index cover templates should not hide image URLs behind data-src'
+);
+
+const directCoverSrcMatches = source.match(/<img class="card-cover"[^`]*\ssrc="\$\{escapeHtml\(cardImageSrc\(coverSrc\)\)\}"/g) || [];
+assert.ok(
+  directCoverSrcMatches.length >= 2,
+  'Native index and search cover templates should render direct src attributes'
+);
+
+console.log('ok - native index covers use direct browser image loading');


### PR DESCRIPTION
## Summary

- Remove the Native theme's serial cover image loading queue.
- Render Native index and search cover images with direct `src` attributes, matching the browser-driven loading behavior used by other themes.
- Keep existing lazy loading, async decoding, low fetch priority, and skeleton handling through the shared `hydrateCardCovers()` path.
- Add a regression test to prevent Native covers from returning to `data-src` plus a theme-specific queue.

## Validation

- `node scripts/test-native-cover-loading-unified.js`
- `node scripts/test-progressive-image-visibility.js`
- `node scripts/test-native-image-cache.js`
- `node scripts/test-cache-control.js`
- `node scripts/test-i18n-content-raw.js`
- `node scripts/test-frontmatter-roundtrip.js`
- `bash scripts/test-main-guard.sh`
- Local HTTP smoke on `http://127.0.0.1:8123/` and `assets/themes/native/modules/interactions.js`