### PR TITLE
[codex] Default to native theme

### DIFF
--- a/site.yaml
+++ b/site.yaml
@@ -52,7 +52,7 @@ defaultLanguage: en
 
 themeMode: user
 
-themePack: arcus
+themePack: native
 
 themeOverride: false
 


### PR DESCRIPTION
## Summary

- Change the site default theme pack from `arcus` to `native`.
- Keep `themeOverride: false`, so the setting remains a default and does not force-overwrite existing user theme choices.

## Validation

- `scripts/check-main-safety.sh`
- `bash scripts/test-main-guard.sh`
- `git diff --check HEAD~1 HEAD`
- HTTP smoke checked `site.yaml`, `assets/themes/native/theme.css`, and `assets/themes/native/theme.json` locally.