### PR TITLE
[codex] Add automated system release packaging

### DIFF
--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -42,7 +42,7 @@ jobs:
           fi
 
           if [[ -n "${latest_tag}" ]]; then
-            changed_files="$(git diff --name-only "${latest_tag}..HEAD" -- index.html index_editor.html assets/main.js assets/js assets/i18n assets/schema assets/themes || true)"
+            changed_files="$(git diff --name-only "${latest_tag}..HEAD" -- index.html index_editor.html assets/main.js assets/js assets/i18n assets/schema assets/themes)"
           else
             changed_files="$(git ls-files -- index.html index_editor.html assets/main.js assets/js assets/i18n assets/schema assets/themes)"
           fi

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -1,0 +1,171 @@
+name: System Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: system-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify release package boundary
+        run: |
+          bash scripts/test-system-release-package.sh
+          node --experimental-default-type=module scripts/test-system-updates.js
+
+      - name: Plan release
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          latest_tag="$(gh release view --json tagName -q '.tagName' 2>/dev/null || true)"
+          if [[ -z "${latest_tag}" ]]; then
+            latest_tag="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | sort -V | tail -n 1 || true)"
+          fi
+
+          if [[ -n "${latest_tag}" ]]; then
+            changed_files="$(git diff --name-only "${latest_tag}..HEAD" -- index.html index_editor.html assets/main.js assets/js assets/i18n assets/schema assets/themes || true)"
+          else
+            changed_files="$(git ls-files -- index.html index_editor.html assets/main.js assets/js assets/i18n assets/schema assets/themes)"
+          fi
+
+          if [[ -z "${changed_files}" ]]; then
+            {
+              echo "should_release=false"
+              echo "latest_tag=${latest_tag}"
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if [[ "${latest_tag}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            major="${BASH_REMATCH[1]}"
+            minor="${BASH_REMATCH[2]}"
+            patch="${BASH_REMATCH[3]}"
+            next_tag="v${major}.${minor}.$((patch + 1))"
+          else
+            next_tag="v0.0.1"
+          fi
+
+          if git rev-parse -q --verify "refs/tags/${next_tag}" >/dev/null; then
+            echo "Refusing to overwrite existing tag ${next_tag}" >&2
+            exit 1
+          fi
+
+          {
+            echo "should_release=true"
+            echo "latest_tag=${latest_tag}"
+            echo "next_tag=${next_tag}"
+            echo "asset_name=nanosite-system-${next_tag}.zip"
+            echo "changed_files<<EOF"
+            printf '%s\n' "${changed_files}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Build system update package
+        if: steps.plan.outputs.should_release == 'true'
+        id: package
+        run: |
+          set -euo pipefail
+          archive_path="$(bash scripts/package-system-release.sh "${{ steps.plan.outputs.next_tag }}" dist)"
+          archive_size="$(wc -c < "${archive_path}" | tr -d ' ')"
+          archive_sha256="$(shasum -a 256 "${archive_path}" | awk '{print $1}')"
+          {
+            echo "archive_path=${archive_path}"
+            echo "archive_size=${archive_size}"
+            echo "archive_sha256=${archive_sha256}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Create draft release
+        if: steps.plan.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          next_tag="${{ steps.plan.outputs.next_tag }}"
+          latest_tag="${{ steps.plan.outputs.latest_tag }}"
+          asset_name="${{ steps.plan.outputs.asset_name }}"
+          notes_file="dist/release-notes.md"
+
+          {
+            echo "## Migration Guide"
+            echo
+            echo "Use the System Updates tool in Markdown Editor to download and apply \`${asset_name}\`."
+            echo
+            echo "## System Package"
+            echo
+            echo "- Asset: \`${asset_name}\`"
+            echo "- SHA-256: \`${{ steps.package.outputs.archive_sha256 }}\`"
+            echo
+            echo "## Changed System Files"
+            echo
+            printf '%s\n' "${{ steps.plan.outputs.changed_files }}" | sed 's/^/- /'
+            if [[ -n "${latest_tag}" ]]; then
+              echo
+              echo "**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/${latest_tag}...${next_tag}"
+            fi
+          } > "${notes_file}"
+
+          gh release create "${next_tag}" \
+            "${{ steps.package.outputs.archive_path }}#NanoSite system update package" \
+            --target "${GITHUB_SHA}" \
+            --title "${next_tag}" \
+            --notes-file "${notes_file}" \
+            --draft
+
+      - name: Validate release asset
+        if: steps.plan.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_ASSET: ${{ steps.plan.outputs.asset_name }}
+          EXPECTED_SIZE: ${{ steps.package.outputs.archive_size }}
+          EXPECTED_SHA256: ${{ steps.package.outputs.archive_sha256 }}
+          NEXT_TAG: ${{ steps.plan.outputs.next_tag }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${NEXT_TAG}" > dist/release.json
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          with open("dist/release.json", "r", encoding="utf-8") as fh:
+              release = json.load(fh)
+
+          expected_name = os.environ["EXPECTED_ASSET"]
+          expected_size = int(os.environ["EXPECTED_SIZE"])
+          expected_sha = os.environ["EXPECTED_SHA256"].lower()
+          assets = [asset for asset in release.get("assets", []) if asset.get("name") == expected_name]
+          if len(assets) != 1:
+              sys.exit(f"expected exactly one release asset named {expected_name}, found {len(assets)}")
+
+          asset = assets[0]
+          if int(asset.get("size") or 0) != expected_size:
+              sys.exit(f"asset size mismatch: expected {expected_size}, got {asset.get('size')}")
+
+          digest = str(asset.get("digest") or "").lower()
+          if digest and digest != f"sha256:{expected_sha}":
+              sys.exit(f"asset digest mismatch: expected sha256:{expected_sha}, got {digest}")
+          PY
+
+      - name: Publish release
+        if: steps.plan.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release edit "${{ steps.plan.outputs.next_tag }}" --draft=false --latest

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   release:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,6 +26,7 @@ jobs:
       - name: Verify release package boundary
         run: |
           bash scripts/test-system-release-package.sh
+          bash scripts/test-system-release-workflow.sh
           node --experimental-default-type=module scripts/test-system-updates.js
 
       - name: Plan release

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -20,6 +20,8 @@ The old long-lived `doc` branch is retired. Do not use it for development, docum
 ```bash
 bash scripts/test-main-guard.sh
 bash scripts/test-frontmatter-roundtrip.sh
+bash scripts/test-system-release-package.sh
+node --experimental-default-type=module scripts/test-system-updates.js
 ```
 
 5. Merge back to `main` after review and verification.
@@ -32,6 +34,14 @@ bash scripts/test-frontmatter-roundtrip.sh
 When a runtime feature changes user-facing behavior, update the relevant documentation in `wwwroot/` in the same branch. This keeps the official site and the code versioned together.
 
 The minimal user starter will live in a separate repository named `NanoSite-Starter`. Do not strip this repository's `wwwroot/` back to a minimal template.
+
+## System Release Packages
+
+`main` publishes GitHub Pages directly from the repository root, but system updates use a separate release ZIP. After a push to `main`, the release workflow checks whether runtime files changed since the latest release tag. If only documentation or content changed under `wwwroot/`, no release is created.
+
+When runtime files changed, the workflow bumps the patch version, creates a GitHub Release, and uploads exactly one package named `nanosite-system-vX.Y.Z.zip`. That package is an allowlisted runtime bundle only: `index.html`, `index_editor.html`, `assets/main.js`, `assets/js/`, `assets/i18n/`, `assets/schema/`, and `assets/themes/`.
+
+The package must not include user-controlled content or site configuration such as `wwwroot/`, `site.yaml`, `CNAME`, `robots.txt`, `sitemap.xml`, repository docs, scripts, workflow files, or repo-specific root media. Users who customize files under `assets/js/` or `assets/themes/` are modifying the system namespace, and those files may be overwritten by system updates.
 
 ## Local Testing Data Isolation
 

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -21,6 +21,7 @@ The old long-lived `doc` branch is retired. Do not use it for development, docum
 bash scripts/test-main-guard.sh
 bash scripts/test-frontmatter-roundtrip.sh
 bash scripts/test-system-release-package.sh
+bash scripts/test-system-release-workflow.sh
 node --experimental-default-type=module scripts/test-system-updates.js
 ```
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Run the focused checks before merging:
 bash scripts/test-main-guard.sh
 bash scripts/test-frontmatter-roundtrip.sh
 bash scripts/test-system-release-package.sh
+bash scripts/test-system-release-workflow.sh
 node --experimental-default-type=module scripts/test-system-updates.js
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,15 @@ Run the focused checks before merging:
 ```bash
 bash scripts/test-main-guard.sh
 bash scripts/test-frontmatter-roundtrip.sh
+bash scripts/test-system-release-package.sh
+node --experimental-default-type=module scripts/test-system-updates.js
 ```
+
+## System Releases
+
+Merges to `main` that change NanoSite runtime files automatically publish a patch release with a dedicated `nanosite-system-vX.Y.Z.zip` update package. The package is intentionally limited to the application shell and runtime assets: `index.html`, `index_editor.html`, `assets/main.js`, `assets/js/`, `assets/i18n/`, `assets/schema/`, and `assets/themes/`.
+
+Official documentation and site content stay out of update packages. Changes that only touch `wwwroot/` do not create a system release, and update packages must never include `wwwroot/`, `site.yaml`, `CNAME`, `robots.txt`, `sitemap.xml`, repo docs, workflow files, scripts, or site-specific media such as `assets/avatar.jpeg` and `assets/hero.jpeg`.
 
 ## Branching
 

--- a/assets/i18n/en.js
+++ b/assets/i18n/en.js
@@ -113,7 +113,7 @@ const translations = {
         publishedLabel: ({ date }) => `Published on ${date}`,
         assetLabel: ({ name, size }) => `Asset: ${name} (${size})`,
         assetWithHash: ({ name, size, hash }) => `Asset: ${name} (${size}) — SHA-256 ${hash}`,
-        noAsset: 'No downloadable assets were attached to this release.',
+        noAsset: 'No NanoSite system update package was attached to this release.',
         status: {
           idle: 'Download the latest release ZIP, then select it to check for updates.',
           reading: 'Reading archive…',
@@ -127,6 +127,7 @@ const translations = {
           emptyFile: 'The selected file is empty.',
           invalidArchive: 'The selected ZIP could not be read as a NanoSite release.',
           sizeMismatch: ({ expected, actual }) => `The selected archive size (${actual}) does not match the release asset (${expected}).`,
+          digestMismatch: 'The selected archive SHA-256 does not match the release asset.',
           generic: 'System update failed. Please try again.'
         },
         fileStatus: {

--- a/assets/i18n/ja.js
+++ b/assets/i18n/ja.js
@@ -113,7 +113,7 @@ const translations = {
         publishedLabel: ({ date }) => `公開日：${date}`,
         assetLabel: ({ name, size }) => `アセット：${name}（${size}）`,
         assetWithHash: ({ name, size, hash }) => `アセット：${name}（${size}） — SHA-256 ${hash}`,
-        noAsset: 'このリリースにはダウンロード可能なアセットがありません。',
+        noAsset: 'このリリースにはダウンロード可能な NanoSite システム更新パッケージがありません。',
         status: {
           idle: '最新のリリース ZIP をダウンロードしてから、更新を確認するために選択してください。',
           reading: 'アーカイブを読み込み中…',
@@ -127,6 +127,7 @@ const translations = {
           emptyFile: '選択したファイルは空です。',
           invalidArchive: '選択した ZIP を NanoSite リリースとして読み込めませんでした。',
           sizeMismatch: ({ expected, actual }) => `選択したアーカイブのサイズ（${actual}）がリリースアセット（${expected}）と一致しません。`,
+          digestMismatch: '選択したアーカイブの SHA-256 がリリースアセットと一致しません。',
           generic: 'システム更新に失敗しました。再試行してください。'
         },
         fileStatus: {

--- a/assets/i18n/zh-TW.js
+++ b/assets/i18n/zh-TW.js
@@ -113,7 +113,7 @@ const translations = {
         publishedLabel: ({ date }) => `釋出時間：${date}`,
         assetLabel: ({ name, size }) => `附件：${name}（${size}）`,
         assetWithHash: ({ name, size, hash }) => `附件：${name}（${size}） — SHA-256 ${hash}`,
-        noAsset: '此釋出沒有可下載的附件。',
+        noAsset: '此釋出沒有可下載的 NanoSite 系統更新包。',
         status: {
           idle: '先下載最新的釋出 ZIP，然後選擇該檔案以檢查更新。',
           reading: '正在讀取壓縮包…',
@@ -127,6 +127,7 @@ const translations = {
           emptyFile: '選擇的檔案為空。',
           invalidArchive: '選中的 ZIP 無法作為 NanoSite 釋出讀取。',
           sizeMismatch: ({ expected, actual }) => `選中的壓縮包大小（${actual}）與釋出附件（${expected}）不一致。`,
+          digestMismatch: '選中的壓縮包 SHA-256 與釋出附件不一致。',
           generic: '系統更新失敗，請重試。'
         },
         fileStatus: {

--- a/assets/i18n/zh.js
+++ b/assets/i18n/zh.js
@@ -113,7 +113,7 @@ const translations = {
         publishedLabel: ({ date }) => `发布时间：${date}`,
         assetLabel: ({ name, size }) => `附件：${name}（${size}）`,
         assetWithHash: ({ name, size, hash }) => `附件：${name}（${size}） — SHA-256 ${hash}`,
-        noAsset: '此发布没有可下载的附件。',
+        noAsset: '此发布没有可下载的 NanoSite 系统更新包。',
         status: {
           idle: '先下载最新的发布 ZIP，然后选择该文件以检查更新。',
           reading: '正在读取压缩包…',
@@ -127,6 +127,7 @@ const translations = {
           emptyFile: '选择的文件为空。',
           invalidArchive: '选中的 ZIP 无法作为 NanoSite 发布读取。',
           sizeMismatch: ({ expected, actual }) => `选中的压缩包大小（${actual}）与发布附件（${expected}）不一致。`,
+          digestMismatch: '选中的压缩包 SHA-256 与发布附件不一致。',
           generic: '系统更新失败，请重试。'
         },
         fileStatus: {

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -9,6 +9,11 @@ const TEXT_EXTENSIONS = new Set([
 ]);
 const TEXT_FILENAMES = new Set(['LICENSE', 'README', 'README.md', 'CHANGELOG', 'CHANGELOG.md']);
 
+export const SYSTEM_UPDATE_ASSET_NAME_PATTERN = /^nanosite-system-v\d+\.\d+\.\d+\.zip$/i;
+
+const SYSTEM_UPDATE_ALLOWED_PATH_PATTERN = /^(?:index\.html|index_editor\.html|assets\/(?:main\.js|js\/.+|i18n\/.+|schema\/.+|themes\/.+))$/;
+const SYSTEM_UPDATE_BLOCKED_PATH_PATTERN = /^(?:\.git\/|\.github\/|wwwroot\/|site\.ya?ml$|site\.local\.ya?ml$|CNAME$|robots\.txt$|sitemap\.xml$|README(?:\.md)?$|BRANCHING\.md$|scripts\/|assets\/(?:avatar|hero)\.jpeg$)/i;
+
 let initialized = false;
 let releaseCache = null;
 let busy = false;
@@ -195,14 +200,93 @@ function renderFileList() {
   });
 }
 
-function normalizePaths(entries) {
-  const paths = entries.map((name) => name.replace(/\\+/g, '/'));
+function normalizeArchiveEntryPath(path) {
+  const raw = String(path || '').replace(/\\+/g, '/');
+  if (!raw || raw.endsWith('/')) return '';
+  if (raw.startsWith('/') || /^[a-z]:\//i.test(raw) || /^[a-z][a-z0-9+.-]*:\/\//i.test(raw)) {
+    throw new Error(`Unsafe system update archive path: ${raw}`);
+  }
+  const clean = raw.replace(/^\/+/, '');
+  const parts = clean.split('/');
+  if (parts.some((part) => part === '..' || part === '.')) {
+    throw new Error(`Unsafe system update archive path: ${raw}`);
+  }
+  return clean;
+}
+
+function stripCommonArchiveRoot(entries) {
+  const paths = entries.map((name) => String(name || '').replace(/\\+/g, '/'));
   if (!paths.length) return [];
   const segments = paths.map((p) => p.split('/'));
   if (!segments.every((parts) => parts.length > 1)) return paths;
   const root = segments[0][0];
   if (!segments.every((parts) => parts[0] === root)) return paths;
   return paths.map((parts) => parts.split('/').slice(1).join('/'));
+}
+
+export function isSystemUpdatePath(path) {
+  const clean = String(path || '').replace(/\\+/g, '/').replace(/^\/+/, '');
+  return SYSTEM_UPDATE_ALLOWED_PATH_PATTERN.test(clean) && !SYSTEM_UPDATE_BLOCKED_PATH_PATTERN.test(clean);
+}
+
+export function collectSystemUpdateArchiveEntries(buffer) {
+  const archive = unzipSync(new Uint8Array(buffer));
+  const names = Object.keys(archive || {});
+  if (!names.length) return [];
+
+  const rawEntries = names
+    .map((name) => ({
+      raw: name,
+      path: normalizeArchiveEntryPath(name),
+      data: archive[name]
+    }))
+    .filter((item) => item.path && item.data && item.data.length);
+
+  const strippedPaths = stripCommonArchiveRoot(rawEntries.map((item) => item.path));
+  return rawEntries.map((entry, index) => {
+    const path = normalizeArchiveEntryPath(strippedPaths[index]);
+    if (!isSystemUpdatePath(path)) {
+      throw new Error(`Unsafe system update archive path: ${path}`);
+    }
+    return {
+      path,
+      data: entry.data
+    };
+  });
+}
+
+export function selectSystemUpdateAsset(releaseData) {
+  const assets = Array.isArray(releaseData && releaseData.assets) ? releaseData.assets : [];
+  const asset = assets.find((item) => item && SYSTEM_UPDATE_ASSET_NAME_PATTERN.test(String(item.name || '')));
+  if (!asset) return null;
+  return {
+    name: asset.name || 'nanosite-system.zip',
+    url: asset.browser_download_url || asset.url || '',
+    size: asset.size || 0,
+    digest: asset.digest || ''
+  };
+}
+
+export async function verifySystemUpdateAsset(buffer, asset = {}) {
+  if (!(buffer instanceof ArrayBuffer)) buffer = getBuffer(buffer);
+  const actualSize = buffer ? buffer.byteLength : 0;
+  const actualSha256 = await digestSha256(buffer);
+  const expectedSize = Number(asset && asset.size);
+  if (Number.isFinite(expectedSize) && expectedSize > 0 && Math.abs(expectedSize - actualSize) > 0) {
+    throw new Error(t('editor.systemUpdates.errors.sizeMismatch', {
+      expected: formatSize(expectedSize),
+      actual: formatSize(actualSize)
+    }));
+  }
+  const expectedDigestRaw = String((asset && asset.digest) || '').trim().toLowerCase();
+  const expectedDigest = expectedDigestRaw.replace(/^sha256:/, '');
+  if (expectedDigest && expectedDigest !== actualSha256.toLowerCase()) {
+    throw new Error(t('editor.systemUpdates.errors.digestMismatch'));
+  }
+  return {
+    size: actualSize,
+    sha256: actualSha256
+  };
 }
 
 async function fetchLatestRelease() {
@@ -213,28 +297,14 @@ async function fetchLatestRelease() {
   });
   if (!response.ok) throw new Error(t('editor.systemUpdates.errors.releaseFetch'));
   const data = await response.json();
-  const asset = Array.isArray(data.assets) && data.assets.length ? data.assets[0] : null;
-  const archiveUrl = data && (data.zipball_url || data.tarball_url) ? (data.zipball_url || data.tarball_url) : '';
-  const archiveName = (() => {
-    const base = data && (data.tag_name || data.name);
-    if (!base) return 'source.zip';
-    return `${String(base).replace(/\s+/g, '-').replace(/[^\w.-]+/g, '') || 'source'}.zip`;
-  })();
+  const asset = selectSystemUpdateAsset(data);
   releaseCache = {
     name: data.name || data.tag_name || 'latest',
     tag: data.tag_name || '',
     publishedAt: data.published_at || data.created_at || '',
     notes: data.body || '',
     htmlUrl: data.html_url || '',
-    asset: asset ? {
-      name: asset.name || 'release.zip',
-      url: asset.browser_download_url,
-      size: asset.size || 0
-    } : null,
-    archive: archiveUrl ? {
-      name: archiveName,
-      url: archiveUrl
-    } : null
+    asset
   };
   renderReleaseMeta();
   renderNotes(releaseCache.notes);
@@ -342,21 +412,8 @@ async function compareArchive(entries) {
 }
 
 async function processArchive(buffer) {
-  const archive = unzipSync(new Uint8Array(buffer));
-  const names = Object.keys(archive || {});
-  if (!names.length) return [];
-  const normalizedNames = normalizePaths(names);
-  const entries = normalizedNames.map((path, index) => ({
-    path,
-    data: archive[names[index]]
-  })).filter((item) => item.path && item.path.slice(-1) !== '/');
-  const filtered = entries.filter((item) => {
-    if (!item.path || item.path.endsWith('/')) return false;
-    const lower = item.path.toLowerCase();
-    if (lower.startsWith('.git/') || lower.startsWith('.github/')) return false;
-    return true;
-  });
-  return compareArchive(filtered);
+  const entries = collectSystemUpdateArchiveEntries(buffer);
+  return compareArchive(entries);
 }
 
 async function analyzeArchive(buffer, filename) {
@@ -368,22 +425,19 @@ async function analyzeArchive(buffer, filename) {
   const release = await fetchLatestRelease().catch(() => releaseCache);
   const nameFromRelease = release && release.asset ? (release.asset.name || release.name) : '';
   assetName = filename || nameFromRelease || 'release.zip';
-  assetSha256 = await digestSha256(buffer);
-  assetSize = buffer.byteLength;
+  const verification = release && release.asset
+    ? await verifySystemUpdateAsset(buffer, release.asset)
+    : { sha256: await digestSha256(buffer), size: buffer.byteLength };
+  assetSha256 = verification.sha256;
+  assetSize = verification.size;
 
   if (release) {
     if (release.asset) {
-      const expectedSize = Number(release.asset.size);
-      if (Number.isFinite(expectedSize) && expectedSize > 0 && Math.abs(expectedSize - assetSize) > 0) {
-        throw new Error(t('editor.systemUpdates.errors.sizeMismatch', {
-          expected: formatSize(expectedSize),
-          actual: formatSize(assetSize)
-        }));
-      }
       release.asset.size = assetSize;
+      release.asset.digest = `sha256:${assetSha256}`;
       if (!release.asset.name) release.asset.name = assetName;
     } else {
-      release.asset = { name: assetName, url: '', size: assetSize };
+      release.asset = { name: assetName, url: '', size: assetSize, digest: `sha256:${assetSha256}` };
     }
     renderReleaseMeta();
     updateDownloadLink();
@@ -503,4 +557,3 @@ export function clearSystemUpdateState(options = {}) {
   }
   renderReleaseMeta();
 }
-

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -416,7 +416,7 @@ async function processArchive(buffer) {
   return compareArchive(entries);
 }
 
-async function analyzeArchive(buffer, filename) {
+export async function analyzeArchive(buffer, filename) {
   if (!(buffer instanceof ArrayBuffer)) buffer = getBuffer(buffer);
   if (!buffer || !buffer.byteLength) {
     throw new Error(t('editor.systemUpdates.errors.emptyFile'));
@@ -434,10 +434,9 @@ async function analyzeArchive(buffer, filename) {
   if (release) {
     if (release.asset) {
       release.asset.size = assetSize;
-      release.asset.digest = `sha256:${assetSha256}`;
       if (!release.asset.name) release.asset.name = assetName;
     } else {
-      release.asset = { name: assetName, url: '', size: assetSize, digest: `sha256:${assetSha256}` };
+      release.asset = { name: assetName, url: '', size: assetSize, digest: '' };
     }
     renderReleaseMeta();
     updateDownloadLink();
@@ -552,6 +551,9 @@ export function clearSystemUpdateState(options = {}) {
   assetSha256 = '';
   assetSize = 0;
   assetName = '';
+  if (options && options.clearReleaseCache === true) {
+    releaseCache = null;
+  }
   if (options && options.keepStatus !== true) {
     setStatus(t('editor.systemUpdates.status.idle'));
   }

--- a/scripts/package-system-release.sh
+++ b/scripts/package-system-release.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${1:-}"
+output_dir="${2:-dist}"
+
+if [[ ! "${version}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "usage: $0 vMAJOR.MINOR.PATCH [output-dir]" >&2
+  exit 2
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+archive_name="nanosite-system-${version}.zip"
+prefix="nanosite-system-${version}/"
+
+system_paths=(
+  "index.html"
+  "index_editor.html"
+  "assets/main.js"
+  "assets/js"
+  "assets/i18n"
+  "assets/schema"
+  "assets/themes"
+)
+
+mkdir -p "${output_dir}"
+output_dir="$(cd "${output_dir}" && pwd)"
+archive_path="${output_dir}/${archive_name}"
+cd "${repo_root}"
+
+git archive \
+  --format=zip \
+  --prefix="${prefix}" \
+  --output="${archive_path}" \
+  HEAD \
+  -- "${system_paths[@]}"
+
+printf '%s\n' "${archive_path}"

--- a/scripts/test-system-release-package.sh
+++ b/scripts/test-system-release-package.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+version="v9.9.9"
+zip_path="${tmp_dir}/nanosite-system-${version}.zip"
+
+bash "${repo_root}/scripts/package-system-release.sh" "${version}" "${tmp_dir}" >/dev/null
+
+if [[ ! -f "${zip_path}" ]]; then
+  echo "expected package at ${zip_path}" >&2
+  exit 1
+fi
+
+entries_file="${tmp_dir}/entries.txt"
+unzip -Z1 "${zip_path}" | sed '/\/$/d' > "${entries_file}"
+
+if ! grep -qx "nanosite-system-${version}/index.html" "${entries_file}"; then
+  echo "expected package to include index.html" >&2
+  exit 1
+fi
+
+if ! grep -qx "nanosite-system-${version}/index_editor.html" "${entries_file}"; then
+  echo "expected package to include index_editor.html" >&2
+  exit 1
+fi
+
+if ! grep -qx "nanosite-system-${version}/assets/js/system-updates.js" "${entries_file}"; then
+  echo "expected package to include system updater code" >&2
+  exit 1
+fi
+
+blocked='(^|/)(wwwroot/|site\.yaml$|site\.local\.ya?ml$|CNAME$|README\.md$|BRANCHING\.md$|robots\.txt$|sitemap\.xml$|scripts/|\.github/|assets/avatar\.jpeg$|assets/hero\.jpeg$)'
+if grep -Eq "${blocked}" "${entries_file}"; then
+  echo "release package contains files outside the system update boundary:" >&2
+  grep -E "${blocked}" "${entries_file}" >&2
+  exit 1
+fi
+
+allowed="^nanosite-system-${version}/(index\\.html|index_editor\\.html|assets/(main\\.js|js/.*|i18n/.*|schema/.*|themes/.*))$"
+while IFS= read -r entry; do
+  if [[ ! "${entry}" =~ ${allowed} ]]; then
+    echo "unexpected file in system release package: ${entry}" >&2
+    exit 1
+  fi
+done < "${entries_file}"

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -19,3 +19,11 @@ if ! awk '
   echo "system release job must be guarded to run only on refs/heads/main" >&2
   exit 1
 fi
+
+if awk '
+  /changed_files="\$\(git diff --name-only/ && /\|\| true/ { found = 1 }
+  END { exit found ? 0 : 1 }
+' "${workflow}" >/dev/null; then
+  echo "system release workflow must not ignore git diff failures while planning releases" >&2
+  exit 1
+fi

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+workflow=".github/workflows/system-release.yml"
+
+if [[ ! -f "${workflow}" ]]; then
+  echo "expected ${workflow} to exist" >&2
+  exit 1
+fi
+
+if ! awk '
+  /^  release:/ { in_release = 1; next }
+  in_release && /^  [A-Za-z0-9_-]+:/ { in_release = 0 }
+  in_release && /^    if:/ { print; found = 1; exit }
+  END { if (!found) exit 1 }
+' "${workflow}" | grep -F "github.ref == 'refs/heads/main'" >/dev/null; then
+  echo "system release job must be guarded to run only on refs/heads/main" >&2
+  exit 1
+fi

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import { webcrypto } from 'node:crypto';
+import { zipSync, strToU8 } from '../assets/js/vendor/fflate.browser.js';
+
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
+if (!globalThis.btoa) {
+  globalThis.btoa = (value) => Buffer.from(value, 'binary').toString('base64');
+}
+globalThis.document = {
+  title: 'NanoSite',
+  baseURI: 'https://example.test/',
+  documentElement: { setAttribute() {} },
+  querySelectorAll: () => []
+};
+globalThis.window = {
+  location: { href: 'https://example.test/', protocol: 'https:' },
+  dispatchEvent() {}
+};
+globalThis.CustomEvent = class CustomEvent {
+  constructor(type, init = {}) {
+    this.type = type;
+    this.detail = init.detail;
+  }
+};
+
+const {
+  collectSystemUpdateArchiveEntries,
+  selectSystemUpdateAsset,
+  verifySystemUpdateAsset
+} = await import('../assets/js/system-updates.js?system-updates-test');
+
+function makeZip(files) {
+  const entries = {};
+  Object.entries(files).forEach(([path, content]) => {
+    entries[path] = strToU8(String(content));
+  });
+  return zipSync(entries).buffer;
+}
+
+async function sha256(buffer) {
+  const digest = await webcrypto.subtle.digest('SHA-256', buffer);
+  return Buffer.from(digest).toString('hex');
+}
+
+async function run(name, fn) {
+  try {
+    await fn();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    console.error(`not ok - ${name}`);
+    throw error;
+  }
+}
+
+await run('selects the dedicated NanoSite system release asset', async () => {
+  const asset = selectSystemUpdateAsset({
+    assets: [
+      { name: 'source.zip', browser_download_url: 'https://example.test/source.zip' },
+      { name: 'nanosite-system-v3.3.5.zip', browser_download_url: 'https://example.test/system.zip' }
+    ]
+  });
+
+  assert.equal(asset.name, 'nanosite-system-v3.3.5.zip');
+  assert.equal(asset.url, 'https://example.test/system.zip');
+  assert.equal(selectSystemUpdateAsset({
+    assets: [{ name: 'NanoSite-v3.3.5-source.zip', browser_download_url: 'https://example.test/source.zip' }]
+  }), null);
+});
+
+await run('verifies release asset size and digest before archive comparison', async () => {
+  const buffer = makeZip({ 'nanosite-system-v3.3.5/index.html': '<!doctype html>' });
+  const digest = await sha256(buffer);
+
+  await verifySystemUpdateAsset(buffer, {
+    name: 'nanosite-system-v3.3.5.zip',
+    size: buffer.byteLength,
+    digest: `sha256:${digest}`
+  }, 'nanosite-system-v3.3.5.zip');
+
+  await assert.rejects(
+    () => verifySystemUpdateAsset(buffer, {
+      name: 'nanosite-system-v3.3.5.zip',
+      size: buffer.byteLength,
+      digest: 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
+    }, 'nanosite-system-v3.3.5.zip'),
+    /sha-?256|digest|hash/i
+  );
+});
+
+await run('normalizes a rooted system update archive to safe site-relative paths', async () => {
+  const buffer = makeZip({
+    'nanosite-system-v3.3.5/index.html': '<!doctype html>',
+    'nanosite-system-v3.3.5/assets/js/system-updates.js': 'export {};'
+  });
+
+  const entries = collectSystemUpdateArchiveEntries(buffer);
+
+  assert.deepEqual(entries.map((entry) => entry.path).sort(), [
+    'assets/js/system-updates.js',
+    'index.html'
+  ]);
+});
+
+await run('rejects archives that would overwrite user content or site config', async () => {
+  assert.throws(
+    () => collectSystemUpdateArchiveEntries(makeZip({
+      'nanosite-system-v3.3.5/wwwroot/index.yaml': 'posts: []'
+    })),
+    /unsafe|system update/i
+  );
+
+  assert.throws(
+    () => collectSystemUpdateArchiveEntries(makeZip({
+      'nanosite-system-v3.3.5/site.yaml': 'contentRoot: wwwroot'
+    })),
+    /unsafe|system update/i
+  );
+});
+
+await run('rejects path traversal entries before comparing files', async () => {
+  assert.throws(
+    () => collectSystemUpdateArchiveEntries(makeZip({
+      'nanosite-system-v3.3.5/../site.yaml': 'contentRoot: wwwroot'
+    })),
+    /unsafe|system update/i
+  );
+});

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -24,7 +24,9 @@ globalThis.CustomEvent = class CustomEvent {
 };
 
 const {
+  analyzeArchive,
   collectSystemUpdateArchiveEntries,
+  clearSystemUpdateState,
   selectSystemUpdateAsset,
   verifySystemUpdateAsset
 } = await import('../assets/js/system-updates.js?system-updates-test');
@@ -124,4 +126,41 @@ await run('rejects path traversal entries before comparing files', async () => {
     })),
     /unsafe|system update/i
   );
+});
+
+await run('does not poison expected release digest from a selected local archive', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  const wrongBuffer = makeZip({ 'nanosite-system-v3.3.5/index.html': '<!doctype html><p>wrong</p>' });
+  const rightBuffer = makeZip({ 'nanosite-system-v3.3.5/index.html': '<!doctype html><p>right</p>' });
+  let releaseCalls = 0;
+
+  globalThis.fetch = async (input) => {
+    const url = String(input || '');
+    if (url.includes('/repos/deemoe404/NanoSite/releases/latest')) {
+      releaseCalls += 1;
+      return {
+        ok: true,
+        json: async () => ({
+          name: 'v3.3.5',
+          tag_name: 'v3.3.5',
+          assets: [{
+            name: 'nanosite-system-v3.3.5.zip',
+            browser_download_url: 'https://example.test/nanosite-system-v3.3.5.zip',
+            size: 0,
+            digest: ''
+          }]
+        })
+      };
+    }
+    return {
+      ok: false,
+      arrayBuffer: async () => new ArrayBuffer(0)
+    };
+  };
+
+  await analyzeArchive(wrongBuffer, 'nanosite-system-v3.3.5.zip');
+  await analyzeArchive(rightBuffer, 'nanosite-system-v3.3.5.zip');
+
+  assert.equal(releaseCalls, 1);
+  delete globalThis.fetch;
 });


### PR DESCRIPTION
## Summary
- Add a `System Release` GitHub Actions workflow that publishes a patch release only when system/runtime files changed on `main`.
- Add a dedicated `nanosite-system-vX.Y.Z.zip` package generator and boundary tests so release assets exclude user content and site config.
- Harden the editor system updater to select only dedicated system package assets, verify size/SHA-256, and reject unsafe archive paths such as `wwwroot/`, `site.yaml`, and traversal entries.
- Document the runtime/content release boundary in README and BRANCHING.

## Validation
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-frontmatter-roundtrip.sh`
- `bash scripts/test-system-release-package.sh`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `for f in scripts/test-cache-control.js scripts/test-card-cover-error-state.js scripts/test-i18n-content-raw.js scripts/test-native-cover-loading-unified.js scripts/test-native-image-cache.js scripts/test-progressive-image-visibility.js; do node --experimental-default-type=module "$f"; done`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/system-release.yml"); YAML.load_file(".github/workflows/main-guard.yml")'`

## Notes
After this PR merges to `main`, the new workflow should detect system-file changes since `v3.3.4` and publish `v3.3.5` with `nanosite-system-v3.3.5.zip` as the latest release asset.