### PR TITLE
[codex] Revamp site editor UI

### DIFF
--- a/assets/i18n/chs.js
+++ b/assets/i18n/chs.js
@@ -345,6 +345,10 @@ const translations = {
               title: 'SEO 与分享',
               description: '提供用于搜索引擎和链接预览的元信息。'
             },
+            configuration: {
+              title: '站点配置',
+              description: '控制站点行为、主题默认值和编辑器提醒。'
+            },
             behavior: {
               title: '行为',
               description: '控制分页、默认打开的页面以及“全部文章”的显示。'

--- a/assets/i18n/cht-tw.js
+++ b/assets/i18n/cht-tw.js
@@ -345,6 +345,10 @@ const translations = {
               title: 'SEO 與分享',
               description: '提供用於搜尋引擎和連結預覽的元資訊。'
             },
+            configuration: {
+              title: '網站設定',
+              description: '控制網站行為、主題預設值和編輯器提醒。'
+            },
             behavior: {
               title: '行為',
               description: '控制分頁、預設開啟的頁面以及“全部文章”的顯示。'

--- a/assets/i18n/en.js
+++ b/assets/i18n/en.js
@@ -344,6 +344,10 @@ const translations = {
               title: 'SEO & sharing',
               description: 'Provide metadata used for search engines and link previews.'
             },
+            configuration: {
+              title: 'Site Configuration',
+              description: 'Control site behavior, theme defaults, and editor warnings.'
+            },
             behavior: {
               title: 'Behavior',
               description: 'Control pagination, landing behavior, and All Posts visibility.'

--- a/assets/i18n/ja.js
+++ b/assets/i18n/ja.js
@@ -345,6 +345,10 @@ const translations = {
               title: 'SEO / 共有',
               description: '検索エンジンやリンクプレビューで利用されるメタ情報を設定します。'
             },
+            configuration: {
+              title: 'サイト設定',
+              description: 'サイトの動作、既定のテーマ、編集時の警告をまとめて設定します。'
+            },
             behavior: {
               title: '動作',
               description: 'ページネーション、初期表示タブ、All Posts の表示を制御します。'

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -2284,8 +2284,8 @@ function applySiteDiffMarkers(diff) {
     if (info.type === 'list' && info.entries && index != null && subfield) {
       return !!(info.entries[index] && info.entries[index][subfield]);
     }
-    if (info.type === 'object' && info.fields && subfield) {
-      return !!info.fields[subfield];
+    if (info.type === 'object' && info.fields) {
+      return subfield ? !!info.fields[subfield] : false;
     }
     return true;
   };

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -173,6 +173,96 @@ const composerOrderMainTransitions = new WeakMap();
 let composerSiteScrollAnimationId = null;
 let composerSiteScrollCleanup = null;
 
+function syncSiteEditorSingleLabelWidth(root) {
+  if (!root || typeof root.querySelectorAll !== 'function') return;
+  try {
+    if (typeof root.__nsSiteSingleLabelWidthCleanup === 'function') root.__nsSiteSingleLabelWidthCleanup();
+  } catch (_) {}
+  try { root.__nsSiteSingleLabelWidthCleanup = null; } catch (_) {}
+
+  const labels = Array.from(root.querySelectorAll('.cs-single-grid-title'));
+  if (!labels.length) {
+    try { root.style.removeProperty('--cs-editor-single-label-width'); } catch (_) {}
+    return;
+  }
+
+  let frame = 0;
+  let observer = null;
+  const requestFrame = (fn) => {
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      return window.requestAnimationFrame(fn);
+    }
+    if (typeof requestAnimationFrame === 'function') return requestAnimationFrame(fn);
+    return setTimeout(fn, 0);
+  };
+  const cancelFrame = (id) => {
+    if (!id) return;
+    if (typeof window !== 'undefined' && typeof window.cancelAnimationFrame === 'function') {
+      window.cancelAnimationFrame(id);
+      return;
+    }
+    if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(id);
+    else clearTimeout(id);
+  };
+  const measure = () => {
+    frame = 0;
+    let width = 88;
+    labels.forEach((label) => {
+      const cell = label.closest ? label.closest('.cs-single-grid-label') : label;
+      const target = cell || label;
+      let measured = 0;
+      try {
+        const rect = target.getBoundingClientRect();
+        measured = rect && Number.isFinite(rect.width) ? rect.width : 0;
+      } catch (_) {}
+      try {
+        const tooltip = target.querySelector ? target.querySelector('.cs-help-tooltip-wrap') : null;
+        const tooltipRect = tooltip && tooltip.getBoundingClientRect ? tooltip.getBoundingClientRect() : null;
+        const tooltipWidth = tooltipRect && Number.isFinite(tooltipRect.width) ? tooltipRect.width : (tooltip ? tooltip.scrollWidth || 0 : 0);
+        const labelWidth = label.scrollWidth || 0;
+        const targetStyle = typeof window !== 'undefined' && typeof window.getComputedStyle === 'function'
+          ? window.getComputedStyle(target)
+          : null;
+        const gap = targetStyle ? parseFloat(targetStyle.gap || targetStyle.columnGap || '0') || 0 : 0;
+        measured = Math.max(measured, labelWidth + tooltipWidth + gap);
+      } catch (_) {
+        try { measured = Math.max(measured, target.scrollWidth || 0, label.scrollWidth || 0); } catch (_) {}
+      }
+      width = Math.max(width, measured);
+    });
+    try { root.style.setProperty('--cs-editor-single-label-width', `${Math.ceil(width)}px`); } catch (_) {}
+  };
+  const schedule = () => {
+    if (frame) return;
+    frame = requestFrame(measure);
+  };
+
+  if (typeof ResizeObserver === 'function') {
+    try {
+      observer = new ResizeObserver(schedule);
+      observer.observe(root);
+      labels.forEach((label) => {
+        const cell = label.closest ? label.closest('.cs-single-grid-label') : label;
+        observer.observe(cell || label);
+      });
+    } catch (_) {
+      observer = null;
+    }
+  }
+
+  try {
+    if (document.fonts && typeof document.fonts.ready?.then === 'function') document.fonts.ready.then(schedule).catch(() => {});
+  } catch (_) {}
+  schedule();
+
+  root.__nsSiteSingleLabelWidthCleanup = () => {
+    cancelFrame(frame);
+    frame = 0;
+    try { if (observer) observer.disconnect(); } catch (_) {}
+    observer = null;
+  };
+}
+
 function applyComposerEffectiveSiteConfig(siteConfig) {
   const tracked = siteConfig && typeof siteConfig === 'object' ? siteConfig : {};
   const effective = mergeYamlConfig(tracked, composerSiteLocalOverride);
@@ -11515,6 +11605,10 @@ function buildSiteUI(root, state) {
   } catch (_) {}
   try { root.__nsSiteScrollSyncCleanup = null; } catch (_) {}
   try {
+    if (typeof root.__nsSiteSingleLabelWidthCleanup === 'function') root.__nsSiteSingleLabelWidthCleanup();
+  } catch (_) {}
+  try { root.__nsSiteSingleLabelWidthCleanup = null; } catch (_) {}
+  try {
     if (typeof root.__nsSiteNavFocusHandler === 'function') root.removeEventListener('focusin', root.__nsSiteNavFocusHandler);
   } catch (_) {}
   try { root.__nsSiteNavFocusHandler = null; } catch (_) {}
@@ -12886,15 +12980,14 @@ function buildSiteUI(root, state) {
       tooltipBubble.className = 'cs-help-tooltip-bubble';
       tooltipBubble.setAttribute('role', 'tooltip');
       tooltipBubble.textContent = item.description;
-      tooltipWrap.appendChild(tooltip);
-      tooltipWrap.appendChild(tooltipBubble);
-      labelCell.appendChild(tooltipWrap);
-
       const label = document.createElement('label');
       label.className = 'cs-single-grid-title';
       label.htmlFor = controlId;
       label.textContent = item.label;
       labelCell.appendChild(label);
+      tooltipWrap.appendChild(tooltip);
+      tooltipWrap.appendChild(tooltipBubble);
+      labelCell.appendChild(tooltipWrap);
       row.appendChild(labelCell);
 
       const controlCell = document.createElement('div');
@@ -13765,11 +13858,11 @@ function buildSiteUI(root, state) {
     grid: true,
     ensureDefault: false
   });
-  renderSeoResourceGrid(seoSection);
   createLinkListField(seoSection, 'profileLinks', {
     label: t('editor.composer.site.fields.profileLinks'),
     description: t('editor.composer.site.fields.profileLinksHelp')
   });
+  renderSeoResourceGrid(seoSection);
 
   const behaviorSection = createSection(
     t('editor.composer.site.sections.behavior.title'),
@@ -13885,6 +13978,7 @@ function buildSiteUI(root, state) {
   }
 
   renderCompactSectionMenu();
+  syncSiteEditorSingleLabelWidth(root);
   refreshNavDiffState();
   try { scheduleScrollSync(); } catch (_) {}
 }
@@ -14305,10 +14399,10 @@ function rebuildSiteUI() {
   .cs-identity-actions{display:flex;align-items:center;justify-content:flex-end;min-width:0}
   .cs-identity-remove{margin-left:0;white-space:nowrap}
   .cs-single-grid-fieldset{gap:0}
-  .cs-single-grid{display:grid;grid-template-columns:minmax(88px,max-content) minmax(0,var(--cs-editor-single-control-width));column-gap:var(--cs-editor-row-column-gap);row-gap:var(--cs-editor-row-gap);align-items:center;justify-content:start}
+  .cs-single-grid{display:grid;grid-template-columns:var(--cs-editor-single-label-width,88px) minmax(0,var(--cs-editor-single-control-width));column-gap:var(--cs-editor-row-column-gap);row-gap:var(--cs-editor-row-gap);align-items:center;justify-content:start}
   .cs-single-grid-row{display:grid;grid-template-columns:subgrid;grid-column:1/-1;align-items:center;gap:var(--cs-editor-row-column-gap);min-height:var(--cs-editor-control-height);padding:0;position:relative}
   .cs-single-grid-row[data-diff="changed"]{background:color-mix(in srgb,var(--primary) 6%, transparent);box-shadow:inset 3px 0 0 color-mix(in srgb,var(--primary) 60%, var(--border));border-radius:8px;padding-left:.85rem}
-  .cs-single-grid-label{display:inline-flex;align-items:center;gap:.35rem;min-width:0;font-weight:700;color:color-mix(in srgb,var(--text) 86%, transparent)}
+  .cs-single-grid-label{display:inline-flex;align-items:center;justify-content:flex-end;gap:.35rem;min-width:0;font-weight:700;color:color-mix(in srgb,var(--text) 86%, transparent)}
   .cs-single-grid-title{font-size:.84rem;white-space:nowrap}
   .cs-single-grid-control{min-width:0;display:flex;align-items:center}
   .cs-single-grid-control .cs-input,.cs-single-grid-control .cs-select{width:100%;min-width:0}

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -13783,6 +13783,12 @@ function buildSiteUI(root, state) {
   );
   renderThemeGrid(themeSection);
 
+  const assetsSection = createSection(
+    t('editor.composer.site.sections.assets.title'),
+    t('editor.composer.site.sections.assets.description')
+  );
+  renderAssetWarningsGrid(assetsSection);
+
   const repoSection = createSection(
     t('editor.composer.site.sections.repo.title'),
     t('editor.composer.site.sections.repo.description')
@@ -13857,12 +13863,6 @@ function buildSiteUI(root, state) {
 
   repoInputs.append(pathRow, branchWrap);
   repoField.appendChild(repoInputs);
-
-  const assetsSection = createSection(
-    t('editor.composer.site.sections.assets.title'),
-    t('editor.composer.site.sections.assets.description')
-  );
-  renderAssetWarningsGrid(assetsSection);
 
   if (site.__extras && Object.keys(site.__extras).length) {
     const extrasSection = createSection(

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -212,7 +212,7 @@ function syncSiteEditorSingleLabelWidth(root) {
       const target = cell || label;
       let measured = 0;
       try {
-        const tooltip = target.querySelector ? target.querySelector('.cs-help-tooltip-wrap') : null;
+        const tooltip = target.querySelector ? target.querySelector('.cs-help-tooltip') : null;
         const tooltipWidth = tooltip ? tooltip.scrollWidth || 0 : 0;
         const labelWidth = label.scrollWidth || 0;
         const targetStyle = typeof window !== 'undefined' && typeof window.getComputedStyle === 'function'
@@ -221,7 +221,10 @@ function syncSiteEditorSingleLabelWidth(root) {
         const gap = targetStyle ? parseFloat(targetStyle.gap || targetStyle.columnGap || '0') || 0 : 0;
         measured = labelWidth + tooltipWidth + gap;
       } catch (_) {
-        try { measured = Math.max(measured, target.scrollWidth || 0, label.scrollWidth || 0); } catch (_) {}
+        try {
+          const tooltip = target.querySelector ? target.querySelector('.cs-help-tooltip') : null;
+          measured = (label.scrollWidth || 0) + (tooltip ? tooltip.scrollWidth || 0 : 0);
+        } catch (_) {}
       }
       width = Math.max(width, measured);
     });

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -212,19 +212,14 @@ function syncSiteEditorSingleLabelWidth(root) {
       const target = cell || label;
       let measured = 0;
       try {
-        const rect = target.getBoundingClientRect();
-        measured = rect && Number.isFinite(rect.width) ? rect.width : 0;
-      } catch (_) {}
-      try {
         const tooltip = target.querySelector ? target.querySelector('.cs-help-tooltip-wrap') : null;
-        const tooltipRect = tooltip && tooltip.getBoundingClientRect ? tooltip.getBoundingClientRect() : null;
-        const tooltipWidth = tooltipRect && Number.isFinite(tooltipRect.width) ? tooltipRect.width : (tooltip ? tooltip.scrollWidth || 0 : 0);
+        const tooltipWidth = tooltip ? tooltip.scrollWidth || 0 : 0;
         const labelWidth = label.scrollWidth || 0;
         const targetStyle = typeof window !== 'undefined' && typeof window.getComputedStyle === 'function'
           ? window.getComputedStyle(target)
           : null;
         const gap = targetStyle ? parseFloat(targetStyle.gap || targetStyle.columnGap || '0') || 0 : 0;
-        measured = Math.max(measured, labelWidth + tooltipWidth + gap);
+        measured = labelWidth + tooltipWidth + gap;
       } catch (_) {
         try { measured = Math.max(measured, target.scrollWidth || 0, label.scrollWidth || 0); } catch (_) {}
       }

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -14429,6 +14429,7 @@ function rebuildSiteUI() {
   .cs-field + .cs-field{border-top:1px solid color-mix(in srgb,var(--border) 82%, transparent);margin-top:.35rem;padding-top:.95rem}
   .cs-field[data-diff="changed"]{background:color-mix(in srgb,var(--primary) 6%, transparent);box-shadow:inset 3px 0 0 color-mix(in srgb,var(--primary) 60%, var(--border));border-radius:8px;padding-left:.85rem}
   .cs-field[data-diff="changed"] .cs-field-label{color:color-mix(in srgb,var(--primary) 82%, var(--text))}
+  .cs-repo-grid[data-diff="changed"],.cs-extra-list[data-diff="changed"]{background:color-mix(in srgb,var(--primary) 6%, transparent);box-shadow:inset 3px 0 0 color-mix(in srgb,var(--primary) 60%, var(--border));border-radius:8px;padding-left:.85rem}
   .cs-field-head{display:flex;align-items:center;gap:.45rem;flex-wrap:wrap}
   .cs-field-inline-help .cs-field-head{align-items:baseline}
   .cs-field-label-wrap{display:flex;align-items:center;gap:.45rem;flex:1 1 auto;min-width:120px}

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -14285,7 +14285,7 @@ function rebuildSiteUI() {
   .cs-localized-row--grid{display:grid;grid-template-columns:minmax(88px,88px) minmax(0,1fr) minmax(72px,max-content);align-items:center;column-gap:var(--cs-editor-row-column-gap);row-gap:0;min-height:var(--cs-editor-control-height);padding:0}
   .cs-localized-input{flex:1 1 240px;min-width:180px}
   .cs-localized-row--grid .cs-localized-input{min-width:0}
-  .cs-localized-row--grid .cs-lang-chip{justify-self:start}
+  .cs-localized-row--grid .cs-lang-chip{justify-self:end}
   .cs-localized-row--multiline textarea.cs-localized-textarea{box-sizing:border-box;display:block;height:var(--cs-editor-control-height);min-height:var(--cs-editor-control-height);max-height:var(--cs-editor-control-height);padding-block:0;line-height:calc(var(--cs-editor-control-height) - 2px);resize:none;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;transition:height .18s ease,min-height .18s ease,max-height .18s ease,border-color .16s ease,box-shadow .16s ease,background .16s ease}
   .cs-localized-row--multiline.is-expanded,.cs-localized-row--multiline:has(textarea.cs-localized-textarea:focus){align-items:start}
   .cs-localized-row--multiline.is-expanded .cs-remove-lang,.cs-localized-row--multiline:has(textarea.cs-localized-textarea:focus) .cs-remove-lang{align-self:start}
@@ -14298,7 +14298,7 @@ function rebuildSiteUI() {
   .cs-identity-head{align-items:end;padding:0 0 .1rem}
   .cs-identity-head-spacer{min-width:1px}
   .cs-identity-column-title{font-size:.72rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:color-mix(in srgb,var(--muted) 78%, transparent)}
-  .cs-identity-lang{min-width:0;display:flex;align-items:center}
+  .cs-identity-lang{min-width:0;display:flex;align-items:center;justify-content:flex-end}
   .cs-identity-field{min-width:0;display:flex;flex-direction:column;gap:.2rem}
   .cs-identity-field .cs-input{min-width:0}
   .cs-identity-cell-label{display:none;font-size:.72rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:color-mix(in srgb,var(--muted) 78%, transparent)}

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -12404,14 +12404,69 @@ function buildSiteUI(root, state) {
     return field;
   };
 
+  const createSubheadingField = (section, config) => {
+    const field = document.createElement('div');
+    field.className = 'cs-field cs-subheading-field';
+    if (config.dataKey) field.dataset.field = config.dataKey;
+    if (config.label || config.description) {
+      const head = document.createElement('div');
+      head.className = 'cs-config-subsection-head';
+      if (config.label) {
+        const title = document.createElement('div');
+        title.className = 'cs-config-subsection-title';
+        title.textContent = config.label;
+        head.appendChild(title);
+      }
+      if (config.description) {
+        const description = document.createElement('p');
+        description.className = 'cs-config-subsection-description';
+        description.textContent = config.description;
+        head.appendChild(description);
+      }
+      field.appendChild(head);
+    }
+    section.appendChild(field);
+    return field;
+  };
+
+  const createConfigSubsection = (section, title, description) => {
+    const block = document.createElement('div');
+    block.className = 'cs-config-subsection';
+    if (title || description) {
+      const head = document.createElement('div');
+      head.className = 'cs-config-subsection-head';
+      if (title) {
+        const heading = document.createElement('div');
+        heading.className = 'cs-config-subsection-title';
+        heading.textContent = title;
+        head.appendChild(heading);
+      }
+      if (description) {
+        const desc = document.createElement('p');
+        desc.className = 'cs-config-subsection-description';
+        desc.textContent = description;
+        head.appendChild(desc);
+      }
+      block.appendChild(head);
+    }
+    section.appendChild(block);
+    return block;
+  };
+
   const renderLocalizedField = (section, key, options = {}) => {
     ensureLocalized(key, options.ensureDefault !== false);
     const useLocalizedGrid = !!(options.grid || options.multiline);
-    const field = createField(section, {
-      dataKey: key,
-      label: options.label,
-      description: options.description
-    });
+    const field = options.subheading
+      ? createSubheadingField(section, {
+        dataKey: key,
+        label: options.label,
+        description: options.description
+      })
+      : createField(section, {
+        dataKey: key,
+        label: options.label,
+        description: options.description
+      });
     const list = document.createElement('div');
     list.className = useLocalizedGrid
       ? 'cs-localized-list cs-localized-list--grid'
@@ -13689,11 +13744,17 @@ function buildSiteUI(root, state) {
 
   const createLinkListField = (section, key, config) => {
     const list = ensureLinkList(key);
-    const field = createField(section, {
-      dataKey: key,
-      label: config.label,
-      description: config.description
-    });
+    const field = config.subheading
+      ? createSubheadingField(section, {
+        dataKey: key,
+        label: config.label,
+        description: config.description
+      })
+      : createField(section, {
+        dataKey: key,
+        label: config.label,
+        description: config.description
+      });
     const listWrap = document.createElement('div');
     listWrap.className = 'cs-link-list';
     field.appendChild(listWrap);
@@ -13850,37 +13911,47 @@ function buildSiteUI(root, state) {
     description: t('editor.composer.site.fields.siteDescriptionHelp'),
     multiline: true,
     rows: 3,
-    ensureDefault: false
+    ensureDefault: false,
+    subheading: true
   });
   renderLocalizedField(seoSection, 'siteKeywords', {
     label: t('editor.composer.site.fields.siteKeywords'),
     description: t('editor.composer.site.fields.siteKeywordsHelp'),
     grid: true,
-    ensureDefault: false
+    ensureDefault: false,
+    subheading: true
   });
   createLinkListField(seoSection, 'profileLinks', {
     label: t('editor.composer.site.fields.profileLinks'),
-    description: t('editor.composer.site.fields.profileLinksHelp')
+    description: t('editor.composer.site.fields.profileLinksHelp'),
+    subheading: true
   });
   renderSeoResourceGrid(seoSection);
 
-  const behaviorSection = createSection(
+  const siteConfigSection = createSection(
+    t('editor.composer.site.sections.configuration.title'),
+    t('editor.composer.site.sections.configuration.description')
+  );
+  const behaviorSubsection = createConfigSubsection(
+    siteConfigSection,
     t('editor.composer.site.sections.behavior.title'),
     t('editor.composer.site.sections.behavior.description')
   );
-  renderBehaviorGrid(behaviorSection);
+  renderBehaviorGrid(behaviorSubsection);
 
-  const themeSection = createSection(
+  const themeSubsection = createConfigSubsection(
+    siteConfigSection,
     t('editor.composer.site.sections.theme.title'),
     t('editor.composer.site.sections.theme.description')
   );
-  renderThemeGrid(themeSection);
+  renderThemeGrid(themeSubsection);
 
-  const assetsSection = createSection(
+  const assetsSubsection = createConfigSubsection(
+    siteConfigSection,
     t('editor.composer.site.sections.assets.title'),
     t('editor.composer.site.sections.assets.description')
   );
-  renderAssetWarningsGrid(assetsSection);
+  renderAssetWarningsGrid(assetsSubsection);
 
   const repoSection = createSection(
     t('editor.composer.site.sections.repo.title'),
@@ -14356,6 +14427,12 @@ function rebuildSiteUI() {
   .cs-section-head{display:flex;align-items:baseline;gap:.65rem;flex-wrap:wrap}
   .cs-section-title{margin:0;font-size:1rem;font-weight:700;color:color-mix(in srgb,var(--text) 90%, transparent)}
   .cs-section-description{margin:0;font-size:.82rem;color:color-mix(in srgb,var(--muted) 88%, transparent);flex:1 1 260px;text-align:right}
+  .cs-config-subsection{display:flex;flex-direction:column;gap:.4rem}
+  .cs-config-subsection + .cs-config-subsection{border-top:1px solid color-mix(in srgb,var(--border) 82%, transparent);margin-top:.35rem;padding-top:.95rem}
+  .cs-config-subsection-head{display:flex;align-items:baseline;gap:.45rem;flex-wrap:wrap;margin-bottom:.05rem}
+  .cs-config-subsection-title{margin:0;font-size:.84rem;font-weight:600;color:color-mix(in srgb,var(--text) 76%, transparent)}
+  .cs-config-subsection-description{margin:0;font-size:.8rem;color:color-mix(in srgb,var(--muted) 88%, transparent);flex:1 1 auto;text-align:left}
+  .cs-config-subsection > .cs-config-subsection-head + .cs-field{padding-top:0}
   .cs-field{margin:0;padding:.6rem 0;display:flex;flex-direction:column;gap:.4rem;position:relative}
   .cs-field + .cs-field{border-top:1px solid color-mix(in srgb,var(--border) 82%, transparent);margin-top:.35rem;padding-top:.95rem}
   .cs-field[data-diff="changed"]{background:color-mix(in srgb,var(--primary) 6%, transparent);box-shadow:inset 3px 0 0 color-mix(in srgb,var(--primary) 60%, var(--border));border-radius:8px;padding-left:.85rem}

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -14029,19 +14029,15 @@ function buildSiteUI(root, state) {
       t('editor.composer.site.sections.extras.title'),
       t('editor.composer.site.sections.extras.description')
     );
-    const field = createField(extrasSection, {
-      dataKey: '__extras',
-      label: t('editor.composer.site.fields.extras'),
-      description: t('editor.composer.site.fields.extrasHelp')
-    });
     const list = document.createElement('ul');
     list.className = 'cs-extra-list';
+    list.dataset.field = '__extras';
     Object.keys(site.__extras).sort().forEach((key) => {
       const item = document.createElement('li');
       item.textContent = key;
       list.appendChild(item);
     });
-    field.appendChild(list);
+    extrasSection.appendChild(list);
   }
 
   renderCompactSectionMenu();

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -2173,15 +2173,22 @@ function compareLocalizedMaps(cur = {}, base = {}) {
   return changedLangs;
 }
 
-function compareLinkLists(cur = [], base = []) {
+function compareLinkListChanges(cur = [], base = []) {
   const max = Math.max(cur.length, base.length);
+  const entries = {};
   for (let i = 0; i < max; i += 1) {
     const a = cur[i] || { label: '', href: '' };
     const b = base[i] || { label: '', href: '' };
-    if (safeString(a.label) !== safeString(b.label)) return true;
-    if (safeString(a.href) !== safeString(b.href)) return true;
+    const changed = {};
+    if (safeString(a.label) !== safeString(b.label)) changed.label = true;
+    if (safeString(a.href) !== safeString(b.href)) changed.href = true;
+    if (Object.keys(changed).length) entries[i] = changed;
   }
-  return false;
+  return entries;
+}
+
+function compareLinkLists(cur = [], base = []) {
+  return Object.keys(compareLinkListChanges(cur, base)).length > 0;
 }
 
 function computeSiteDiff(current, baseline) {
@@ -2224,25 +2231,30 @@ function computeSiteDiff(current, baseline) {
     }
   });
 
-  if (compareLinkLists(cur.profileLinks || [], base.profileLinks || [])) {
-    diff.fields.profileLinks = { type: 'list' };
+  const profileLinkChanges = compareLinkListChanges(cur.profileLinks || [], base.profileLinks || []);
+  if (Object.keys(profileLinkChanges).length) {
+    diff.fields.profileLinks = { type: 'list', entries: profileLinkChanges };
     diff.hasChanges = true;
   }
 
   const repoCur = cur.repo || {};
   const repoBase = base.repo || {};
-  if (safeString(repoCur.owner) !== safeString(repoBase.owner)
-    || safeString(repoCur.name) !== safeString(repoBase.name)
-    || safeString(repoCur.branch) !== safeString(repoBase.branch)) {
-    diff.fields.repo = { type: 'object' };
+  const repoFields = {};
+  if (safeString(repoCur.owner) !== safeString(repoBase.owner)) repoFields.owner = true;
+  if (safeString(repoCur.name) !== safeString(repoBase.name)) repoFields.name = true;
+  if (safeString(repoCur.branch) !== safeString(repoBase.branch)) repoFields.branch = true;
+  if (Object.keys(repoFields).length) {
+    diff.fields.repo = { type: 'object', fields: repoFields };
     diff.hasChanges = true;
   }
 
   const curWarn = (cur.assetWarnings && cur.assetWarnings.largeImage) || {};
   const baseWarn = (base.assetWarnings && base.assetWarnings.largeImage) || {};
-  if (normalizeBoolean(curWarn.enabled) !== normalizeBoolean(baseWarn.enabled)
-    || normalizeNumber(curWarn.thresholdKB) !== normalizeNumber(baseWarn.thresholdKB)) {
-    diff.fields.assetWarnings = { type: 'object' };
+  const warningFields = {};
+  if (normalizeBoolean(curWarn.enabled) !== normalizeBoolean(baseWarn.enabled)) warningFields.enabled = true;
+  if (normalizeNumber(curWarn.thresholdKB) !== normalizeNumber(baseWarn.thresholdKB)) warningFields.thresholdKB = true;
+  if (Object.keys(warningFields).length) {
+    diff.fields.assetWarnings = { type: 'object', fields: warningFields };
     diff.hasChanges = true;
   }
 
@@ -2260,12 +2272,39 @@ function applySiteDiffMarkers(diff) {
   const root = document.getElementById('composerSite');
   if (!root) return;
   const fields = diff && diff.fields ? diff.fields : {};
+  const matchesFieldDiff = (el, key) => {
+    const info = fields[key];
+    if (!info) return false;
+    const lang = el.getAttribute('data-lang');
+    const subfield = el.getAttribute('data-subfield');
+    const index = el.getAttribute('data-index');
+    if (info.type === 'localized' && Array.isArray(info.languages)) {
+      return lang ? info.languages.includes(lang) : true;
+    }
+    if (info.type === 'list' && info.entries && index != null && subfield) {
+      return !!(info.entries[index] && info.entries[index][subfield]);
+    }
+    if (info.type === 'object' && info.fields && subfield) {
+      return !!info.fields[subfield];
+    }
+    return true;
+  };
+  const isChangedTarget = (el) => {
+    const key = el.getAttribute('data-field');
+    const keys = String(key || '').split('|').map(item => item.trim()).filter(Boolean);
+    return keys.length ? keys.some(fieldKey => matchesFieldDiff(el, fieldKey)) : false;
+  };
+  const hasChangedDescendant = (el) => {
+    return Array.from(el.querySelectorAll('[data-field]')).some(child => child !== el && isChangedTarget(child));
+  };
   root.querySelectorAll('[data-field]').forEach((el) => {
     const key = el.getAttribute('data-field');
     const keys = String(key || '').split('|').map(item => item.trim()).filter(Boolean);
-    const changed = keys.length
-      ? keys.some(fieldKey => !!fields[fieldKey])
-      : !!fields[key];
+    if (hasChangedDescendant(el)) {
+      el.removeAttribute('data-diff');
+      return;
+    }
+    const changed = keys.length ? keys.some(fieldKey => matchesFieldDiff(el, fieldKey)) : false;
     if (key && changed) el.setAttribute('data-diff', 'changed');
     else el.removeAttribute('data-diff');
   });
@@ -3455,15 +3494,77 @@ function applyTabsDiffMarkers(diff) {
   });
 }
 
+function getComposerDiffChangeCount(diff) {
+  if (!diff || !diff.hasChanges) return 0;
+  if (diff.fields && typeof diff.fields === 'object') {
+    return Object.keys(diff.fields).filter(Boolean).length;
+  }
+  let count = 0;
+  if (diff.keys && typeof diff.keys === 'object') {
+    count += Object.keys(diff.keys).filter(Boolean).length;
+  }
+  if (diff.orderChanged) count += 1;
+  return Math.max(1, count);
+}
+
+function ensureFileDirtyBadgeElement(el) {
+  if (!el) return null;
+  let badge = el.querySelector('.vt-dirty-badge');
+  if (!badge) {
+    badge = document.createElement('span');
+    badge.className = 'vt-dirty-badge';
+    badge.setAttribute('aria-hidden', 'true');
+    badge.hidden = true;
+    el.appendChild(badge);
+  }
+  return badge;
+}
+
+function getFileToggleBaseLabel(el) {
+  if (!el) return '';
+  if (el.dataset && el.dataset.fileLabel) return el.dataset.fileLabel;
+  const text = Array.from(el.childNodes || [])
+    .filter(node => !(node.nodeType === 1 && node.classList && node.classList.contains('vt-dirty-badge')))
+    .map(node => node.textContent || '')
+    .join('')
+    .trim();
+  if (text && el.dataset) el.dataset.fileLabel = text;
+  return text;
+}
+
 function updateFileDirtyBadge(kind) {
   const name = kind === 'tabs' ? 'tabs' : (kind === 'site' ? 'site' : 'index');
   const el = document.querySelector(`a.vt-btn[data-cfile="${name}"]`);
   if (!el) return;
   const diff = composerDiffCache[kind];
+  const changeCount = getComposerDiffChangeCount(diff);
   const hasChanges = !!(diff && diff.hasChanges);
+  const badge = ensureFileDirtyBadgeElement(el);
+  const baseLabel = getFileToggleBaseLabel(el);
   el.classList.toggle('has-draft', hasChanges);
-  if (hasChanges) el.setAttribute('data-dirty', '1');
-  else el.removeAttribute('data-dirty');
+  if (hasChanges) {
+    const displayValue = changeCount > 99 ? '99+' : String(changeCount);
+    if (badge) {
+      badge.textContent = displayValue;
+      badge.hidden = false;
+    }
+    el.setAttribute('data-dirty', '1');
+    if (el.dataset) el.dataset.dirtyCount = String(changeCount);
+    if (baseLabel) {
+      const accessibleCount = changeCount > 99 ? 'more than 99' : String(changeCount);
+      const changeLabel = changeCount === 1 ? 'pending change' : 'pending changes';
+      el.setAttribute('aria-label', `${baseLabel} (${accessibleCount} ${changeLabel})`);
+    }
+  } else {
+    if (badge) {
+      badge.hidden = true;
+      badge.textContent = '';
+    }
+    el.removeAttribute('data-dirty');
+    if (el.dataset) delete el.dataset.dirtyCount;
+    if (baseLabel) el.setAttribute('aria-label', baseLabel);
+    else el.removeAttribute('aria-label');
+  }
 }
 
 function collectUnsyncedMarkdownEntries() {
@@ -12656,6 +12757,8 @@ function buildSiteUI(root, state) {
         if (!options.multiline) input.type = 'text';
         else input.rows = options.rows || 3;
         input.className = options.multiline ? 'cs-input cs-localized-textarea' : 'cs-input';
+        input.dataset.field = key;
+        input.dataset.lang = lang;
         if (options.placeholder) input.placeholder = options.placeholder;
         input.value = localized[lang] || '';
         if (options.multiline) {
@@ -12919,6 +13022,9 @@ function buildSiteUI(root, state) {
       const input = document.createElement('input');
       input.type = 'text';
       input.className = 'cs-input';
+      input.dataset.field = key;
+      input.dataset.lang = lang;
+      input.dataset.subfield = key;
       input.dataset.siteIdentityField = key;
       input.value = value || '';
       input.addEventListener('input', () => {
@@ -12991,6 +13097,7 @@ function buildSiteUI(root, state) {
     if (!config.multiline) input.type = config.type || 'text';
     else input.rows = config.rows || 3;
     input.className = 'cs-input';
+    input.dataset.field = config.dataKey;
     input.value = config.get() || '';
     if (config.placeholder) input.placeholder = config.placeholder;
     input.addEventListener('input', () => {
@@ -13064,6 +13171,7 @@ function buildSiteUI(root, state) {
       input.id = controlId;
       input.type = item.type || 'text';
       input.className = 'cs-input';
+      input.dataset.field = item.dataKey;
       input.value = item.get() || '';
       input.placeholder = item.placeholder || '';
       input.addEventListener('input', () => {
@@ -13121,6 +13229,7 @@ function buildSiteUI(root, state) {
     const input = document.createElement('input');
     input.type = 'number';
     input.className = 'cs-input cs-input-small';
+    input.dataset.field = config.dataKey;
     if (config.min != null) input.min = String(config.min);
     if (config.max != null) input.max = String(config.max);
     if (config.step != null) input.step = String(config.step);
@@ -13195,6 +13304,7 @@ function buildSiteUI(root, state) {
       target: labelWrap || head || field,
       classes: ['cs-field-head-switch']
     });
+    toggle.dataset.field = config.dataKey;
 
     const sync = () => {
       const value = config.get();
@@ -13223,6 +13333,7 @@ function buildSiteUI(root, state) {
       target: labelWrap || head || field,
       classes: ['cs-field-head-switch']
     });
+    toggle.dataset.field = config.dataKey;
 
     const sync = () => {
       syncSwitchState(checkbox, toggle, config.get(), false);
@@ -13252,6 +13363,7 @@ function buildSiteUI(root, state) {
     control.className = 'cs-field-controls';
     const select = document.createElement('select');
     select.className = 'cs-select';
+    select.dataset.field = config.dataKey;
     (config.options || []).forEach((opt) => {
       const option = document.createElement('option');
       option.value = opt.value;
@@ -13318,6 +13430,7 @@ function buildSiteUI(root, state) {
       const select = document.createElement('select');
       select.id = controlId;
       select.className = 'cs-select';
+      select.dataset.field = item.dataKey;
       controlCell.appendChild(select);
       return select;
     };
@@ -13364,6 +13477,7 @@ function buildSiteUI(root, state) {
       input.id = controlId;
       input.type = 'number';
       input.className = 'cs-input';
+      input.dataset.field = item.dataKey;
       if (item.min != null) input.min = String(item.min);
       const value = item.get();
       input.value = value != null && !Number.isNaN(value) ? String(value) : '';
@@ -13400,6 +13514,7 @@ function buildSiteUI(root, state) {
         target: controlCell,
         classes: ['cs-single-grid-switch']
       });
+      toggle.dataset.field = item.dataKey;
       const sync = () => {
         syncSwitchState(checkbox, toggle, item.get(), allowMixed);
       };
@@ -13532,6 +13647,7 @@ function buildSiteUI(root, state) {
       const select = document.createElement('select');
       select.id = controlId;
       select.className = 'cs-select';
+      select.dataset.field = item.dataKey;
       (item.options || []).forEach((opt) => {
         const option = document.createElement('option');
         option.value = opt.value;
@@ -13683,6 +13799,7 @@ function buildSiteUI(root, state) {
       target: controlCell,
       classes: ['cs-single-grid-switch']
     });
+    toggle.dataset.field = 'themeOverride';
     checkbox.addEventListener('change', () => {
       site.themeOverride = checkbox.checked;
       syncSwitchState(checkbox, toggle, checkbox.checked, true);
@@ -13715,6 +13832,8 @@ function buildSiteUI(root, state) {
         classes: ['cs-single-grid-switch']
       }
     );
+    toggle.dataset.field = 'assetWarnings';
+    toggle.dataset.subfield = 'enabled';
     checkbox.addEventListener('change', () => {
       warnings.largeImage.enabled = checkbox.checked;
       syncSwitchState(checkbox, toggle, checkbox.checked, true);
@@ -13731,6 +13850,8 @@ function buildSiteUI(root, state) {
     thresholdInput.id = thresholdId;
     thresholdInput.type = 'number';
     thresholdInput.className = 'cs-input';
+    thresholdInput.dataset.field = 'assetWarnings';
+    thresholdInput.dataset.subfield = 'thresholdKB';
     thresholdInput.min = '1';
     const threshold = warnings.largeImage.thresholdKB;
     thresholdInput.value = threshold != null && !Number.isNaN(threshold) ? String(threshold) : '';
@@ -13811,6 +13932,9 @@ function buildSiteUI(root, state) {
         labelInput.type = 'text';
         labelInput.id = labelInputId;
         labelInput.className = 'cs-input';
+        labelInput.dataset.field = key;
+        labelInput.dataset.index = String(index);
+        labelInput.dataset.subfield = 'label';
         labelInput.placeholder = t('editor.composer.site.linkLabelPlaceholder');
         if (index > 0) {
           labelInput.setAttribute('aria-labelledby', labelTitleId);
@@ -13843,6 +13967,9 @@ function buildSiteUI(root, state) {
         hrefInput.type = 'text';
         hrefInput.id = hrefInputId;
         hrefInput.className = 'cs-input';
+        hrefInput.dataset.field = key;
+        hrefInput.dataset.index = String(index);
+        hrefInput.dataset.subfield = 'href';
         hrefInput.placeholder = t('editor.composer.site.linkHrefPlaceholder');
         if (index > 0) {
           hrefInput.setAttribute('aria-labelledby', hrefTitleId);
@@ -13933,6 +14060,8 @@ function buildSiteUI(root, state) {
 
   const ownerWrap = document.createElement('div');
   ownerWrap.className = 'cs-repo-field cs-repo-field--owner';
+  ownerWrap.dataset.field = 'repo';
+  ownerWrap.dataset.subfield = 'owner';
   const ownerAffix = document.createElement('span');
   ownerAffix.className = 'cs-repo-affix';
   ownerAffix.textContent = t('editor.composer.site.repoOwnerPrefix');
@@ -13941,6 +14070,8 @@ function buildSiteUI(root, state) {
 
   const repoWrap = document.createElement('div');
   repoWrap.className = 'cs-repo-field cs-repo-field--name';
+  repoWrap.dataset.field = 'repo';
+  repoWrap.dataset.subfield = 'name';
   const repoAffix = document.createElement('span');
   repoAffix.className = 'cs-repo-affix';
   repoAffix.textContent = t('editor.composer.site.repoNamePrefix');
@@ -13957,6 +14088,8 @@ function buildSiteUI(root, state) {
 
   const branchWrap = document.createElement('div');
   branchWrap.className = 'cs-repo-field cs-repo-field--branch';
+  branchWrap.dataset.field = 'repo';
+  branchWrap.dataset.subfield = 'branch';
   const branchAffix = document.createElement('span');
   branchAffix.className = 'cs-repo-affix';
   branchAffix.textContent = t('editor.composer.site.repoBranchPrefix');
@@ -14427,9 +14560,6 @@ function rebuildSiteUI() {
   .cs-config-subsection > .cs-config-subsection-head + .cs-field{padding-top:0}
   .cs-field{margin:0;padding:.6rem 0;display:flex;flex-direction:column;gap:.4rem;position:relative}
   .cs-field + .cs-field{border-top:1px solid color-mix(in srgb,var(--border) 82%, transparent);margin-top:.35rem;padding-top:.95rem}
-  .cs-field[data-diff="changed"]{background:color-mix(in srgb,var(--primary) 6%, transparent);box-shadow:inset 3px 0 0 color-mix(in srgb,var(--primary) 60%, var(--border));border-radius:8px;padding-left:.85rem}
-  .cs-field[data-diff="changed"] .cs-field-label{color:color-mix(in srgb,var(--primary) 82%, var(--text))}
-  .cs-repo-grid[data-diff="changed"],.cs-extra-list[data-diff="changed"]{background:color-mix(in srgb,var(--primary) 6%, transparent);box-shadow:inset 3px 0 0 color-mix(in srgb,var(--primary) 60%, var(--border));border-radius:8px;padding-left:.85rem}
   .cs-field-head{display:flex;align-items:center;gap:.45rem;flex-wrap:wrap}
   .cs-field-inline-help .cs-field-head{align-items:baseline}
   .cs-field-label-wrap{display:flex;align-items:center;gap:.45rem;flex:1 1 auto;min-width:120px}
@@ -14471,7 +14601,6 @@ function rebuildSiteUI() {
   .cs-single-grid-fieldset{gap:0}
   .cs-single-grid{display:grid;grid-template-columns:var(--cs-editor-single-label-width,88px) minmax(0,var(--cs-editor-single-control-width));column-gap:var(--cs-editor-row-column-gap);row-gap:var(--cs-editor-row-gap);align-items:center;justify-content:start}
   .cs-single-grid-row{display:grid;grid-template-columns:subgrid;grid-column:1/-1;align-items:center;gap:var(--cs-editor-row-column-gap);min-height:var(--cs-editor-control-height);padding:0;position:relative}
-  .cs-single-grid-row[data-diff="changed"]{background:color-mix(in srgb,var(--primary) 6%, transparent);box-shadow:inset 3px 0 0 color-mix(in srgb,var(--primary) 60%, var(--border));border-radius:8px;padding-left:.85rem}
   .cs-single-grid-label{display:inline-flex;align-items:center;justify-content:flex-end;gap:.35rem;min-width:0;font-weight:700;color:color-mix(in srgb,var(--text) 86%, transparent)}
   .cs-single-grid-title{font-size:.84rem;white-space:nowrap}
   .cs-single-grid-control{min-width:0;display:flex;align-items:center}
@@ -14524,6 +14653,9 @@ function rebuildSiteUI() {
   .cs-switch[data-state="mixed"] .cs-switch-track{background:color-mix(in srgb,#f59e0b 35%, var(--card));border-color:color-mix(in srgb,#f59e0b 55%, var(--border))}
   .cs-switch[data-state="mixed"] .cs-switch-thumb{background:color-mix(in srgb,#f59e0b 94%, var(--card));box-shadow:0 3px 8px color-mix(in srgb,#f59e0b 35%, transparent)}
   .cs-switch-input:focus-visible + .cs-switch-track{outline:2px solid color-mix(in srgb,var(--primary) 60%, transparent);outline-offset:2px}
+  .cs-input[data-diff="changed"],.cs-select[data-diff="changed"],.cs-field[data-diff="changed"] .cs-input,.cs-field[data-diff="changed"] .cs-select,.cs-single-grid-row[data-diff="changed"] .cs-input,.cs-single-grid-row[data-diff="changed"] .cs-select{background:color-mix(in srgb,#f59e0b 10%, transparent);border-color:color-mix(in srgb,#f59e0b 45%, var(--border))}
+  .cs-repo-field[data-diff="changed"],.cs-repo-grid[data-diff="changed"] .cs-repo-field,.cs-extra-list[data-diff="changed"] li{background:color-mix(in srgb,#f59e0b 10%, transparent);border-color:color-mix(in srgb,#f59e0b 45%, var(--border))}
+  .cs-switch[data-diff="changed"] .cs-switch-track,.cs-field[data-diff="changed"] .cs-switch-track,.cs-single-grid-row[data-diff="changed"] .cs-switch-track{background:color-mix(in srgb,#f59e0b 18%, var(--card));border-color:color-mix(in srgb,#f59e0b 45%, var(--border))}
   @media (max-width:1024px){
     .cs-layout{grid-template-columns:minmax(180px,220px) minmax(0,1fr);gap:1.1rem}
   }
@@ -14555,7 +14687,6 @@ function rebuildSiteUI() {
     .cs-identity-actions{justify-content:flex-start}
     .cs-single-grid{grid-template-columns:1fr;row-gap:.35rem}
     .cs-single-grid-row{grid-template-columns:1fr;align-items:stretch;gap:.35rem;padding:.2rem 0}
-    .cs-single-grid-row[data-diff="changed"]{padding-left:.65rem}
   }
 
   /* Modal animations */

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -3522,14 +3522,11 @@ function ensureFileDirtyBadgeElement(el) {
 
 function getFileToggleBaseLabel(el) {
   if (!el) return '';
-  if (el.dataset && el.dataset.fileLabel) return el.dataset.fileLabel;
-  const text = Array.from(el.childNodes || [])
+  return Array.from(el.childNodes || [])
     .filter(node => !(node.nodeType === 1 && node.classList && node.classList.contains('vt-dirty-badge')))
     .map(node => node.textContent || '')
     .join('')
     .trim();
-  if (text && el.dataset) el.dataset.fileLabel = text;
-  return text;
 }
 
 function updateFileDirtyBadge(kind) {
@@ -3565,6 +3562,16 @@ function updateFileDirtyBadge(kind) {
     if (baseLabel) el.setAttribute('aria-label', baseLabel);
     else el.removeAttribute('aria-label');
   }
+}
+
+function refreshFileDirtyBadges() {
+  updateFileDirtyBadge('index');
+  updateFileDirtyBadge('tabs');
+  updateFileDirtyBadge('site');
+}
+
+if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+  document.addEventListener('ns-editor-language-applied', refreshFileDirtyBadges);
 }
 
 function collectUnsyncedMarkdownEntries() {
@@ -14616,6 +14623,7 @@ function rebuildSiteUI() {
   textarea.cs-input{min-height:4.6rem;resize:vertical}
   .cs-input-small{max-width:220px}
   .cs-empty{padding:.7rem .85rem;border:1px dashed color-mix(in srgb,var(--border) 75%, transparent);border-radius:9px;background:color-mix(in srgb,var(--text) 2%, var(--card));color:color-mix(in srgb,var(--muted) 90%, transparent);font-size:.88rem}
+  .cs-field[data-diff="changed"] .cs-empty{background:color-mix(in srgb,#f59e0b 10%, var(--card));border-color:color-mix(in srgb,#f59e0b 45%, var(--border));color:color-mix(in srgb,#b45309 72%, var(--text))}
   .cs-add-lang,.cs-add-link{align-self:flex-start}
   .cs-remove-lang,.cs-remove-link{margin-left:auto}
   .cs-select{min-width:200px;padding:.3rem .45rem;border-radius:8px;border:1px solid color-mix(in srgb,var(--border) 80%, transparent);background:color-mix(in srgb,var(--card) 99%, transparent);color:var(--text);font-size:.84rem;line-height:1.25;font-family:inherit;transition:border-color .16s ease, box-shadow .16s ease}

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -13895,76 +13895,14 @@ function buildSiteUI(root, state) {
     renderRows();
   };
 
-  const identitySection = createSection(
-    t('editor.composer.site.sections.identity.title'),
-    t('editor.composer.site.sections.identity.description')
-  );
-  renderIdentityLocalizedGrid(identitySection);
-  renderIdentityPathGrid(identitySection);
-
-  const seoSection = createSection(
-    t('editor.composer.site.sections.seo.title'),
-    t('editor.composer.site.sections.seo.description')
-  );
-  renderLocalizedField(seoSection, 'siteDescription', {
-    label: t('editor.composer.site.fields.siteDescription'),
-    description: t('editor.composer.site.fields.siteDescriptionHelp'),
-    multiline: true,
-    rows: 3,
-    ensureDefault: false,
-    subheading: true
-  });
-  renderLocalizedField(seoSection, 'siteKeywords', {
-    label: t('editor.composer.site.fields.siteKeywords'),
-    description: t('editor.composer.site.fields.siteKeywordsHelp'),
-    grid: true,
-    ensureDefault: false,
-    subheading: true
-  });
-  createLinkListField(seoSection, 'profileLinks', {
-    label: t('editor.composer.site.fields.profileLinks'),
-    description: t('editor.composer.site.fields.profileLinksHelp'),
-    subheading: true
-  });
-  renderSeoResourceGrid(seoSection);
-
-  const siteConfigSection = createSection(
-    t('editor.composer.site.sections.configuration.title'),
-    t('editor.composer.site.sections.configuration.description')
-  );
-  const behaviorSubsection = createConfigSubsection(
-    siteConfigSection,
-    t('editor.composer.site.sections.behavior.title'),
-    t('editor.composer.site.sections.behavior.description')
-  );
-  renderBehaviorGrid(behaviorSubsection);
-
-  const themeSubsection = createConfigSubsection(
-    siteConfigSection,
-    t('editor.composer.site.sections.theme.title'),
-    t('editor.composer.site.sections.theme.description')
-  );
-  renderThemeGrid(themeSubsection);
-
-  const assetsSubsection = createConfigSubsection(
-    siteConfigSection,
-    t('editor.composer.site.sections.assets.title'),
-    t('editor.composer.site.sections.assets.description')
-  );
-  renderAssetWarningsGrid(assetsSubsection);
-
   const repoSection = createSection(
     t('editor.composer.site.sections.repo.title'),
     t('editor.composer.site.sections.repo.description')
   );
   const repo = ensureRepo();
-  const repoField = createField(repoSection, {
-    dataKey: 'repo',
-    label: t('editor.composer.site.fields.repo'),
-    description: t('editor.composer.site.fields.repoHelp')
-  });
   const repoInputs = document.createElement('div');
   repoInputs.className = 'cs-repo-grid';
+  repoInputs.dataset.field = 'repo';
 
   const ownerInput = document.createElement('input');
   ownerInput.type = 'text';
@@ -14026,7 +13964,65 @@ function buildSiteUI(root, state) {
   branchWrap.append(branchAffix, branchInput);
 
   repoInputs.append(pathRow, branchWrap);
-  repoField.appendChild(repoInputs);
+  repoSection.appendChild(repoInputs);
+
+  const identitySection = createSection(
+    t('editor.composer.site.sections.identity.title'),
+    t('editor.composer.site.sections.identity.description')
+  );
+  renderIdentityLocalizedGrid(identitySection);
+  renderIdentityPathGrid(identitySection);
+
+  const seoSection = createSection(
+    t('editor.composer.site.sections.seo.title'),
+    t('editor.composer.site.sections.seo.description')
+  );
+  renderLocalizedField(seoSection, 'siteDescription', {
+    label: t('editor.composer.site.fields.siteDescription'),
+    description: t('editor.composer.site.fields.siteDescriptionHelp'),
+    multiline: true,
+    rows: 3,
+    ensureDefault: false,
+    subheading: true
+  });
+  renderLocalizedField(seoSection, 'siteKeywords', {
+    label: t('editor.composer.site.fields.siteKeywords'),
+    description: t('editor.composer.site.fields.siteKeywordsHelp'),
+    grid: true,
+    ensureDefault: false,
+    subheading: true
+  });
+  createLinkListField(seoSection, 'profileLinks', {
+    label: t('editor.composer.site.fields.profileLinks'),
+    description: t('editor.composer.site.fields.profileLinksHelp'),
+    subheading: true
+  });
+  renderSeoResourceGrid(seoSection);
+
+  const siteConfigSection = createSection(
+    t('editor.composer.site.sections.configuration.title'),
+    t('editor.composer.site.sections.configuration.description')
+  );
+  const behaviorSubsection = createConfigSubsection(
+    siteConfigSection,
+    t('editor.composer.site.sections.behavior.title'),
+    t('editor.composer.site.sections.behavior.description')
+  );
+  renderBehaviorGrid(behaviorSubsection);
+
+  const themeSubsection = createConfigSubsection(
+    siteConfigSection,
+    t('editor.composer.site.sections.theme.title'),
+    t('editor.composer.site.sections.theme.description')
+  );
+  renderThemeGrid(themeSubsection);
+
+  const assetsSubsection = createConfigSubsection(
+    siteConfigSection,
+    t('editor.composer.site.sections.assets.title'),
+    t('editor.composer.site.sections.assets.description')
+  );
+  renderAssetWarningsGrid(assetsSubsection);
 
   if (site.__extras && Object.keys(site.__extras).length) {
     const extrasSection = createSection(

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -14374,7 +14374,7 @@ function rebuildSiteUI() {
   .cs-field-head-switch{display:flex;align-items:center;gap:.4rem}
   .cs-localized-list{display:flex;flex-direction:column;gap:.35rem}
   .cs-localized-row{display:flex;flex-wrap:wrap;gap:.45rem;padding:.2rem 0}
-  .cs-identity-grid,.cs-localized-list--grid,.cs-single-grid-fieldset{--cs-editor-row-gap:.35rem;--cs-editor-row-column-gap:.45rem;--cs-editor-control-height:1.95rem;--cs-editor-single-control-width:15rem}
+  .cs-identity-grid,.cs-localized-list--grid,.cs-single-grid-fieldset,.cs-link-list{--cs-editor-row-gap:.35rem;--cs-editor-row-column-gap:.45rem;--cs-editor-control-height:1.95rem;--cs-editor-single-control-width:15rem}
   .cs-localized-list--grid{gap:var(--cs-editor-row-gap)}
   .cs-localized-row--grid{display:grid;grid-template-columns:minmax(88px,88px) minmax(0,1fr) minmax(72px,max-content);align-items:center;column-gap:var(--cs-editor-row-column-gap);row-gap:0;min-height:var(--cs-editor-control-height);padding:0}
   .cs-localized-input{flex:1 1 240px;min-width:180px}
@@ -14421,9 +14421,9 @@ function rebuildSiteUI() {
   .cs-remove-lang,.cs-remove-link{margin-left:auto}
   .cs-select{min-width:200px;padding:.3rem .45rem;border-radius:8px;border:1px solid color-mix(in srgb,var(--border) 80%, transparent);background:color-mix(in srgb,var(--card) 99%, transparent);color:var(--text);font-size:.84rem;line-height:1.25;font-family:inherit;transition:border-color .16s ease, box-shadow .16s ease}
   .cs-select:focus{outline:none;border-color:color-mix(in srgb,var(--primary) 55%, var(--border));box-shadow:0 0 0 2px color-mix(in srgb,var(--primary) 18%, transparent)}
-  .cs-link-list{display:flex;flex-direction:column;gap:0}
-  .cs-link-row{display:flex;flex-wrap:wrap;align-items:flex-start;gap:.45rem .85rem;padding:.3rem 0}
-  .cs-link-row + .cs-link-row{margin-top:.3rem}
+  .cs-link-list{display:flex;flex-direction:column;gap:var(--cs-editor-row-gap)}
+  .cs-link-row{display:flex;flex-wrap:wrap;align-items:flex-start;gap:var(--cs-editor-row-column-gap);min-height:var(--cs-editor-control-height);padding:0}
+  .cs-link-row + .cs-link-row{margin-top:0}
   .cs-link-field{flex:1 1 200px;min-width:160px;display:flex;flex-direction:column;gap:.25rem}
   .cs-link-field--compact{gap:.15rem}
   .cs-link-field-title{font-size:.72rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:color-mix(in srgb,var(--muted) 78%, transparent)}
@@ -14474,7 +14474,7 @@ function rebuildSiteUI() {
   }
   @media (max-width:720px){
     .cs-section-description{text-align:left}
-    .cs-identity-grid,.cs-localized-list--grid,.cs-single-grid-fieldset{--cs-editor-row-gap:.5rem}
+    .cs-identity-grid,.cs-localized-list--grid,.cs-single-grid-fieldset,.cs-link-list{--cs-editor-row-gap:.5rem}
     .cs-localized-row--grid{grid-template-columns:1fr;gap:.35rem}
     .cs-localized-row--grid .cs-remove-lang{justify-self:flex-start}
     .cs-identity-grid{gap:.5rem}

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -14280,7 +14280,7 @@ function rebuildSiteUI() {
   .cs-field-head-switch{display:flex;align-items:center;gap:.4rem}
   .cs-localized-list{display:flex;flex-direction:column;gap:.35rem}
   .cs-localized-row{display:flex;flex-wrap:wrap;gap:.45rem;padding:.2rem 0}
-  .cs-identity-grid,.cs-localized-list--grid,.cs-single-grid-fieldset{--cs-editor-row-gap:.35rem;--cs-editor-row-column-gap:.45rem;--cs-editor-control-height:1.95rem}
+  .cs-identity-grid,.cs-localized-list--grid,.cs-single-grid-fieldset{--cs-editor-row-gap:.35rem;--cs-editor-row-column-gap:.45rem;--cs-editor-control-height:1.95rem;--cs-editor-single-control-width:15rem}
   .cs-localized-list--grid{gap:var(--cs-editor-row-gap)}
   .cs-localized-row--grid{display:grid;grid-template-columns:minmax(88px,88px) minmax(0,1fr) minmax(72px,max-content);align-items:center;column-gap:var(--cs-editor-row-column-gap);row-gap:0;min-height:var(--cs-editor-control-height);padding:0}
   .cs-localized-input{flex:1 1 240px;min-width:180px}
@@ -14305,7 +14305,7 @@ function rebuildSiteUI() {
   .cs-identity-actions{display:flex;align-items:center;justify-content:flex-end;min-width:0}
   .cs-identity-remove{margin-left:0;white-space:nowrap}
   .cs-single-grid-fieldset{gap:0}
-  .cs-single-grid{display:grid;grid-template-columns:minmax(88px,max-content) minmax(0,1fr);column-gap:var(--cs-editor-row-column-gap);row-gap:var(--cs-editor-row-gap);align-items:center}
+  .cs-single-grid{display:grid;grid-template-columns:minmax(88px,max-content) minmax(0,var(--cs-editor-single-control-width));column-gap:var(--cs-editor-row-column-gap);row-gap:var(--cs-editor-row-gap);align-items:center;justify-content:start}
   .cs-single-grid-row{display:grid;grid-template-columns:subgrid;grid-column:1/-1;align-items:center;gap:var(--cs-editor-row-column-gap);min-height:var(--cs-editor-control-height);padding:0;position:relative}
   .cs-single-grid-row[data-diff="changed"]{background:color-mix(in srgb,var(--primary) 6%, transparent);box-shadow:inset 3px 0 0 color-mix(in srgb,var(--primary) 60%, var(--border));border-radius:8px;padding-left:.85rem}
   .cs-single-grid-label{display:inline-flex;align-items:center;gap:.35rem;min-width:0;font-weight:700;color:color-mix(in srgb,var(--text) 86%, transparent)}

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -2281,8 +2281,9 @@ function applySiteDiffMarkers(diff) {
     if (info.type === 'localized' && Array.isArray(info.languages)) {
       return lang ? info.languages.includes(lang) : true;
     }
-    if (info.type === 'list' && info.entries && index != null && subfield) {
-      return !!(info.entries[index] && info.entries[index][subfield]);
+    if (info.type === 'list' && info.entries) {
+      if (index != null && subfield) return !!(info.entries[index] && info.entries[index][subfield]);
+      return true;
     }
     if (info.type === 'object' && info.fields) {
       return subfield ? !!info.fields[subfield] : false;

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -120,16 +120,6 @@ export function bindPostEditor() {
     }
     try { popup.opener = null; } catch (_) {}
     try { popup.focus(); } catch (_) {}
-    // Some embedded browsers return a popup object but never surface a tab.
-    window.setTimeout(() => {
-      let stayedHere = false;
-      try {
-        stayedHere = document.visibilityState === 'visible';
-      } catch (_) {
-        stayedHere = false;
-      }
-      if (stayedHere) window.location.href = editorUrl;
-    }, 250);
   });
 }
 

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -108,13 +108,7 @@ export function bindPostEditor() {
     } catch (_) {
       popup = null;
     }
-    let popupUsable = false;
-    try {
-      popupUsable = !!popup.document;
-    } catch (_) {
-      popupUsable = false;
-    }
-    if (!popup || popup.closed || typeof popup.closed === 'undefined' || !popupUsable) {
+    if (!popup) {
       window.location.href = editorUrl;
       return;
     }

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -101,7 +101,35 @@ export function bindPostEditor() {
   const btn = document.getElementById('postEditor');
   if (!btn) return;
   btn.addEventListener('click', () => {
-    window.open('index_editor.html', '_blank');
+    const editorUrl = 'index_editor.html';
+    let popup = null;
+    try {
+      popup = window.open(editorUrl, '_blank');
+    } catch (_) {
+      popup = null;
+    }
+    let popupUsable = false;
+    try {
+      popupUsable = !!popup.document;
+    } catch (_) {
+      popupUsable = false;
+    }
+    if (!popup || popup.closed || typeof popup.closed === 'undefined' || !popupUsable) {
+      window.location.href = editorUrl;
+      return;
+    }
+    try { popup.opener = null; } catch (_) {}
+    try { popup.focus(); } catch (_) {}
+    // Some embedded browsers return a popup object but never surface a tab.
+    window.setTimeout(() => {
+      let stayedHere = false;
+      try {
+        stayedHere = document.visibilityState === 'visible';
+      } catch (_) {
+        stayedHere = false;
+      }
+      if (stayedHere) window.location.href = editorUrl;
+    }, 250);
   });
 }
 

--- a/index_editor.html
+++ b/index_editor.html
@@ -1370,8 +1370,9 @@
     .wrap-toggle .vt-btn:hover { text-decoration:underline; }
     .view-toggle .vt-btn.active,
     .wrap-toggle .vt-btn.active { background:#eaeef2; color:#24292f; text-decoration:none; cursor:default; }
-    .view-toggle .vt-btn.has-draft::before { content:'●'; display:inline-block; font-size:.65rem; color:#f97316; margin-right:.35rem; line-height:1; }
-    .view-toggle .vt-btn.has-draft { padding-left:.5rem; }
+    .view-toggle .vt-btn .vt-dirty-badge{position:absolute;top:-.45rem;right:0;min-width:1.15rem;height:1.15rem;padding:0 .32rem;border-radius:999px;background:#ef4444;color:#fff;font-size:.68rem;font-weight:700;line-height:1;display:inline-flex;align-items:center;justify-content:center;box-shadow:0 3px 7px rgba(15,23,42,.2),0 0 0 2px var(--card);opacity:0;transform:translateX(50%) scale(.72);transition:opacity .16s ease,transform .16s ease;pointer-events:none;z-index:2;font-feature-settings:'tnum' 1,'case' 1}
+    .view-toggle .vt-btn .vt-dirty-badge[hidden]{display:none}
+    .view-toggle .vt-btn.has-draft .vt-dirty-badge{opacity:1;transform:translateX(50%) scale(1)}
     .view-toggle .dim,
     .wrap-toggle .dim { color:#8c959f; }
     /* Editor: reuse SEO hi-editor rules for perfect alignment */
@@ -1763,17 +1764,6 @@
             <button class="btn-secondary" id="btnDiscard" title="Discard local draft and reload remote file" data-i18n="editor.composer.discard" data-i18n-title="editor.composer.discardTitle" hidden>Discard</button>
           </div>
         </div>
-        <div class="composer-order-inline-meta" id="composerOrderInlineMeta" hidden>
-          <div class="composer-order-inline-meta-head">
-            <div class="composer-order-inline-titles">
-              <h3 class="composer-order-inline-title" data-i18n="editor.composer.changeSummary">Change summary</h3>
-              <span class="composer-order-inline-kind">index.yaml</span>
-            </div>
-            <button type="button" class="btn-secondary btn-compact composer-order-inline-open" data-kind="index" aria-label="Open change overview" data-i18n="editor.composer.reviewChanges" data-i18n-aria-label="editor.composer.reviewChanges">Review changes</button>
-          </div>
-          <div class="composer-order-inline-stats" aria-live="polite"></div>
-        </div>
-
         <!-- Composer Lists -->
         <div class="composer-panels" id="composerPanels">
           <div class="composer-order-host" data-kind="index" data-inline-active="false" id="composerIndexHost">

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -331,6 +331,12 @@ assert.match(
 
 assert.match(
   source,
+  /if \(info\.type === 'object' && info\.fields\) \{\s*return subfield \? !!info\.fields\[subfield\] : false;\s*\}/,
+  'Object field diffs should only match controls that declare a changed subfield'
+);
+
+assert.match(
+  source,
   /input\.dataset\.field = key;[\s\S]*input\.dataset\.lang = lang;/,
   'Localized site inputs should carry field and language diff metadata'
 );

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -257,6 +257,18 @@ assert.match(
   'compact single-value label measurement should use intrinsic label width instead of the currently constrained grid cell'
 );
 
+assert.match(
+  source,
+  /target\.querySelector \? target\.querySelector\('\.cs-help-tooltip'\) : null[\s\S]*const tooltipWidth = tooltip \? tooltip\.scrollWidth \|\| 0 : 0;/,
+  'compact single-value label measurement should measure only the help icon, not the tooltip wrapper'
+);
+
+assert.doesNotMatch(
+  source,
+  /querySelector\('\.cs-help-tooltip-wrap'\)[\s\S]*const tooltipWidth = tooltip \? tooltip\.scrollWidth \|\| 0 : 0;/,
+  'compact single-value label measurement should not include hidden tooltip bubble width'
+);
+
 assert.doesNotMatch(
   source,
   /function syncSiteEditorSingleLabelWidth\(root\) \{[\s\S]*getBoundingClientRect[\s\S]*root\.style\.setProperty\('--cs-editor-single-label-width'/,

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -12,6 +12,36 @@ const editorSource = readFileSync(editorPath, 'utf8');
 const nativeThemeSource = readFileSync(nativeThemePath, 'utf8');
 
 assert.match(
+  editorSource,
+  /\.view-toggle \.vt-btn \.vt-dirty-badge\{position:absolute;top:-\.45rem;right:0;min-width:1\.15rem;height:1\.15rem[\s\S]*transform:translateX\(50%\) scale\(\.72\)/,
+  'composer file switch dirty indicators should render as right-edge centered numeric badges'
+);
+
+assert.doesNotMatch(
+  editorSource,
+  /\.view-toggle \.vt-btn\.has-draft::before/,
+  'composer file switch dirty indicators should not render as inline orange dots'
+);
+
+assert.doesNotMatch(
+  editorSource,
+  /id="composerOrderInlineMeta"|data-i18n="editor\.composer\.changeSummary"/,
+  'composer should not render the inline change summary block above the editor'
+);
+
+assert.match(
+  source,
+  /function getComposerDiffChangeCount\(diff\) \{[\s\S]*Object\.keys\(diff\.fields\)[\s\S]*Object\.keys\(diff\.keys\)[\s\S]*diff\.orderChanged/,
+  'composer file dirty badges should derive a numeric count from the current diff'
+);
+
+assert.match(
+  source,
+  /function updateFileDirtyBadge\(kind\) \{[\s\S]*const changeCount = getComposerDiffChangeCount\(diff\);[\s\S]*badge\.textContent = displayValue;[\s\S]*el\.dataset\.dirtyCount = String\(changeCount\);/,
+  'composer file switch dirty badges should render the change count into the button'
+);
+
+assert.match(
   source,
   /const renderIdentityLocalizedGrid = \(section\) => \{/,
   'composer site editor should define a merged identity localized grid renderer'
@@ -283,8 +313,68 @@ assert.match(
 
 assert.match(
   source,
-  /\.cs-repo-grid\[data-diff="changed"\],\.cs-extra-list\[data-diff="changed"\]\{background:color-mix\(in srgb,var\(--primary\) 6%, transparent\);box-shadow:inset 3px 0 0 color-mix\(in srgb,var\(--primary\) 60%, var\(--border\)\);border-radius:8px;padding-left:\.85rem\}/,
-  'Repository and Other keys direct containers should keep visible changed-state diff highlighting'
+  /function applySiteDiffMarkers\(diff\) \{[\s\S]*const lang = el\.getAttribute\('data-lang'\);[\s\S]*const subfield = el\.getAttribute\('data-subfield'\);[\s\S]*const hasChangedDescendant = \(el\) =>[\s\S]*if \(hasChangedDescendant\(el\)\) \{/,
+  'Site editor diff markers should support control-level language and subfield matching'
+);
+
+assert.match(
+  source,
+  /input\.dataset\.field = key;[\s\S]*input\.dataset\.lang = lang;/,
+  'Localized site inputs should carry field and language diff metadata'
+);
+
+assert.match(
+  source,
+  /input\.dataset\.field = key;[\s\S]*input\.dataset\.lang = lang;[\s\S]*input\.dataset\.subfield = key;/,
+  'Identity grid inputs should carry field, language, and subfield diff metadata'
+);
+
+assert.match(
+  source,
+  /ownerWrap\.dataset\.field = 'repo';[\s\S]*ownerWrap\.dataset\.subfield = 'owner';[\s\S]*repoWrap\.dataset\.field = 'repo';[\s\S]*repoWrap\.dataset\.subfield = 'name';[\s\S]*branchWrap\.dataset\.field = 'repo';[\s\S]*branchWrap\.dataset\.subfield = 'branch';/,
+  'Repository diff metadata should target the specific owner, repo name, or branch pill'
+);
+
+assert.match(
+  source,
+  /labelInput\.dataset\.field = key;[\s\S]*labelInput\.dataset\.index = String\(index\);[\s\S]*labelInput\.dataset\.subfield = 'label';[\s\S]*hrefInput\.dataset\.field = key;[\s\S]*hrefInput\.dataset\.index = String\(index\);[\s\S]*hrefInput\.dataset\.subfield = 'href';/,
+  'Profile link diff metadata should target the specific label or URL input'
+);
+
+assert.doesNotMatch(
+  source,
+  /\.cs-field\[data-diff="changed"\],\.cs-repo-grid\[data-diff="changed"\],\.cs-extra-list\[data-diff="changed"\],\.cs-single-grid-row\[data-diff="changed"\]\{background:/,
+  'Site editor changed-state highlights should not tint whole field containers'
+);
+
+assert.match(
+  source,
+  /\.cs-field\[data-diff="changed"\] \.cs-input,\.cs-field\[data-diff="changed"\] \.cs-select,[\s\S]*\.cs-single-grid-row\[data-diff="changed"\] \.cs-input,[\s\S]*\.cs-single-grid-row\[data-diff="changed"\] \.cs-select[\s\S]*\{background:color-mix\(in srgb,#f59e0b 10%, transparent\);border-color:color-mix\(in srgb,#f59e0b 45%, var\(--border\)\)\}/,
+  'Site editor changed-state highlights should tint changed text and select controls'
+);
+
+assert.match(
+  source,
+  /\.cs-repo-grid\[data-diff="changed"\] \.cs-repo-field,[\s\S]*\.cs-extra-list\[data-diff="changed"\] li[\s\S]*background:color-mix\(in srgb,#f59e0b 10%, transparent\)/,
+  'Site editor changed-state highlights should tint changed repository fields and read-only key rows'
+);
+
+assert.match(
+  source,
+  /\.cs-field\[data-diff="changed"\] \.cs-switch-track,[\s\S]*\.cs-single-grid-row\[data-diff="changed"\] \.cs-switch-track[\s\S]*background:color-mix\(in srgb,#f59e0b 18%, var\(--card\)\)/,
+  'Site editor changed-state highlights should tint changed switch tracks'
+);
+
+assert.doesNotMatch(
+  source,
+  /\[data-diff="changed"\][^{]*\{[^}]*box-shadow:inset[^}]*\}/,
+  'Site editor changed-state highlights should not add inset bars'
+);
+
+assert.doesNotMatch(
+  source,
+  /\[data-diff="changed"\][^{]*\{[^}]*padding-left:[^}]*\}/,
+  'Site editor changed-state highlights should not add left padding that shifts fields'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -205,6 +205,12 @@ assert.match(
 
 assert.match(
   source,
+  /const themeSection = createSection\([\s\S]*renderThemeGrid\(themeSection\);[\s\S]*const assetsSection = createSection\([\s\S]*renderAssetWarningsGrid\(assetsSection\);[\s\S]*const repoSection = createSection\(/,
+  'Site editor should render Asset warnings before Repository'
+);
+
+assert.match(
+  source,
   /field\.className = 'cs-field cs-single-grid-fieldset';/,
   'avatar and content root should share one compact fieldset instead of separate tall fields'
 );

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -337,6 +337,12 @@ assert.match(
 
 assert.match(
   source,
+  /if \(info\.type === 'list' && info\.entries\) \{\s*if \(index != null && subfield\) return !!\(info\.entries\[index\] && info\.entries\[index\]\[subfield\]\);\s*return true;\s*\}/,
+  'List field diffs should preserve field-level markers when removed rows have no remaining controls'
+);
+
+assert.match(
+  source,
   /input\.dataset\.field = key;[\s\S]*input\.dataset\.lang = lang;/,
   'Localized site inputs should carry field and language diff metadata'
 );

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -53,6 +53,12 @@ assert.match(
   'SEO Resource URL should render through the compact grid'
 );
 
+assert.match(
+  source,
+  /renderLocalizedField\(seoSection, 'siteKeywords'[\s\S]*createLinkListField\(seoSection, 'profileLinks'[\s\S]*renderSeoResourceGrid\(seoSection\);/,
+  'SEO section should render Profile links before Resource URL'
+);
+
 assert.doesNotMatch(
   source,
   /renderLocalizedField\(identitySection,\s*'siteTitle'/,
@@ -131,6 +137,12 @@ assert.match(
   'identity and aligned localized rows should share one row rhythm and fixed single-control width contract'
 );
 
+assert.doesNotMatch(
+  source,
+  /\.(?:cs-root|cs-single-grid-fieldset)\{[^}]*--cs-editor-single-label-width/,
+  'compact containers should not redeclare the measured label width because that masks the inherited dynamic value'
+);
+
 assert.match(
   source,
   /\.cs-localized-list--grid\{gap:var\(--cs-editor-row-gap\)\}[\s\S]*\.cs-localized-row--grid\{display:grid;grid-template-columns:minmax\(88px,88px\) minmax\(0,1fr\) minmax\(72px,max-content\);align-items:center;column-gap:var\(--cs-editor-row-column-gap\);row-gap:0;min-height:var\(--cs-editor-control-height\);padding:0/,
@@ -165,6 +177,24 @@ assert.match(
   source,
   /const createSingleGridFieldset = \(section\) => \{/,
   'compact single-value sections should share one reusable grid fieldset renderer'
+);
+
+assert.match(
+  source,
+  /function syncSiteEditorSingleLabelWidth\(root\) \{[\s\S]*querySelectorAll\('\.cs-single-grid-title'\)[\s\S]*requestAnimationFrame[\s\S]*ResizeObserver[\s\S]*--cs-editor-single-label-width/,
+  'compact single-value labels should be measured once after render and shared through a CSS variable'
+);
+
+assert.match(
+  source,
+  /label\.scrollWidth[\s\S]*getComputedStyle\(target\)[\s\S]*gap/,
+  'compact single-value label measurement should use intrinsic label width instead of the currently constrained grid cell'
+);
+
+assert.match(
+  source,
+  /buildSiteUI\(root, state\) \{[\s\S]*renderCompactSectionMenu\(\);[\s\S]*syncSiteEditorSingleLabelWidth\(root\);[\s\S]*refreshNavDiffState\(\);/,
+  'site editor should resync the measured single-label width after rebuilding translated labels'
 );
 
 assert.match(
@@ -241,8 +271,20 @@ assert.match(
 
 assert.match(
   source,
-  /\.cs-single-grid\{display:grid;grid-template-columns:minmax\(88px,max-content\) minmax\(0,var\(--cs-editor-single-control-width\)\);column-gap:var\(--cs-editor-row-column-gap\);row-gap:var\(--cs-editor-row-gap\);align-items:center;justify-content:start\}[\s\S]*\.cs-single-grid-row\{display:grid;grid-template-columns:subgrid;grid-column:1\/-1;align-items:center;gap:var\(--cs-editor-row-column-gap\);min-height:var\(--cs-editor-control-height\);padding:0/,
-  'compact identity path rows should use one fixed-width parent grid and subgrid rows so labels and inputs share column tracks'
+  /label\.className = 'cs-single-grid-title';[\s\S]*labelCell\.appendChild\(label\);[\s\S]*labelCell\.appendChild\(tooltipWrap\);/,
+  'compact single-grid rows should place help tooltip buttons between the label text and the control'
+);
+
+assert.match(
+  source,
+  /\.cs-single-grid-label\{display:inline-flex;align-items:center;justify-content:flex-end;gap:\.35rem;/,
+  'compact single-grid label cells should right-align the label and trailing help icon'
+);
+
+assert.match(
+  source,
+  /\.cs-single-grid\{display:grid;grid-template-columns:var\(--cs-editor-single-label-width,88px\) minmax\(0,var\(--cs-editor-single-control-width\)\);column-gap:var\(--cs-editor-row-column-gap\);row-gap:var\(--cs-editor-row-gap\);align-items:center;justify-content:start\}[\s\S]*\.cs-single-grid-row\{display:grid;grid-template-columns:subgrid;grid-column:1\/-1;align-items:center;gap:var\(--cs-editor-row-column-gap\);min-height:var\(--cs-editor-control-height\);padding:0/,
+  'compact identity path rows should use one measured label column and a fixed-width control column'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -133,8 +133,8 @@ assert.match(
 
 assert.match(
   source,
-  /\.cs-identity-grid,.cs-localized-list--grid,.cs-single-grid-fieldset\{--cs-editor-row-gap:\.35rem;--cs-editor-row-column-gap:\.45rem;--cs-editor-control-height:1\.95rem;--cs-editor-single-control-width:15rem\}/,
-  'identity and aligned localized rows should share one row rhythm and fixed single-control width contract'
+  /\.cs-identity-grid,.cs-localized-list--grid,.cs-single-grid-fieldset,.cs-link-list\{--cs-editor-row-gap:\.35rem;--cs-editor-row-column-gap:\.45rem;--cs-editor-control-height:1\.95rem;--cs-editor-single-control-width:15rem\}/,
+  'identity, aligned localized rows, and profile links should share one row rhythm and fixed single-control width contract'
 );
 
 assert.doesNotMatch(
@@ -285,6 +285,18 @@ assert.match(
   source,
   /\.cs-single-grid\{display:grid;grid-template-columns:var\(--cs-editor-single-label-width,88px\) minmax\(0,var\(--cs-editor-single-control-width\)\);column-gap:var\(--cs-editor-row-column-gap\);row-gap:var\(--cs-editor-row-gap\);align-items:center;justify-content:start\}[\s\S]*\.cs-single-grid-row\{display:grid;grid-template-columns:subgrid;grid-column:1\/-1;align-items:center;gap:var\(--cs-editor-row-column-gap\);min-height:var\(--cs-editor-control-height\);padding:0/,
   'compact identity path rows should use one measured label column and a fixed-width control column'
+);
+
+assert.match(
+  source,
+  /\.cs-link-list\{display:flex;flex-direction:column;gap:var\(--cs-editor-row-gap\)\}[\s\S]*\.cs-link-row\{display:flex;flex-wrap:wrap;align-items:flex-start;gap:var\(--cs-editor-row-column-gap\);min-height:var\(--cs-editor-control-height\);padding:0\}[\s\S]*\.cs-link-row \+ \.cs-link-row\{margin-top:0\}/,
+  'profile link rows should use the same vertical row rhythm as localized grid rows'
+);
+
+assert.match(
+  source,
+  /\.cs-link-row\{display:flex;flex-wrap:wrap;align-items:flex-start;gap:var\(--cs-editor-row-column-gap\);min-height:var\(--cs-editor-control-height\);padding:0\}/,
+  'profile link label and URL fields should use the same horizontal gap as identity grid columns'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -265,8 +265,26 @@ assert.match(
 
 assert.match(
   source,
-  /const siteConfigSection = createSection\([\s\S]*renderBehaviorGrid\(behaviorSubsection\);[\s\S]*renderThemeGrid\(themeSubsection\);[\s\S]*renderAssetWarningsGrid\(assetsSubsection\);[\s\S]*const repoSection = createSection\(/,
-  'Site editor should combine Behavior, Theme, and Asset warnings before Repository'
+  /const repoSection = createSection\([\s\S]*sections\.repo\.title[\s\S]*sections\.repo\.description[\s\S]*const identitySection = createSection\(/,
+  'Repository should be the first site editor card before Identity'
+);
+
+assert.doesNotMatch(
+  source,
+  /createField\(repoSection,\s*\{[\s\S]*dataKey: 'repo'[\s\S]*fields\.repo[\s\S]*fields\.repoHelp/,
+  'Repository card should not render a duplicate GitHub repository field heading'
+);
+
+assert.match(
+  source,
+  /repoInputs\.className = 'cs-repo-grid';[\s\S]*repoInputs\.dataset\.field = 'repo';[\s\S]*repoInputs\.append\(pathRow, branchWrap\);[\s\S]*repoSection\.appendChild\(repoInputs\);/,
+  'Repository inputs should remain diff-addressable while rendering directly in the Repository card'
+);
+
+assert.match(
+  source,
+  /const siteConfigSection = createSection\([\s\S]*renderBehaviorGrid\(behaviorSubsection\);[\s\S]*renderThemeGrid\(themeSubsection\);[\s\S]*renderAssetWarningsGrid\(assetsSubsection\);[\s\S]*const extrasSection = createSection\(/,
+  'Site editor should combine Behavior, Theme, and Asset warnings before Other keys'
 );
 
 assert.doesNotMatch(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -145,8 +145,14 @@ assert.match(
 
 assert.match(
   source,
-  /\.cs-localized-row--grid \.cs-lang-chip\{justify-self:start\}/,
-  'aligned localized rows should keep language chips content-width instead of stretching them'
+  /\.cs-localized-row--grid \.cs-lang-chip\{justify-self:end\}/,
+  'aligned localized rows should right-align language chips within the language column'
+);
+
+assert.match(
+  source,
+  /\.cs-identity-lang\{min-width:0;display:flex;align-items:center;justify-content:flex-end\}/,
+  'identity localized rows should right-align language chips within the language column'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -289,6 +289,18 @@ assert.match(
 
 assert.doesNotMatch(
   source,
+  /createField\(extrasSection,\s*\{[\s\S]*dataKey: '__extras'[\s\S]*fields\.extras[\s\S]*fields\.extrasHelp/,
+  'Other keys should not render a duplicate Preserved keys field heading'
+);
+
+assert.match(
+  source,
+  /list\.className = 'cs-extra-list';[\s\S]*list\.dataset\.field = '__extras';[\s\S]*extrasSection\.appendChild\(list\);/,
+  'Other keys list should remain diff-addressable while rendering directly in the card'
+);
+
+assert.doesNotMatch(
+  source,
   /const behaviorSection = createSection\([\s\S]*const themeSection = createSection\([\s\S]*const assetsSection = createSection\(/,
   'Behavior, Theme, and Asset warnings should not render as separate top-level cards'
 );

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -41,6 +41,18 @@ assert.match(
   'composer file switch dirty badges should render the change count into the button'
 );
 
+assert.doesNotMatch(
+  source,
+  /dataset\.fileLabel/,
+  'composer file switch dirty labels should not cache translated tab text across language changes'
+);
+
+assert.match(
+  source,
+  /function refreshFileDirtyBadges\(\) \{[\s\S]*updateFileDirtyBadge\('index'\);[\s\S]*updateFileDirtyBadge\('tabs'\);[\s\S]*updateFileDirtyBadge\('site'\);[\s\S]*document\.addEventListener\('ns-editor-language-applied', refreshFileDirtyBadges\)/,
+  'composer file switch dirty labels should be recomputed after editor language changes'
+);
+
 assert.match(
   source,
   /const renderIdentityLocalizedGrid = \(section\) => \{/,
@@ -351,6 +363,12 @@ assert.match(
   source,
   /\.cs-field\[data-diff="changed"\] \.cs-input,\.cs-field\[data-diff="changed"\] \.cs-select,[\s\S]*\.cs-single-grid-row\[data-diff="changed"\] \.cs-input,[\s\S]*\.cs-single-grid-row\[data-diff="changed"\] \.cs-select[\s\S]*\{background:color-mix\(in srgb,#f59e0b 10%, transparent\);border-color:color-mix\(in srgb,#f59e0b 45%, var\(--border\)\)\}/,
   'Site editor changed-state highlights should tint changed text and select controls'
+);
+
+assert.match(
+  source,
+  /\.cs-field\[data-diff="changed"\] \.cs-empty\{background:color-mix\(in srgb,#f59e0b 10%, var\(--card\)\);border-color:color-mix\(in srgb,#f59e0b 45%, var\(--border\)\)/,
+  'Site editor changed-state highlights should tint empty placeholders for changed list fields'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -283,6 +283,12 @@ assert.match(
 
 assert.match(
   source,
+  /\.cs-repo-grid\[data-diff="changed"\],\.cs-extra-list\[data-diff="changed"\]\{background:color-mix\(in srgb,var\(--primary\) 6%, transparent\);box-shadow:inset 3px 0 0 color-mix\(in srgb,var\(--primary\) 60%, var\(--border\)\);border-radius:8px;padding-left:\.85rem\}/,
+  'Repository and Other keys direct containers should keep visible changed-state diff highlighting'
+);
+
+assert.match(
+  source,
   /const siteConfigSection = createSection\([\s\S]*renderBehaviorGrid\(behaviorSubsection\);[\s\S]*renderThemeGrid\(themeSubsection\);[\s\S]*renderAssetWarningsGrid\(assetsSubsection\);[\s\S]*const extrasSection = createSection\(/,
   'Site editor should combine Behavior, Theme, and Asset warnings before Other keys'
 );

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -31,20 +31,20 @@ assert.match(
 
 assert.match(
   source,
-  /renderBehaviorGrid\(behaviorSection\);/,
-  'Behavior section should render single-value fields through the compact grid'
+  /const siteConfigSection = createSection\([\s\S]*sections\.configuration\.title[\s\S]*sections\.configuration\.description[\s\S]*createConfigSubsection\(\s*siteConfigSection,[\s\S]*sections\.behavior\.title[\s\S]*renderBehaviorGrid\(behaviorSubsection\);/,
+  'Behavior settings should render inside the combined Site Configuration section'
 );
 
 assert.match(
   source,
-  /renderThemeGrid\(themeSection\);/,
-  'Theme section should render single-value fields through the compact grid'
+  /createConfigSubsection\(\s*siteConfigSection,[\s\S]*sections\.theme\.title[\s\S]*renderThemeGrid\(themeSubsection\);/,
+  'Theme settings should render inside the combined Site Configuration section'
 );
 
 assert.match(
   source,
-  /renderAssetWarningsGrid\(assetsSection\);/,
-  'Asset warnings section should render single-value fields through the compact grid'
+  /createConfigSubsection\(\s*siteConfigSection,[\s\S]*sections\.assets\.title[\s\S]*renderAssetWarningsGrid\(assetsSubsection\);/,
+  'Asset warnings should render inside the combined Site Configuration section'
 );
 
 assert.match(
@@ -57,6 +57,30 @@ assert.match(
   source,
   /renderLocalizedField\(seoSection, 'siteKeywords'[\s\S]*createLinkListField\(seoSection, 'profileLinks'[\s\S]*renderSeoResourceGrid\(seoSection\);/,
   'SEO section should render Profile links before Resource URL'
+);
+
+assert.match(
+  source,
+  /createLinkListField\(seoSection, 'profileLinks', \{[\s\S]*subheading: true[\s\S]*\}\);/,
+  'SEO Profile links should opt into the shared subsection heading style'
+);
+
+assert.match(
+  source,
+  /renderLocalizedField\(seoSection, 'siteDescription', \{[\s\S]*subheading: true[\s\S]*\}\);[\s\S]*renderLocalizedField\(seoSection, 'siteKeywords', \{[\s\S]*subheading: true[\s\S]*\}\);/,
+  'SEO localized fields should opt into the shared subsection heading style'
+);
+
+assert.match(
+  source,
+  /const field = options\.subheading[\s\S]*createSubheadingField\(section, \{[\s\S]*dataKey: key,[\s\S]*label: options\.label,[\s\S]*description: options\.description[\s\S]*createField\(section, \{/,
+  'localized fields should be able to reuse the shared subsection heading renderer'
+);
+
+assert.match(
+  source,
+  /const createSubheadingField = \(section, config\) => \{[\s\S]*head\.className = 'cs-config-subsection-head'[\s\S]*title\.className = 'cs-config-subsection-title'[\s\S]*description\.className = 'cs-config-subsection-description'/,
+  'subheading fields should reuse the same title and description classes as combined configuration subsections'
 );
 
 assert.doesNotMatch(
@@ -241,8 +265,14 @@ assert.match(
 
 assert.match(
   source,
-  /const themeSection = createSection\([\s\S]*renderThemeGrid\(themeSection\);[\s\S]*const assetsSection = createSection\([\s\S]*renderAssetWarningsGrid\(assetsSection\);[\s\S]*const repoSection = createSection\(/,
-  'Site editor should render Asset warnings before Repository'
+  /const siteConfigSection = createSection\([\s\S]*renderBehaviorGrid\(behaviorSubsection\);[\s\S]*renderThemeGrid\(themeSubsection\);[\s\S]*renderAssetWarningsGrid\(assetsSubsection\);[\s\S]*const repoSection = createSection\(/,
+  'Site editor should combine Behavior, Theme, and Asset warnings before Repository'
+);
+
+assert.doesNotMatch(
+  source,
+  /const behaviorSection = createSection\([\s\S]*const themeSection = createSection\([\s\S]*const assetsSection = createSection\(/,
+  'Behavior, Theme, and Asset warnings should not render as separate top-level cards'
 );
 
 assert.match(
@@ -297,6 +327,30 @@ assert.match(
   source,
   /\.cs-link-row\{display:flex;flex-wrap:wrap;align-items:flex-start;gap:var\(--cs-editor-row-column-gap\);min-height:var\(--cs-editor-control-height\);padding:0\}/,
   'profile link label and URL fields should use the same horizontal gap as identity grid columns'
+);
+
+assert.match(
+  source,
+  /\.cs-config-subsection \+ \.cs-config-subsection\{border-top:1px solid color-mix\(in srgb,var\(--border\) 82%, transparent\);margin-top:\.35rem;padding-top:\.95rem\}/,
+  'combined Site Configuration subsections should be separated by the same divider rhythm as large cards'
+);
+
+assert.match(
+  source,
+  /\.cs-config-subsection-title\{margin:0;font-size:\.84rem;font-weight:600;color:color-mix\(in srgb,var\(--text\) 76%, transparent\)\}[\s\S]*\.cs-config-subsection-description\{margin:0;font-size:\.8rem;color:color-mix\(in srgb,var\(--muted\) 88%, transparent\);flex:1 1 auto;text-align:left\}/,
+  'combined Site Configuration subsection headings should use the smaller field-heading rhythm instead of top-level section titles'
+);
+
+assert.match(
+  source,
+  /\.cs-config-subsection\{display:flex;flex-direction:column;gap:\.4rem\}[\s\S]*\.cs-config-subsection > \.cs-config-subsection-head \+ \.cs-field\{padding-top:0\}/,
+  'combined Site Configuration subsection content should sit as close to its heading as SEO subheading content'
+);
+
+assert.doesNotMatch(
+  source,
+  /createConfigSubsection[\s\S]*document\.createElement\('h4'\)/,
+  'combined Site Configuration subsection labels should not render as document headings'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -127,8 +127,8 @@ assert.match(
 
 assert.match(
   source,
-  /\.cs-identity-grid,.cs-localized-list--grid,.cs-single-grid-fieldset\{--cs-editor-row-gap:\.35rem;--cs-editor-row-column-gap:\.45rem;--cs-editor-control-height:1\.95rem\}/,
-  'identity and aligned localized rows should share one row rhythm contract'
+  /\.cs-identity-grid,.cs-localized-list--grid,.cs-single-grid-fieldset\{--cs-editor-row-gap:\.35rem;--cs-editor-row-column-gap:\.45rem;--cs-editor-control-height:1\.95rem;--cs-editor-single-control-width:15rem\}/,
+  'identity and aligned localized rows should share one row rhythm and fixed single-control width contract'
 );
 
 assert.match(
@@ -235,8 +235,8 @@ assert.match(
 
 assert.match(
   source,
-  /\.cs-single-grid\{display:grid;grid-template-columns:minmax\(88px,max-content\) minmax\(0,1fr\);column-gap:var\(--cs-editor-row-column-gap\);row-gap:var\(--cs-editor-row-gap\);align-items:center\}[\s\S]*\.cs-single-grid-row\{display:grid;grid-template-columns:subgrid;grid-column:1\/-1;align-items:center;gap:var\(--cs-editor-row-column-gap\);min-height:var\(--cs-editor-control-height\);padding:0/,
-  'compact identity path rows should use one parent grid and subgrid rows so labels and inputs share column tracks'
+  /\.cs-single-grid\{display:grid;grid-template-columns:minmax\(88px,max-content\) minmax\(0,var\(--cs-editor-single-control-width\)\);column-gap:var\(--cs-editor-row-column-gap\);row-gap:var\(--cs-editor-row-gap\);align-items:center;justify-content:start\}[\s\S]*\.cs-single-grid-row\{display:grid;grid-template-columns:subgrid;grid-column:1\/-1;align-items:center;gap:var\(--cs-editor-row-column-gap\);min-height:var\(--cs-editor-control-height\);padding:0/,
+  'compact identity path rows should use one fixed-width parent grid and subgrid rows so labels and inputs share column tracks'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -257,6 +257,12 @@ assert.match(
   'compact single-value label measurement should use intrinsic label width instead of the currently constrained grid cell'
 );
 
+assert.doesNotMatch(
+  source,
+  /function syncSiteEditorSingleLabelWidth\(root\) \{[\s\S]*getBoundingClientRect[\s\S]*root\.style\.setProperty\('--cs-editor-single-label-width'/,
+  'compact single-value label measurement should not seed width from constrained layout rects'
+);
+
 assert.match(
   source,
   /buildSiteUI\(root, state\) \{[\s\S]*renderCompactSectionMenu\(\);[\s\S]*syncSiteEditorSingleLabelWidth\(root\);[\s\S]*refreshNavDiffState\(\);/,

--- a/scripts/test-post-editor-popup-fallback.js
+++ b/scripts/test-post-editor-popup-fallback.js
@@ -21,8 +21,14 @@ assert.match(
 
 assert.match(
   source,
-  /popupUsable = !!popup\.document;/,
-  'post editor button should verify the popup is actually usable before skipping fallback'
+  /if \(!popup\) \{\s*window\.location\.href = editorUrl;\s*return;\s*\}/,
+  'post editor button should fall back only when window.open returns no popup handle'
+);
+
+assert.doesNotMatch(
+  source,
+  /popup\.closed|typeof popup\.closed|popup\.document/,
+  'post editor button should not treat severed popup handles as failed opens'
 );
 
 assert.match(

--- a/scripts/test-post-editor-popup-fallback.js
+++ b/scripts/test-post-editor-popup-fallback.js
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const themePath = resolve(here, '../assets/js/theme.js');
+const source = readFileSync(themePath, 'utf8');
+
+assert.match(
+  source,
+  /const editorUrl = 'index_editor\.html';/,
+  'post editor button should keep one canonical editor URL'
+);
+
+assert.match(
+  source,
+  /window\.open\(editorUrl,\s*'_blank'\)/,
+  'post editor button should still prefer opening the editor in a new tab'
+);
+
+assert.match(
+  source,
+  /popupUsable = !!popup\.document;/,
+  'post editor button should verify the popup is actually usable before skipping fallback'
+);
+
+assert.match(
+  source,
+  /popup\.opener = null;/,
+  'post editor button should detach opener after a successful popup open'
+);
+
+assert.match(
+  source,
+  /window\.location\.href = editorUrl;/,
+  'post editor button should fall back to same-tab navigation when popup opening fails'
+);
+
+assert.match(
+  source,
+  /window\.setTimeout\(\(\) => \{/,
+  'post editor button should schedule a delayed fallback for silent popup failures'
+);
+
+assert.match(
+  source,
+  /document\.visibilityState === 'visible'/,
+  'delayed fallback should only fire when the original page remains visible'
+);

--- a/scripts/test-post-editor-popup-fallback.js
+++ b/scripts/test-post-editor-popup-fallback.js
@@ -37,14 +37,14 @@ assert.match(
   'post editor button should fall back to same-tab navigation when popup opening fails'
 );
 
-assert.match(
+assert.doesNotMatch(
   source,
-  /window\.setTimeout\(\(\) => \{/,
-  'post editor button should schedule a delayed fallback for silent popup failures'
+  /window\.setTimeout\(\(\) => \{[\s\S]*window\.location\.href = editorUrl;/,
+  'post editor button should not schedule a delayed redirect after popup open succeeds'
 );
 
-assert.match(
+assert.doesNotMatch(
   source,
   /document\.visibilityState === 'visible'/,
-  'delayed fallback should only fire when the original page remains visible'
+  'post editor button should not treat a visible opener page as popup failure'
 );


### PR DESCRIPTION
## Summary
- Reworks the Site composer layout with compact aligned grids for identity, SEO, configuration, repository, and preserved keys.
- Groups behavior, theme, and asset warnings into one Site Configuration card with smaller subsection headings and tighter spacing.
- Moves Repository to the first card and removes duplicate field headings from Repository and Other keys while preserving diff targeting.
- Adds localized labels and structure tests covering the new composer layout contracts.

## Validation
- node scripts/test-composer-identity-grid.js
- node scripts/test-post-editor-popup-fallback.js
- git diff --check HEAD
- Browser DOM checks on http://127.0.0.1:8000/index_editor.html during review
