### PR TITLE
[codex] Add static system release manifest fallback

### DIFF
--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -256,3 +256,61 @@ jobs:
           }))
           PY
           gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${{ steps.create.outputs.release_id }}" --input dist/publish-release.json >/dev/null
+
+      - name: Update static release manifest
+        if: steps.plan.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_ASSET: ${{ steps.plan.outputs.asset_name }}
+          EXPECTED_SIZE: ${{ steps.package.outputs.archive_size }}
+          EXPECTED_SHA256: ${{ steps.package.outputs.archive_sha256 }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/releases/${{ steps.create.outputs.release_id }}" > dist/release-published.json
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          with open("dist/release-published.json", "r", encoding="utf-8") as fh:
+              release = json.load(fh)
+
+          expected_name = os.environ["EXPECTED_ASSET"]
+          expected_size = int(os.environ["EXPECTED_SIZE"])
+          expected_sha = os.environ["EXPECTED_SHA256"].lower()
+          assets = [asset for asset in release.get("assets", []) if asset.get("name") == expected_name]
+          if len(assets) != 1:
+              sys.exit(f"expected exactly one release asset named {expected_name}, found {len(assets)}")
+
+          asset = assets[0]
+          digest = str(asset.get("digest") or "").lower() or f"sha256:{expected_sha}"
+          manifest = {
+              "schemaVersion": 1,
+              "name": release.get("name") or release.get("tag_name") or "",
+              "tag": release.get("tag_name") or "",
+              "publishedAt": release.get("published_at") or release.get("created_at") or "",
+              "notes": release.get("body") or "",
+              "htmlUrl": release.get("html_url") or "",
+              "asset": {
+                  "name": asset.get("name") or expected_name,
+                  "url": asset.get("browser_download_url") or f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/releases/download/{release.get('tag_name')}/{expected_name}",
+                  "size": int(asset.get("size") or expected_size),
+                  "digest": digest
+              }
+          }
+          Path("assets/system-release.json").write_text(
+              json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+              encoding="utf-8"
+          )
+          PY
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add assets/system-release.json
+          if git diff --cached --quiet; then
+            echo "System release manifest already up to date."
+            exit 0
+          fi
+          git commit -m "Update system release manifest"
+          git push origin "HEAD:${GITHUB_REF_NAME}"

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -313,4 +313,15 @@ jobs:
             exit 0
           fi
           git commit -m "Update system release manifest"
-          git push origin "HEAD:${GITHUB_REF_NAME}"
+          for attempt in 1 2 3; do
+            git fetch origin "${GITHUB_REF_NAME}"
+            git rebase "origin/${GITHUB_REF_NAME}"
+            if git push origin "HEAD:${GITHUB_REF_NAME}"; then
+              exit 0
+            fi
+            if [[ "${attempt}" == "3" ]]; then
+              echo "Failed to push system release manifest after rebasing." >&2
+              exit 1
+            fi
+            sleep 2
+          done

--- a/assets/i18n/chs.js
+++ b/assets/i18n/chs.js
@@ -167,6 +167,7 @@ const translations = {
         },
         errors: {
           releaseFetch: '无法加载最新发布信息。',
+          releaseRateLimited: 'GitHub API 已限流。请稍后重试，或手动选择已下载的 ZIP。',
           emptyFile: '选择的文件为空。',
           invalidArchive: '选中的 ZIP 无法作为 NanoSite 发布读取。',
           sizeMismatch: ({ expected, actual }) => `选中的压缩包大小（${actual}）与发布附件（${expected}）不一致。`,

--- a/assets/i18n/cht-tw.js
+++ b/assets/i18n/cht-tw.js
@@ -167,6 +167,7 @@ const translations = {
         },
         errors: {
           releaseFetch: '無法載入最新發布資訊。',
+          releaseRateLimited: 'GitHub API 已限流。請稍後重試，或手動選擇已下載的 ZIP。',
           emptyFile: '選擇的檔案為空。',
           invalidArchive: '選中的 ZIP 無法作為 NanoSite 釋出讀取。',
           sizeMismatch: ({ expected, actual }) => `選中的壓縮包大小（${actual}）與釋出附件（${expected}）不一致。`,

--- a/assets/i18n/en.js
+++ b/assets/i18n/en.js
@@ -167,6 +167,7 @@ const translations = {
         },
         errors: {
           releaseFetch: 'Unable to load latest release information.',
+          releaseRateLimited: 'GitHub API is rate limited. Try again later, or manually select a downloaded ZIP.',
           emptyFile: 'The selected file is empty.',
           invalidArchive: 'The selected ZIP could not be read as a NanoSite release.',
           sizeMismatch: ({ expected, actual }) => `The selected archive size (${actual}) does not match the release asset (${expected}).`,

--- a/assets/i18n/ja.js
+++ b/assets/i18n/ja.js
@@ -167,6 +167,7 @@ const translations = {
         },
         errors: {
           releaseFetch: '最新リリース情報を取得できませんでした。',
+          releaseRateLimited: 'GitHub API のレート制限に達しました。しばらくしてから再試行するか、ダウンロード済み ZIP を手動で選択してください。',
           emptyFile: '選択したファイルは空です。',
           invalidArchive: '選択した ZIP を NanoSite リリースとして読み込めませんでした。',
           sizeMismatch: ({ expected, actual }) => `選択したアーカイブのサイズ（${actual}）がリリースアセット（${expected}）と一致しません。`,

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -11,6 +11,8 @@ const TEXT_FILENAMES = new Set(['LICENSE', 'README', 'README.md', 'CHANGELOG', '
 
 export const SYSTEM_UPDATE_ASSET_NAME_PATTERN = /^nanosite-system-v\d+\.\d+\.\d+\.zip$/i;
 
+const RELEASE_API_URL = 'https://api.github.com/repos/deemoe404/NanoSite/releases/latest';
+const RELEASE_MANIFEST_URL = 'https://raw.githubusercontent.com/deemoe404/NanoSite/main/assets/system-release.json';
 const SYSTEM_UPDATE_ALLOWED_PATH_PATTERN = /^(?:index\.html|index_editor\.html|assets\/(?:main\.js|js\/.+|i18n\/.+|schema\/.+|themes\/.+))$/;
 const SYSTEM_UPDATE_BLOCKED_PATH_PATTERN = /^(?:\.git\/|\.github\/|wwwroot\/|site\.ya?ml$|site\.local\.ya?ml$|CNAME$|robots\.txt$|sitemap\.xml$|README(?:\.md)?$|BRANCHING\.md$|scripts\/|assets\/(?:avatar|hero)\.jpeg$)/i;
 
@@ -267,6 +269,68 @@ export function selectSystemUpdateAsset(releaseData) {
   };
 }
 
+function isObject(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requireManifestString(manifest, key) {
+  const value = manifest && manifest[key];
+  if (typeof value !== 'string') {
+    throw new Error(`Invalid system release manifest: missing ${key}`);
+  }
+  return value;
+}
+
+function normalizeReleaseCache(data) {
+  const asset = selectSystemUpdateAsset(data);
+  return {
+    name: data.name || data.tag_name || 'latest',
+    tag: data.tag_name || '',
+    publishedAt: data.published_at || data.created_at || '',
+    notes: data.body || '',
+    htmlUrl: data.html_url || '',
+    asset
+  };
+}
+
+export function normalizeSystemReleaseManifest(manifest) {
+  if (!isObject(manifest) || manifest.schemaVersion !== 1) {
+    throw new Error('Invalid system release manifest: unsupported schema');
+  }
+  const name = requireManifestString(manifest, 'name');
+  const tag = requireManifestString(manifest, 'tag');
+  const publishedAt = requireManifestString(manifest, 'publishedAt');
+  const notes = requireManifestString(manifest, 'notes');
+  const htmlUrl = requireManifestString(manifest, 'htmlUrl');
+  if (!isObject(manifest.asset)) {
+    throw new Error('Invalid system release manifest: missing asset');
+  }
+  const asset = selectSystemUpdateAsset({ assets: [manifest.asset] });
+  if (!asset || !asset.name || !asset.url) {
+    throw new Error('Invalid system release manifest: invalid asset');
+  }
+  const size = Number(asset.size);
+  if (!Number.isFinite(size) || size <= 0) {
+    throw new Error('Invalid system release manifest: invalid asset size');
+  }
+  const digest = String(asset.digest || '').trim().toLowerCase();
+  if (!/^sha256:[0-9a-f]{64}$/.test(digest)) {
+    throw new Error('Invalid system release manifest: invalid asset digest');
+  }
+  return {
+    name,
+    tag,
+    publishedAt,
+    notes,
+    htmlUrl,
+    asset: {
+      ...asset,
+      size,
+      digest
+    }
+  };
+}
+
 export async function verifySystemUpdateAsset(buffer, asset = {}) {
   if (!(buffer instanceof ArrayBuffer)) buffer = getBuffer(buffer);
   const actualSize = buffer ? buffer.byteLength : 0;
@@ -289,26 +353,98 @@ export async function verifySystemUpdateAsset(buffer, asset = {}) {
   };
 }
 
-async function fetchLatestRelease() {
-  if (releaseCache) return releaseCache;
-  const response = await fetch('https://api.github.com/repos/deemoe404/NanoSite/releases/latest', {
+function getResponseHeader(response, name) {
+  try {
+    return response && response.headers && typeof response.headers.get === 'function'
+      ? String(response.headers.get(name) || '')
+      : '';
+  } catch (_) {
+    return '';
+  }
+}
+
+function isRateLimitedResponse(response) {
+  const status = Number(response && response.status);
+  const remaining = getResponseHeader(response, 'x-ratelimit-remaining');
+  return status === 429 || (status === 403 && remaining === '0');
+}
+
+function createReleaseFetchError(response) {
+  const error = new Error(isRateLimitedResponse(response)
+    ? t('editor.systemUpdates.errors.releaseRateLimited')
+    : t('editor.systemUpdates.errors.releaseFetch'));
+  error.rateLimited = isRateLimitedResponse(response);
+  error.status = Number(response && response.status) || 0;
+  return error;
+}
+
+function renderRelease() {
+  renderReleaseMeta();
+  renderNotes(releaseCache ? releaseCache.notes : '');
+  updateDownloadLink();
+}
+
+async function fetchLatestReleaseFromApi() {
+  const response = await fetch(RELEASE_API_URL, {
     headers: { Accept: 'application/vnd.github+json' },
     cache: 'no-store'
   });
-  if (!response.ok) throw new Error(t('editor.systemUpdates.errors.releaseFetch'));
+  if (!response.ok) throw createReleaseFetchError(response);
   const data = await response.json();
-  const asset = selectSystemUpdateAsset(data);
-  releaseCache = {
-    name: data.name || data.tag_name || 'latest',
-    tag: data.tag_name || '',
-    publishedAt: data.published_at || data.created_at || '',
-    notes: data.body || '',
-    htmlUrl: data.html_url || '',
-    asset
-  };
-  renderReleaseMeta();
-  renderNotes(releaseCache.notes);
-  updateDownloadLink();
+  return normalizeReleaseCache(data);
+}
+
+function getManifestUrls() {
+  const urls = [RELEASE_MANIFEST_URL];
+  try {
+    const localUrl = new URL('assets/system-release.json', document.baseURI).href;
+    if (localUrl && !urls.includes(localUrl)) urls.push(localUrl);
+  } catch (_) {}
+  return urls;
+}
+
+async function fetchLatestReleaseFromManifest() {
+  let lastError = null;
+  const urls = getManifestUrls();
+  for (const url of urls) {
+    try {
+      const response = await fetch(url, {
+        headers: { Accept: 'application/json' },
+        cache: 'no-store'
+      });
+      if (!response.ok) {
+        lastError = new Error(`System release manifest fetch failed (${response.status || 'unknown'})`);
+        continue;
+      }
+      const data = await response.json();
+      return normalizeSystemReleaseManifest(data);
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError || new Error('System release manifest fetch failed');
+}
+
+async function fetchLatestRelease() {
+  if (releaseCache) return releaseCache;
+  let apiError = null;
+  try {
+    releaseCache = await fetchLatestReleaseFromApi();
+  } catch (err) {
+    apiError = err;
+    try {
+      releaseCache = await fetchLatestReleaseFromManifest();
+    } catch (manifestError) {
+      const message = apiError && apiError.rateLimited
+        ? t('editor.systemUpdates.errors.releaseRateLimited')
+        : t('editor.systemUpdates.errors.releaseFetch');
+      const error = new Error(message);
+      error.apiError = apiError;
+      error.manifestError = manifestError;
+      throw error;
+    }
+  }
+  renderRelease();
   return releaseCache;
 }
 
@@ -532,7 +668,7 @@ export function initSystemUpdates(options = {}) {
   setStatus(t('editor.systemUpdates.status.idle'));
   fetchLatestRelease().catch((err) => {
     console.error('Failed to load system update metadata', err);
-    setStatus(t('editor.systemUpdates.errors.releaseFetch'), { tone: 'error' });
+    setStatus(err && err.message ? err.message : t('editor.systemUpdates.errors.releaseFetch'), { tone: 'error' });
   });
 }
 

--- a/assets/system-release.json
+++ b/assets/system-release.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "name": "v3.3.10",
+  "tag": "v3.3.10",
+  "publishedAt": "2026-04-29T08:18:39Z",
+  "notes": "## Migration Guide\n\nUse the System Updates tool in Markdown Editor to download and apply `nanosite-system-v3.3.10.zip`.\n\n## System Package\n\n- Asset: `nanosite-system-v3.3.10.zip`\n- SHA-256: `535de2ddd3c612310760365196c21bb7ab7a5ffacbebb0dcdbd17f59bedc861a`\n\n## Changed System Files\n\n- assets/i18n/chs.js\n- assets/i18n/cht-tw.js\n- assets/i18n/en.js\n- assets/i18n/ja.js\n- assets/js/composer.js\n- index_editor.html\n\n**Full Changelog**: https://github.com/deemoe404/NanoSite/compare/v3.3.9...v3.3.10",
+  "htmlUrl": "https://github.com/deemoe404/NanoSite/releases/tag/v3.3.10",
+  "asset": {
+    "name": "nanosite-system-v3.3.10.zip",
+    "url": "https://github.com/deemoe404/NanoSite/releases/download/v3.3.10/nanosite-system-v3.3.10.zip",
+    "size": 441836,
+    "digest": "sha256:535de2ddd3c612310760365196c21bb7ab7a5ffacbebb0dcdbd17f59bedc861a"
+  }
+}

--- a/assets/system-release.json
+++ b/assets/system-release.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": 1,
-  "name": "v3.3.10",
-  "tag": "v3.3.10",
-  "publishedAt": "2026-04-29T08:18:39Z",
-  "notes": "## Migration Guide\n\nUse the System Updates tool in Markdown Editor to download and apply `nanosite-system-v3.3.10.zip`.\n\n## System Package\n\n- Asset: `nanosite-system-v3.3.10.zip`\n- SHA-256: `535de2ddd3c612310760365196c21bb7ab7a5ffacbebb0dcdbd17f59bedc861a`\n\n## Changed System Files\n\n- assets/i18n/chs.js\n- assets/i18n/cht-tw.js\n- assets/i18n/en.js\n- assets/i18n/ja.js\n- assets/js/composer.js\n- index_editor.html\n\n**Full Changelog**: https://github.com/deemoe404/NanoSite/compare/v3.3.9...v3.3.10",
-  "htmlUrl": "https://github.com/deemoe404/NanoSite/releases/tag/v3.3.10",
+  "name": "v3.3.11",
+  "tag": "v3.3.11",
+  "publishedAt": "2026-04-30T10:35:12Z",
+  "notes": "## Migration Guide\n\nUse the System Updates tool in Markdown Editor to download and apply `nanosite-system-v3.3.11.zip`.\n\n## System Package\n\n- Asset: `nanosite-system-v3.3.11.zip`\n- SHA-256: `26dd4c7cd04a8bbe9fea40ad5845be1a5a4f2207412e248d1173a5513f143115`\n\n## Changed System Files\n\n- assets/i18n/chs.js\n- assets/i18n/cht-hk.js\n- assets/i18n/cht-tw.js\n- assets/i18n/en.js\n- assets/i18n/ja.js\n- assets/i18n/languages.json\n- assets/js/composer.js\n- assets/js/editor-boot.js\n- assets/js/editor-content-tree.js\n- assets/js/editor-github.js\n- assets/js/editor-main.js\n- assets/js/errors.js\n- assets/js/hieditor.js\n- assets/js/i18n.js\n- assets/js/post-nav.js\n- assets/js/seo.js\n- assets/js/system-updates.js\n- assets/js/tags.js\n- assets/js/templates.js\n- assets/js/theme.js\n- assets/js/toc.js\n- index_editor.html\n\n**Full Changelog**: https://github.com/deemoe404/NanoSite/compare/v3.3.10...v3.3.11\n",
+  "htmlUrl": "https://github.com/deemoe404/NanoSite/releases/tag/v3.3.11",
   "asset": {
-    "name": "nanosite-system-v3.3.10.zip",
-    "url": "https://github.com/deemoe404/NanoSite/releases/download/v3.3.10/nanosite-system-v3.3.10.zip",
-    "size": 441836,
-    "digest": "sha256:535de2ddd3c612310760365196c21bb7ab7a5ffacbebb0dcdbd17f59bedc861a"
+    "name": "nanosite-system-v3.3.11.zip",
+    "url": "https://github.com/deemoe404/NanoSite/releases/download/v3.3.11/nanosite-system-v3.3.11.zip",
+    "size": 462653,
+    "digest": "sha256:26dd4c7cd04a8bbe9fea40ad5845be1a5a4f2207412e248d1173a5513f143115"
   }
 }

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -123,6 +123,23 @@ if ! grep -F 'git commit -m "Update system release manifest"' "${workflow}" >/de
   exit 1
 fi
 
+if ! grep -F 'git rebase "origin/${GITHUB_REF_NAME}"' "${workflow}" >/dev/null; then
+  echo "system release workflow must rebase before pushing the manifest commit" >&2
+  exit 1
+fi
+
+if ! grep -F 'Failed to push system release manifest after rebasing.' "${workflow}" >/dev/null; then
+  echo "system release workflow must retry manifest pushes and fail clearly after repeated rebase attempts" >&2
+  exit 1
+fi
+
+manifest_rebase_line="$(grep -nF 'git rebase "origin/${GITHUB_REF_NAME}"' "${workflow}" | head -n 1 | cut -d: -f1)"
+manifest_push_line="$(grep -nF 'git push origin "HEAD:${GITHUB_REF_NAME}"' "${workflow}" | tail -n 1 | cut -d: -f1)"
+if [[ -n "${manifest_rebase_line}" && -n "${manifest_push_line}" && "${manifest_push_line}" -lt "${manifest_rebase_line}" ]]; then
+  echo "system release workflow must rebase before pushing the manifest commit" >&2
+  exit 1
+fi
+
 stale_cleanup_line="$(grep -nF 'stale-draft-release-ids.txt' "${workflow}" | head -n 1 | cut -d: -f1)"
 tag_refusal_line="$(grep -nF 'Refusing to overwrite existing tag' "${workflow}" | head -n 1 | cut -d: -f1)"
 if [[ -n "${tag_refusal_line}" && -n "${stale_cleanup_line}" && "${tag_refusal_line}" -lt "${stale_cleanup_line}" ]]; then

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -28,6 +28,16 @@ if awk '
   exit 1
 fi
 
+if awk '
+  /- name: Plan release/ { in_plan = 1 }
+  /- name: Build system update package/ { in_plan = 0 }
+  in_plan && /assets\/system-release\.json/ { found = 1 }
+  END { exit found ? 0 : 1 }
+' "${workflow}" >/dev/null; then
+  echo "system release manifest must not participate in release planning" >&2
+  exit 1
+fi
+
 if grep -F 'releases/tags/${NEXT_TAG}' "${workflow}" >/dev/null; then
   echo "system release workflow must not validate draft releases through the tag endpoint" >&2
   exit 1
@@ -90,6 +100,26 @@ fi
 
 if ! grep -F 'git tag -d "${next_tag}"' "${workflow}" >/dev/null; then
   echo "system release workflow must delete stale local release tags before retrying" >&2
+  exit 1
+fi
+
+if ! grep -F 'Update static release manifest' "${workflow}" >/dev/null; then
+  echo "system release workflow must update the static release manifest after publishing" >&2
+  exit 1
+fi
+
+if ! grep -F 'dist/release-published.json' "${workflow}" >/dev/null; then
+  echo "system release workflow must read the published release before writing the manifest" >&2
+  exit 1
+fi
+
+if ! grep -F 'git add assets/system-release.json' "${workflow}" >/dev/null; then
+  echo "system release workflow must commit assets/system-release.json" >&2
+  exit 1
+fi
+
+if ! grep -F 'git commit -m "Update system release manifest"' "${workflow}" >/dev/null; then
+  echo "system release workflow must use a stable manifest commit message" >&2
   exit 1
 fi
 

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -27,6 +27,7 @@ const {
   analyzeArchive,
   collectSystemUpdateArchiveEntries,
   clearSystemUpdateState,
+  normalizeSystemReleaseManifest,
   selectSystemUpdateAsset,
   verifySystemUpdateAsset
 } = await import('../assets/js/system-updates.js?system-updates-test');
@@ -42,6 +43,28 @@ function makeZip(files) {
 async function sha256(buffer) {
   const digest = await webcrypto.subtle.digest('SHA-256', buffer);
   return Buffer.from(digest).toString('hex');
+}
+
+function jsonResponse(data, options = {}) {
+  const {
+    ok = true,
+    status = ok ? 200 : 500,
+    headers = {}
+  } = options;
+  const normalizedHeaders = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
+  );
+  return {
+    ok,
+    status,
+    headers: {
+      get(name) {
+        return normalizedHeaders[String(name || '').toLowerCase()] || null;
+      }
+    },
+    json: async () => data,
+    arrayBuffer: async () => new ArrayBuffer(0)
+  };
 }
 
 async function run(name, fn) {
@@ -87,6 +110,142 @@ await run('verifies release asset size and digest before archive comparison', as
     }, 'nanosite-system-v3.3.5.zip'),
     /sha-?256|digest|hash/i
   );
+});
+
+await run('normalizes static system release manifests', async () => {
+  const release = normalizeSystemReleaseManifest({
+    schemaVersion: 1,
+    name: 'v3.3.5',
+    tag: 'v3.3.5',
+    publishedAt: '2026-04-29T08:18:39Z',
+    notes: 'Release notes',
+    htmlUrl: 'https://github.com/deemoe404/NanoSite/releases/tag/v3.3.5',
+    asset: {
+      name: 'nanosite-system-v3.3.5.zip',
+      url: 'https://github.com/deemoe404/NanoSite/releases/download/v3.3.5/nanosite-system-v3.3.5.zip',
+      size: 123,
+      digest: 'sha256:535de2ddd3c612310760365196c21bb7ab7a5ffacbebb0dcdbd17f59bedc861a'
+    }
+  });
+
+  assert.equal(release.tag, 'v3.3.5');
+  assert.equal(release.asset.name, 'nanosite-system-v3.3.5.zip');
+  assert.throws(
+    () => normalizeSystemReleaseManifest({
+      schemaVersion: 1,
+      name: 'v3.3.5',
+      tag: 'v3.3.5',
+      publishedAt: '2026-04-29T08:18:39Z',
+      notes: '',
+      htmlUrl: 'https://github.com/deemoe404/NanoSite/releases/tag/v3.3.5'
+    }),
+    /manifest/i
+  );
+  assert.throws(
+    () => normalizeSystemReleaseManifest({
+      schemaVersion: 1,
+      name: 'v3.3.5',
+      tag: 'v3.3.5',
+      publishedAt: '2026-04-29T08:18:39Z',
+      notes: '',
+      htmlUrl: 'https://github.com/deemoe404/NanoSite/releases/tag/v3.3.5',
+      asset: {
+        name: 'NanoSite-v3.3.5-source.zip',
+        url: 'https://github.com/deemoe404/NanoSite/archive/refs/tags/v3.3.5.zip',
+        size: 123,
+        digest: 'sha256:535de2ddd3c612310760365196c21bb7ab7a5ffacbebb0dcdbd17f59bedc861a'
+      }
+    }),
+    /manifest/i
+  );
+});
+
+await run('falls back to the static release manifest when the GitHub API is rate limited', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  const buffer = makeZip({ 'nanosite-system-v3.3.5/index.html': '<!doctype html><p>manifest</p>' });
+  const digest = await sha256(buffer);
+  let apiCalls = 0;
+  let manifestCalls = 0;
+
+  globalThis.fetch = async (input) => {
+    const url = String(input || '');
+    if (url.includes('/repos/deemoe404/NanoSite/releases/latest')) {
+      apiCalls += 1;
+      return jsonResponse({ message: 'rate limited' }, {
+        ok: false,
+        status: 403,
+        headers: { 'x-ratelimit-remaining': '0' }
+      });
+    }
+    if (url.includes('assets/system-release.json')) {
+      manifestCalls += 1;
+      return jsonResponse({
+        schemaVersion: 1,
+        name: 'v3.3.5',
+        tag: 'v3.3.5',
+        publishedAt: '2026-04-29T08:18:39Z',
+        notes: 'Manifest release notes',
+        htmlUrl: 'https://github.com/deemoe404/NanoSite/releases/tag/v3.3.5',
+        asset: {
+          name: 'nanosite-system-v3.3.5.zip',
+          url: 'https://github.com/deemoe404/NanoSite/releases/download/v3.3.5/nanosite-system-v3.3.5.zip',
+          size: buffer.byteLength,
+          digest: `sha256:${digest}`
+        }
+      });
+    }
+    return {
+      ok: false,
+      arrayBuffer: async () => new ArrayBuffer(0)
+    };
+  };
+
+  await analyzeArchive(buffer, 'nanosite-system-v3.3.5.zip');
+
+  assert.equal(apiCalls, 1);
+  assert.equal(manifestCalls, 1);
+  delete globalThis.fetch;
+});
+
+await run('uses the static manifest digest when verifying a selected archive', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  const buffer = makeZip({ 'nanosite-system-v3.3.5/index.html': '<!doctype html><p>manifest</p>' });
+
+  globalThis.fetch = async (input) => {
+    const url = String(input || '');
+    if (url.includes('/repos/deemoe404/NanoSite/releases/latest')) {
+      return jsonResponse({ message: 'rate limited' }, {
+        ok: false,
+        status: 429
+      });
+    }
+    if (url.includes('assets/system-release.json')) {
+      return jsonResponse({
+        schemaVersion: 1,
+        name: 'v3.3.5',
+        tag: 'v3.3.5',
+        publishedAt: '2026-04-29T08:18:39Z',
+        notes: 'Manifest release notes',
+        htmlUrl: 'https://github.com/deemoe404/NanoSite/releases/tag/v3.3.5',
+        asset: {
+          name: 'nanosite-system-v3.3.5.zip',
+          url: 'https://github.com/deemoe404/NanoSite/releases/download/v3.3.5/nanosite-system-v3.3.5.zip',
+          size: buffer.byteLength,
+          digest: 'sha256:0000000000000000000000000000000000000000000000000000000000000000'
+        }
+      });
+    }
+    return {
+      ok: false,
+      arrayBuffer: async () => new ArrayBuffer(0)
+    };
+  };
+
+  await assert.rejects(
+    () => analyzeArchive(buffer, 'nanosite-system-v3.3.5.zip'),
+    /sha-?256|digest|hash/i
+  );
+  delete globalThis.fetch;
 });
 
 await run('normalizes a rooted system update archive to safe site-relative paths', async () => {


### PR DESCRIPTION
## Summary
- Adds a static `assets/system-release.json` manifest seeded from the latest system release `v3.3.11`.
- Keeps the GitHub Releases API as the primary metadata source and falls back to the raw manifest when the API is unavailable or rate limited.
- Preserves ZIP size and SHA-256 verification through manifest metadata.
- Updates the System Release workflow to write and commit the manifest after publishing future releases.

## Notes
- This follows PR #279 after the editor UI branch landed.
- The manifest is excluded from release planning so the workflow does not create a release loop.
- The Node 20 `actions/checkout@v4` warning is intentionally left for a separate maintenance PR.

## Validation
- node --experimental-default-type=module scripts/test-system-updates.js
- bash scripts/test-system-release-workflow.sh
- bash scripts/test-system-release-package.sh
- python3 -m json.tool assets/system-release.json
- git diff --check
