### PR TITLE
[codex] Route system release manifest updates through PRs

### DIFF
--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -328,11 +328,8 @@ jobs:
           git push --force-with-lease origin "HEAD:${manifest_branch}"
 
           pr_number="$(
-            gh pr list \
-              --repo "${GITHUB_REPOSITORY}" \
-              --head "${manifest_branch}" \
-              --state open \
-              --json number \
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/pulls?state=open&head=${GITHUB_REPOSITORY_OWNER}:${manifest_branch}" \
               --jq '.[0].number // empty'
           )"
           if [[ -n "${pr_number}" ]]; then

--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: system-release
@@ -313,15 +314,37 @@ jobs:
             exit 0
           fi
           git commit -m "Update system release manifest"
-          for attempt in 1 2 3; do
-            git fetch origin "${GITHUB_REF_NAME}"
-            git rebase "origin/${GITHUB_REF_NAME}"
-            if git push origin "HEAD:${GITHUB_REF_NAME}"; then
-              exit 0
-            fi
-            if [[ "${attempt}" == "3" ]]; then
-              echo "Failed to push system release manifest after rebasing." >&2
-              exit 1
-            fi
-            sleep 2
-          done
+          manifest_branch="codex/system-release-manifest-${{ steps.plan.outputs.next_tag }}"
+          manifest_title="Update system release manifest for ${{ steps.plan.outputs.next_tag }}"
+          manifest_body="$(mktemp)"
+          cat > "${manifest_body}" <<EOF
+          Automated manifest refresh for ${{ steps.plan.outputs.next_tag }}.
+
+          This updates assets/system-release.json after the system release has been published. It is intentionally excluded from release planning, so merging this PR will not publish another system release.
+          EOF
+
+          git fetch origin "${GITHUB_REF_NAME}"
+          git rebase "origin/${GITHUB_REF_NAME}"
+          git push --force-with-lease origin "HEAD:${manifest_branch}"
+
+          pr_number="$(
+            gh pr list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --head "${manifest_branch}" \
+              --state open \
+              --json number \
+              --jq '.[0].number // empty'
+          )"
+          if [[ -n "${pr_number}" ]]; then
+            gh pr edit "${pr_number}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "${manifest_title}" \
+              --body-file "${manifest_body}"
+          else
+            gh pr create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --base "${GITHUB_REF_NAME}" \
+              --head "${manifest_branch}" \
+              --title "${manifest_title}" \
+              --body-file "${manifest_body}"
+          fi

--- a/assets/system-release.json
+++ b/assets/system-release.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": 1,
-  "name": "v3.3.11",
-  "tag": "v3.3.11",
-  "publishedAt": "2026-04-30T10:35:12Z",
-  "notes": "## Migration Guide\n\nUse the System Updates tool in Markdown Editor to download and apply `nanosite-system-v3.3.11.zip`.\n\n## System Package\n\n- Asset: `nanosite-system-v3.3.11.zip`\n- SHA-256: `26dd4c7cd04a8bbe9fea40ad5845be1a5a4f2207412e248d1173a5513f143115`\n\n## Changed System Files\n\n- assets/i18n/chs.js\n- assets/i18n/cht-hk.js\n- assets/i18n/cht-tw.js\n- assets/i18n/en.js\n- assets/i18n/ja.js\n- assets/i18n/languages.json\n- assets/js/composer.js\n- assets/js/editor-boot.js\n- assets/js/editor-content-tree.js\n- assets/js/editor-github.js\n- assets/js/editor-main.js\n- assets/js/errors.js\n- assets/js/hieditor.js\n- assets/js/i18n.js\n- assets/js/post-nav.js\n- assets/js/seo.js\n- assets/js/system-updates.js\n- assets/js/tags.js\n- assets/js/templates.js\n- assets/js/theme.js\n- assets/js/toc.js\n- index_editor.html\n\n**Full Changelog**: https://github.com/deemoe404/NanoSite/compare/v3.3.10...v3.3.11\n",
-  "htmlUrl": "https://github.com/deemoe404/NanoSite/releases/tag/v3.3.11",
+  "name": "v3.3.12",
+  "tag": "v3.3.12",
+  "publishedAt": "2026-04-30T11:05:27Z",
+  "notes": "## Migration Guide\n\nUse the System Updates tool in Markdown Editor to download and apply `nanosite-system-v3.3.12.zip`.\n\n## System Package\n\n- Asset: `nanosite-system-v3.3.12.zip`\n- SHA-256: `1513c5581001750f10458262287f227b9a4996837f9ad1ba53b1d4a1975a9eef`\n\n## Changed System Files\n\n- assets/i18n/chs.js\n- assets/i18n/cht-tw.js\n- assets/i18n/en.js\n- assets/i18n/ja.js\n- assets/js/system-updates.js\n\n**Full Changelog**: https://github.com/deemoe404/NanoSite/compare/v3.3.11...v3.3.12\n",
+  "htmlUrl": "https://github.com/deemoe404/NanoSite/releases/tag/v3.3.12",
   "asset": {
-    "name": "nanosite-system-v3.3.11.zip",
-    "url": "https://github.com/deemoe404/NanoSite/releases/download/v3.3.11/nanosite-system-v3.3.11.zip",
-    "size": 462653,
-    "digest": "sha256:26dd4c7cd04a8bbe9fea40ad5845be1a5a4f2207412e248d1173a5513f143115"
+    "name": "nanosite-system-v3.3.12.zip",
+    "url": "https://github.com/deemoe404/NanoSite/releases/download/v3.3.12/nanosite-system-v3.3.12.zip",
+    "size": 463773,
+    "digest": "sha256:1513c5581001750f10458262287f227b9a4996837f9ad1ba53b1d4a1975a9eef"
   }
 }

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -10,6 +10,11 @@ if [[ ! -f "${workflow}" ]]; then
   exit 1
 fi
 
+if ! grep -F 'pull-requests: write' "${workflow}" >/dev/null; then
+  echo "system release workflow must be allowed to create manifest pull requests" >&2
+  exit 1
+fi
+
 if ! awk '
   /^  release:/ { in_release = 1; next }
   in_release && /^  [A-Za-z0-9_-]+:/ { in_release = 0 }
@@ -123,20 +128,28 @@ if ! grep -F 'git commit -m "Update system release manifest"' "${workflow}" >/de
   exit 1
 fi
 
-if ! grep -F 'git rebase "origin/${GITHUB_REF_NAME}"' "${workflow}" >/dev/null; then
-  echo "system release workflow must rebase before pushing the manifest commit" >&2
+if ! grep -F 'manifest_branch="codex/system-release-manifest-${{ steps.plan.outputs.next_tag }}"' "${workflow}" >/dev/null; then
+  echo "system release workflow must publish manifest commits to a dedicated branch" >&2
   exit 1
 fi
 
-if ! grep -F 'Failed to push system release manifest after rebasing.' "${workflow}" >/dev/null; then
-  echo "system release workflow must retry manifest pushes and fail clearly after repeated rebase attempts" >&2
+if ! grep -F 'git push --force-with-lease origin "HEAD:${manifest_branch}"' "${workflow}" >/dev/null; then
+  echo "system release workflow must push the manifest commit to a PR branch" >&2
   exit 1
 fi
 
-manifest_rebase_line="$(grep -nF 'git rebase "origin/${GITHUB_REF_NAME}"' "${workflow}" | head -n 1 | cut -d: -f1)"
-manifest_push_line="$(grep -nF 'git push origin "HEAD:${GITHUB_REF_NAME}"' "${workflow}" | tail -n 1 | cut -d: -f1)"
-if [[ -n "${manifest_rebase_line}" && -n "${manifest_push_line}" && "${manifest_push_line}" -lt "${manifest_rebase_line}" ]]; then
-  echo "system release workflow must rebase before pushing the manifest commit" >&2
+if ! grep -F 'gh pr create' "${workflow}" >/dev/null; then
+  echo "system release workflow must open a pull request for manifest updates" >&2
+  exit 1
+fi
+
+if ! grep -F 'gh pr edit "${pr_number}"' "${workflow}" >/dev/null; then
+  echo "system release workflow must update an existing manifest pull request" >&2
+  exit 1
+fi
+
+if grep -F 'git push origin "HEAD:${GITHUB_REF_NAME}"' "${workflow}" >/dev/null; then
+  echo "system release workflow must not push manifest commits directly to the protected main branch" >&2
   exit 1
 fi
 

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -148,6 +148,16 @@ if ! grep -F 'gh pr edit "${pr_number}"' "${workflow}" >/dev/null; then
   exit 1
 fi
 
+if ! grep -F 'pulls?state=open&head=${GITHUB_REPOSITORY_OWNER}:${manifest_branch}' "${workflow}" >/dev/null; then
+  echo "system release workflow must look up manifest pull requests by exact head owner and branch" >&2
+  exit 1
+fi
+
+if grep -F 'gh pr list' "${workflow}" >/dev/null; then
+  echo "system release workflow must not look up manifest pull requests by ambiguous branch name only" >&2
+  exit 1
+fi
+
 if grep -F 'git push origin "HEAD:${GITHUB_REF_NAME}"' "${workflow}" >/dev/null; then
   echo "system release workflow must not push manifest commits directly to the protected main branch" >&2
   exit 1


### PR DESCRIPTION
## Summary
- stop the system release workflow from pushing manifest commits directly to protected `main`
- push generated manifest commits to a dedicated branch and open or update a manifest PR instead
- seed `assets/system-release.json` from the already published `v3.3.12` release

## Validation
- `bash scripts/test-system-release-workflow.sh`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `bash scripts/test-system-release-package.sh`
- `git diff --check`
- parsed `.github/workflows/system-release.yml` with Ruby YAML