### PR TITLE
Fix draft system release validation

### DIFF
--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -64,11 +64,6 @@ jobs:
             next_tag="v0.0.1"
           fi
 
-          if git rev-parse -q --verify "refs/tags/${next_tag}" >/dev/null; then
-            echo "Refusing to overwrite existing tag ${next_tag}" >&2
-            exit 1
-          fi
-
           {
             echo "should_release=true"
             echo "latest_tag=${latest_tag}"
@@ -125,6 +120,26 @@ jobs:
             echo "Deleting stale draft release ${draft_release_id}"
             gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/${draft_release_id}" >/dev/null
           done < dist/stale-draft-release-ids.txt
+
+          if [[ -s dist/stale-draft-release-ids.txt ]]; then
+            if git ls-remote --exit-code --tags origin "refs/tags/${next_tag}" >/dev/null 2>&1; then
+              echo "Deleting stale remote tag ${next_tag}"
+              git push --delete origin "${next_tag}"
+            fi
+            if git rev-parse -q --verify "refs/tags/${next_tag}" >/dev/null; then
+              echo "Deleting stale local tag ${next_tag}"
+              git tag -d "${next_tag}"
+            fi
+          fi
+
+          if git rev-parse -q --verify "refs/tags/${next_tag}" >/dev/null; then
+            echo "Refusing to overwrite existing tag ${next_tag}" >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/${next_tag}" >/dev/null 2>&1; then
+            echo "Refusing to overwrite existing remote tag ${next_tag}" >&2
+            exit 1
+          fi
 
           {
             echo "## Migration Guide"

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -111,7 +111,7 @@ jobs:
               releases = json.load(fh)
 
           for release in releases:
-              if release.get("draft") and (release.get("tag_name") == next_tag or release.get("name") == next_tag):
+              if release.get("draft") and release.get("tag_name") == next_tag:
                   print(release["id"])
           PY
 
@@ -179,7 +179,7 @@ jobs:
 
           matches = [
               release for release in releases
-              if release.get("draft") and (release.get("tag_name") == next_tag or release.get("name") == next_tag)
+              if release.get("draft") and release.get("tag_name") == next_tag
           ]
           if len(matches) != 1:
               sys.exit(f"expected exactly one draft release for {next_tag}, found {len(matches)}")

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -95,6 +95,7 @@ jobs:
 
       - name: Create draft release
         if: steps.plan.outputs.should_release == 'true'
+        id: create
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -103,6 +104,27 @@ jobs:
           latest_tag="${{ steps.plan.outputs.latest_tag }}"
           asset_name="${{ steps.plan.outputs.asset_name }}"
           notes_file="dist/release-notes.md"
+          export NEXT_TAG="${next_tag}"
+
+          gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > dist/releases-before-create.json
+          python3 - <<'PY' > dist/stale-draft-release-ids.txt
+          import json
+          import os
+
+          next_tag = os.environ["NEXT_TAG"]
+          with open("dist/releases-before-create.json", "r", encoding="utf-8") as fh:
+              releases = json.load(fh)
+
+          for release in releases:
+              if release.get("draft") and (release.get("tag_name") == next_tag or release.get("name") == next_tag):
+                  print(release["id"])
+          PY
+
+          while IFS= read -r draft_release_id; do
+            [[ -n "${draft_release_id}" ]] || continue
+            echo "Deleting stale draft release ${draft_release_id}"
+            gh api --method DELETE "repos/${GITHUB_REPOSITORY}/releases/${draft_release_id}" >/dev/null
+          done < dist/stale-draft-release-ids.txt
 
           {
             echo "## Migration Guide"
@@ -130,6 +152,27 @@ jobs:
             --notes-file "${notes_file}" \
             --draft
 
+          gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > dist/releases-after-create.json
+          release_id="$(python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          next_tag = os.environ["NEXT_TAG"]
+          with open("dist/releases-after-create.json", "r", encoding="utf-8") as fh:
+              releases = json.load(fh)
+
+          matches = [
+              release for release in releases
+              if release.get("draft") and (release.get("tag_name") == next_tag or release.get("name") == next_tag)
+          ]
+          if len(matches) != 1:
+              sys.exit(f"expected exactly one draft release for {next_tag}, found {len(matches)}")
+          print(matches[0]["id"])
+          PY
+          )"
+          echo "release_id=${release_id}" >> "${GITHUB_OUTPUT}"
+
       - name: Validate release asset
         if: steps.plan.outputs.should_release == 'true'
         env:
@@ -137,10 +180,9 @@ jobs:
           EXPECTED_ASSET: ${{ steps.plan.outputs.asset_name }}
           EXPECTED_SIZE: ${{ steps.package.outputs.archive_size }}
           EXPECTED_SHA256: ${{ steps.package.outputs.archive_sha256 }}
-          NEXT_TAG: ${{ steps.plan.outputs.next_tag }}
         run: |
           set -euo pipefail
-          gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${NEXT_TAG}" > dist/release.json
+          gh api "repos/${GITHUB_REPOSITORY}/releases/${{ steps.create.outputs.release_id }}" > dist/release.json
           python3 - <<'PY'
           import json
           import os
@@ -169,5 +211,19 @@ jobs:
         if: steps.plan.outputs.should_release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          NEXT_TAG: ${{ steps.plan.outputs.next_tag }}
         run: |
-          gh release edit "${{ steps.plan.outputs.next_tag }}" --draft=false --latest
+          set -euo pipefail
+          python3 - <<'PY' > dist/publish-release.json
+          import json
+          import os
+
+          print(json.dumps({
+              "tag_name": os.environ["NEXT_TAG"],
+              "target_commitish": os.environ["GITHUB_SHA"],
+              "name": os.environ["NEXT_TAG"],
+              "draft": False,
+              "make_latest": "true"
+          }))
+          PY
+          gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${{ steps.create.outputs.release_id }}" --input dist/publish-release.json >/dev/null

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -42,3 +42,20 @@ if ! grep -F 'stale-draft-release-ids.txt' "${workflow}" >/dev/null; then
   echo "system release workflow must clean stale draft releases for retry safety" >&2
   exit 1
 fi
+
+if ! grep -F 'git push --delete origin "${next_tag}"' "${workflow}" >/dev/null; then
+  echo "system release workflow must delete stale release tags before retrying" >&2
+  exit 1
+fi
+
+if ! grep -F 'git tag -d "${next_tag}"' "${workflow}" >/dev/null; then
+  echo "system release workflow must delete stale local release tags before retrying" >&2
+  exit 1
+fi
+
+stale_cleanup_line="$(grep -nF 'stale-draft-release-ids.txt' "${workflow}" | head -n 1 | cut -d: -f1)"
+tag_refusal_line="$(grep -nF 'Refusing to overwrite existing tag' "${workflow}" | head -n 1 | cut -d: -f1)"
+if [[ -n "${tag_refusal_line}" && -n "${stale_cleanup_line}" && "${tag_refusal_line}" -lt "${stale_cleanup_line}" ]]; then
+  echo "system release workflow must clean stale drafts and tags before refusing an existing tag" >&2
+  exit 1
+fi

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -27,3 +27,18 @@ if awk '
   echo "system release workflow must not ignore git diff failures while planning releases" >&2
   exit 1
 fi
+
+if grep -F 'releases/tags/${NEXT_TAG}' "${workflow}" >/dev/null; then
+  echo "system release workflow must not validate draft releases through the tag endpoint" >&2
+  exit 1
+fi
+
+if ! grep -F 'steps.create.outputs.release_id' "${workflow}" >/dev/null; then
+  echo "system release workflow must validate and publish the draft release by release id" >&2
+  exit 1
+fi
+
+if ! grep -F 'stale-draft-release-ids.txt' "${workflow}" >/dev/null; then
+  echo "system release workflow must clean stale draft releases for retry safety" >&2
+  exit 1
+fi

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -43,6 +43,16 @@ if ! grep -F 'stale-draft-release-ids.txt' "${workflow}" >/dev/null; then
   exit 1
 fi
 
+if grep -F 'release.get("name") == next_tag' "${workflow}" >/dev/null; then
+  echo "system release workflow must identify stale releases by tag_name, not editable release names" >&2
+  exit 1
+fi
+
+if ! grep -F 'release.get("tag_name") == next_tag' "${workflow}" >/dev/null; then
+  echo "system release workflow must match stale draft releases by tag_name" >&2
+  exit 1
+fi
+
 if ! grep -F 'git push --delete origin "${next_tag}"' "${workflow}" >/dev/null; then
   echo "system release workflow must delete stale release tags before retrying" >&2
   exit 1


### PR DESCRIPTION
## Summary
- Diagnose and fix the failed first System Release run after #271 landed.
- Validate draft releases by release id instead of the `/releases/tags/{tag}` endpoint, which returns 404 for the draft created by `gh release create`.
- Clean stale same-version draft releases before retrying so the failed `v3.3.5` draft does not block the next run.
- Publish the validated draft through the release id while explicitly setting the planned tag/name/latest state.

## Verification
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-frontmatter-roundtrip.sh`
- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-system-release-workflow.sh`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- existing JS smoke test loop
- `git diff --check`
- workflow YAML parse via Ruby