### PR TITLE
[codex] Remove deprecated site navigation links

### DIFF
--- a/assets/i18n/chs.js
+++ b/assets/i18n/chs.js
@@ -383,8 +383,6 @@ const translations = {
             siteKeywordsHelp: '用于 SEO 的逗号分隔关键词（可选）。',
             profileLinks: '个人链接',
             profileLinksHelp: '显示在头像附近的个人或社交链接。',
-            navLinks: '导航链接',
-            navLinksHelp: '显示在导航菜单中的自定义链接。',
             defaultLanguage: '默认语言',
             defaultLanguageHelp: '当浏览器首选语言不匹配时使用的语言代码。',
             contentOutdatedDays: '过期提醒（天）',

--- a/assets/i18n/cht-tw.js
+++ b/assets/i18n/cht-tw.js
@@ -383,8 +383,6 @@ const translations = {
             siteKeywordsHelp: '用於 SEO 的逗號分隔關鍵詞（可選）。',
             profileLinks: '個人連結',
             profileLinksHelp: '顯示在頭像附近的個人或社交連結。',
-            navLinks: '導航連結',
-            navLinksHelp: '顯示在導航選單中的自定義連結。',
             defaultLanguage: '預設語言',
             defaultLanguageHelp: '當瀏覽器首選語言不匹配時使用的語言程式碼。',
             contentOutdatedDays: '過期提醒（天）',

--- a/assets/i18n/en.js
+++ b/assets/i18n/en.js
@@ -382,8 +382,6 @@ const translations = {
             siteKeywordsHelp: 'Comma-separated keywords for SEO (optional).',
             profileLinks: 'Profile links',
             profileLinksHelp: 'List of profile or social links shown near the avatar.',
-            navLinks: 'Navigation links',
-            navLinksHelp: 'Custom links shown in the navigation menu.',
             defaultLanguage: 'Default language',
             defaultLanguageHelp: 'Language code to use when no browser preference is matched.',
             contentOutdatedDays: 'Outdated threshold (days)',

--- a/assets/i18n/ja.js
+++ b/assets/i18n/ja.js
@@ -383,8 +383,6 @@ const translations = {
             siteKeywordsHelp: 'SEO 用のカンマ区切りキーワード（任意）。',
             profileLinks: 'プロフィールリンク',
             profileLinksHelp: 'アバター付近に表示されるプロフィール / ソーシャルリンク。',
-            navLinks: 'ナビゲーションリンク',
-            navLinksHelp: 'ナビゲーションメニューに表示するカスタムリンク。',
             defaultLanguage: '既定の言語',
             defaultLanguageHelp: 'ブラウザー設定が一致しない場合に使用する言語コード。',
             contentOutdatedDays: '古い記事のしきい値（日）',

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -211,7 +211,6 @@ const SITE_FIELD_LABEL_MAP = {
   resourceURL: { i18nKey: 'editor.composer.site.fields.resourceURL' },
   contentRoot: { i18nKey: 'editor.composer.site.fields.contentRoot' },
   profileLinks: { i18nKey: 'editor.composer.site.fields.profileLinks' },
-  links: { i18nKey: 'editor.composer.site.fields.navLinks' },
   contentOutdatedDays: { i18nKey: 'editor.composer.site.fields.contentOutdatedDays' },
   cardCoverFallback: { i18nKey: 'editor.composer.site.fields.cardCoverFallback' },
   errorOverlay: { i18nKey: 'editor.composer.site.fields.errorOverlay' },
@@ -1870,7 +1869,6 @@ function prepareSiteState(raw) {
   site.resourceURL = safeString(src.resourceURL || '');
   site.contentRoot = safeString(src.contentRoot || 'wwwroot');
   site.profileLinks = normalizeLinkList(src.profileLinks);
-  site.links = normalizeLinkList(src.links);
   site.contentOutdatedDays = normalizeNumber(src.contentOutdatedDays);
   site.cardCoverFallback = normalizeBoolean(src.cardCoverFallback);
   site.errorOverlay = normalizeBoolean(src.errorOverlay);
@@ -1904,14 +1902,16 @@ function prepareSiteState(raw) {
 
   const recognized = new Set([
     'siteTitle', 'siteSubtitle', 'siteDescription', 'siteKeywords', 'avatar', 'resourceURL', 'contentRoot',
-    'profileLinks', 'links', 'contentOutdatedDays', 'cardCoverFallback', 'errorOverlay', 'pageSize', 'postsPerPage',
+    'profileLinks', 'contentOutdatedDays', 'cardCoverFallback', 'errorOverlay', 'pageSize', 'postsPerPage',
     'defaultLanguage', 'themeMode', 'themePack', 'themeOverride', 'repo', 'assetWarnings', 'landingTab', 'showAllPosts',
     'enableAllPosts', 'disableAllPosts'
   ]);
+  const deprecated = new Set(['links']);
 
   const extras = {};
   Object.keys(src).forEach((key) => {
     if (recognized.has(key)) return;
+    if (deprecated.has(key)) return;
     extras[key] = deepClone(src[key]);
   });
   site.__extras = extras;
@@ -1930,7 +1930,6 @@ function cloneSiteState(state) {
     resourceURL: safeString(state.resourceURL || ''),
     contentRoot: safeString(state.contentRoot || ''),
     profileLinks: Array.isArray(state.profileLinks) ? deepClone(state.profileLinks) : [],
-    links: Array.isArray(state.links) ? deepClone(state.links) : [],
     contentOutdatedDays: state.contentOutdatedDays != null ? Number(state.contentOutdatedDays) : null,
     cardCoverFallback: normalizeBoolean(state.cardCoverFallback),
     errorOverlay: normalizeBoolean(state.errorOverlay),
@@ -2028,10 +2027,6 @@ function buildSiteSnapshot(state) {
   if (site.profileLinks && site.profileLinks.length) {
     const links = linkListForOutput(site.profileLinks);
     if (links) snapshot.profileLinks = links;
-  }
-  if (site.links && site.links.length) {
-    const links = linkListForOutput(site.links);
-    if (links) snapshot.links = links;
   }
   if (site.resourceURL) snapshot.resourceURL = site.resourceURL;
   if (site.contentRoot) snapshot.contentRoot = site.contentRoot;
@@ -2141,11 +2136,6 @@ function computeSiteDiff(current, baseline) {
 
   if (compareLinkLists(cur.profileLinks || [], base.profileLinks || [])) {
     diff.fields.profileLinks = { type: 'list' };
-    diff.hasChanges = true;
-  }
-
-  if (compareLinkLists(cur.links || [], base.links || [])) {
-    diff.fields.links = { type: 'list' };
     diff.hasChanges = true;
   }
 
@@ -2259,7 +2249,7 @@ function writeYamlObject(lines, indent, obj) {
 function toSiteYaml(data) {
   const snapshot = buildSiteSnapshot(data || {});
   const keysInOrder = [
-    'siteTitle', 'siteSubtitle', 'siteDescription', 'siteKeywords', 'avatar', 'profileLinks', 'links', 'resourceURL',
+    'siteTitle', 'siteSubtitle', 'siteDescription', 'siteKeywords', 'avatar', 'profileLinks', 'resourceURL',
     'contentRoot', 'contentOutdatedDays', 'cardCoverFallback', 'errorOverlay', 'pageSize', 'defaultLanguage',
     'themeMode', 'themePack', 'themeOverride', 'showAllPosts', 'landingTab', 'repo', 'assetWarnings'
   ];
@@ -13779,10 +13769,6 @@ function buildSiteUI(root, state) {
   createLinkListField(seoSection, 'profileLinks', {
     label: t('editor.composer.site.fields.profileLinks'),
     description: t('editor.composer.site.fields.profileLinksHelp')
-  });
-  createLinkListField(seoSection, 'links', {
-    label: t('editor.composer.site.fields.navLinks'),
-    description: t('editor.composer.site.fields.navLinksHelp')
   });
 
   const behaviorSection = createSection(

--- a/assets/schema/site.json
+++ b/assets/schema/site.json
@@ -49,24 +49,6 @@
         "$ref": "#/$defs/link"
       }
     },
-    "links": {
-      "oneOf": [
-        {
-          "type": "array",
-          "description": "Navigation links as an array.",
-          "items": {
-            "$ref": "#/$defs/link"
-          }
-        },
-        {
-          "type": "object",
-          "description": "Navigation links as a map of label to URL.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      ]
-    },
     "contentOutdatedDays": {
       "type": "integer",
       "minimum": 0,

--- a/assets/themes/native/modules/interactions.js
+++ b/assets/themes/native/modules/interactions.js
@@ -728,7 +728,7 @@ function renderSiteLinksNative(params = {}, documentRef = defaultDocument) {
   const cfg = params.config;
   const root = documentRef.querySelector('.site-card .social-links');
   if (!root || !cfg) return false;
-  const linksVal = (cfg && (cfg.profileLinks || cfg.links)) || [];
+  const linksVal = (cfg && cfg.profileLinks) || [];
   let items = [];
   if (Array.isArray(linksVal)) {
     items = linksVal

--- a/scripts/test-remove-site-navigation-links.js
+++ b/scripts/test-remove-site-navigation-links.js
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, '..');
+
+const read = (path) => readFileSync(resolve(root, path), 'utf8');
+
+const schema = JSON.parse(read('assets/schema/site.json'));
+const composer = read('assets/js/composer.js');
+const nativeInteractions = read('assets/themes/native/modules/interactions.js');
+
+assert.ok(
+  Object.prototype.hasOwnProperty.call(schema.properties, 'profileLinks'),
+  'site schema should still expose profileLinks'
+);
+
+assert.equal(
+  Object.prototype.hasOwnProperty.call(schema.properties, 'links'),
+  false,
+  'site schema should not expose the deprecated site.links navigation field'
+);
+
+assert.doesNotMatch(
+  composer,
+  /\blinks:\s*\{\s*i18nKey:\s*'editor\.composer\.site\.fields\.navLinks'/,
+  'composer diff labels should not include a site.links navigation label'
+);
+
+assert.doesNotMatch(
+  composer,
+  /\bsite\.links\b|\bsrc\.links\b|\bsnapshot\.links\b|\bcur\.links\b|\bbase\.links\b/,
+  'composer site state should not read, diff, or save site.links'
+);
+
+assert.doesNotMatch(
+  composer,
+  /createLinkListField\(seoSection,\s*'links'/,
+  'site editor should not render a Navigation links list field'
+);
+
+assert.doesNotMatch(
+  nativeInteractions,
+  /cfg\.profileLinks\s*\|\|\s*cfg\.links/,
+  'native theme should not fall back from profileLinks to deprecated site.links'
+);
+
+for (const locale of ['chs', 'cht-hk', 'cht-tw', 'en', 'ja']) {
+  const source = read(`assets/i18n/${locale}.js`);
+  assert.doesNotMatch(
+    source,
+    /\bnavLinks\b/,
+    `${locale} locale should not keep Navigation links editor copy`
+  );
+}
+
+console.log('ok - site.links navigation configuration is removed');


### PR DESCRIPTION
## Summary
- Remove the deprecated `site.links` / Navigation links configuration surface from the site schema and composer state.
- Keep `profileLinks` as the only profile/social link configuration and keep tab navigation sourced from `wwwroot/tabs.yaml`.
- Drop the native theme fallback from `profileLinks` to `links` and remove unused Navigation links editor copy.
- Add a regression test that asserts the deprecated configuration is no longer exposed, saved, or rendered as fallback behavior.

## Validation
- `for f in scripts/test-*.js; do node "$f"; done`
- `for f in scripts/test-*.sh; do bash "$f"; done`