### PR TITLE
[codex] Stabilize system release creation

### DIFF
--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -160,33 +160,47 @@ jobs:
             fi
           } > "${notes_file}"
 
-          gh release create "${next_tag}" \
-            "${{ steps.package.outputs.archive_path }}#NanoSite system update package" \
-            --target "${GITHUB_SHA}" \
-            --title "${next_tag}" \
-            --notes-file "${notes_file}" \
-            --draft
-
-          gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" > dist/releases-after-create.json
-          release_id="$(python3 - <<'PY'
+          export RELEASE_NOTES_FILE="${notes_file}"
+          python3 - <<'PY' > dist/create-release.json
           import json
           import os
-          import sys
+          from pathlib import Path
 
           next_tag = os.environ["NEXT_TAG"]
-          with open("dist/releases-after-create.json", "r", encoding="utf-8") as fh:
-              releases = json.load(fh)
+          notes_file = Path(os.environ["RELEASE_NOTES_FILE"])
+          print(json.dumps({
+              "tag_name": next_tag,
+              "target_commitish": os.environ["GITHUB_SHA"],
+              "name": next_tag,
+              "body": notes_file.read_text(encoding="utf-8"),
+              "draft": True,
+              "prerelease": False
+          }))
+          PY
 
-          matches = [
-              release for release in releases
-              if release.get("draft") and release.get("tag_name") == next_tag
-          ]
-          if len(matches) != 1:
-              sys.exit(f"expected exactly one draft release for {next_tag}, found {len(matches)}")
-          print(matches[0]["id"])
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/releases" --input dist/create-release.json > dist/release-created.json
+          release_id="$(python3 - <<'PY'
+          import json
+          import sys
+
+          with open("dist/release-created.json", "r", encoding="utf-8") as fh:
+              release = json.load(fh)
+
+          release_id = release.get("id")
+          if not isinstance(release_id, int):
+              sys.exit("release creation response did not include a numeric id")
+          print(release_id)
           PY
           )"
           echo "release_id=${release_id}" >> "${GITHUB_OUTPUT}"
+
+          curl --fail-with-body --silent --show-error --request POST \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Content-Type: application/zip" \
+            --data-binary @"${{ steps.package.outputs.archive_path }}" \
+            "https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?name=${asset_name}&label=NanoSite%20system%20update%20package" \
+            > dist/release-asset.json
 
       - name: Validate release asset
         if: steps.plan.outputs.should_release == 'true'

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -38,6 +38,36 @@ if ! grep -F 'steps.create.outputs.release_id' "${workflow}" >/dev/null; then
   exit 1
 fi
 
+if grep -F 'gh release create' "${workflow}" >/dev/null; then
+  echo "system release workflow must create draft releases through the releases API, not gh release create" >&2
+  exit 1
+fi
+
+if grep -F 'releases-after-create.json' "${workflow}" >/dev/null; then
+  echo "system release workflow must not list releases after create to recover the new release id" >&2
+  exit 1
+fi
+
+if grep -F 'expected exactly one draft release' "${workflow}" >/dev/null; then
+  echo "system release workflow must not depend on immediate list visibility after draft creation" >&2
+  exit 1
+fi
+
+if ! grep -F 'dist/release-created.json' "${workflow}" >/dev/null; then
+  echo "system release workflow must persist the draft release creation response" >&2
+  exit 1
+fi
+
+if ! grep -F 'repos/${GITHUB_REPOSITORY}/releases" --input dist/create-release.json' "${workflow}" >/dev/null; then
+  echo "system release workflow must create draft releases through the REST releases API" >&2
+  exit 1
+fi
+
+if ! grep -F 'uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets' "${workflow}" >/dev/null; then
+  echo "system release workflow must upload the release asset by release id" >&2
+  exit 1
+fi
+
 if ! grep -F 'stale-draft-release-ids.txt' "${workflow}" >/dev/null; then
   echo "system release workflow must clean stale draft releases for retry safety" >&2
   exit 1


### PR DESCRIPTION
## Summary
- create system release drafts through the GitHub Releases REST API and parse the returned release id directly
- upload the system package asset through the upload API using that release id
- tighten the workflow guard test so it rejects the previous create-then-list recovery path

## Validation
- `git diff --check`
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-system-release-workflow.sh`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/system-release.yml"); puts "yaml ok"'`
