### PR TITLE
[codex] limit editor content width

### DIFF
--- a/index_editor.html
+++ b/index_editor.html
@@ -23,7 +23,8 @@
       --composer-inline-duration-in: 480ms;
       --composer-inline-duration-out: 380ms;
       --editor-toolbar-offset: 0px;
-      --editor-page-max-width: 100vw;
+      --editor-content-frame-max-width: 1280px;
+      --editor-page-max-width: calc(var(--editor-rail-width, 340px) + 6px + var(--editor-content-frame-max-width));
       --editor-edge-offset: 0px;
       --editor-rail-width: 340px;
       --back-to-top-size: 2.5rem;
@@ -120,6 +121,15 @@
       position:relative;
       scrollbar-gutter:stable;
     }
+    .editor-content-frame {
+      width: min(var(--editor-content-frame-max-width, 1280px), 100%);
+      min-width: 0;
+      min-height: 100%;
+      margin-inline: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
     .editor-mobile-rail-toggle {
       display:none;
       align-items:center;
@@ -142,7 +152,7 @@
     .editor-mobile-rail-scrim {
       display:none;
     }
-    .editor-content-pane > .editor-layout {
+    .editor-content-frame > .editor-layout {
       min-height:100%;
     }
     .site-footer,
@@ -1699,7 +1709,8 @@
       </aside>
       <div class="editor-rail-resizer" id="editorRailResizer" role="separator" aria-orientation="vertical" aria-label="Resize file tree" tabindex="0"></div>
       <main class="editor-content-pane" id="editorContentPane">
-        <button type="button" class="editor-mobile-rail-toggle" id="editorMobileRailToggle" aria-controls="editorRail" aria-expanded="false" data-i18n="editor.tree.aria">Content files</button>
+        <div class="editor-content-frame">
+          <button type="button" class="editor-mobile-rail-toggle" id="editorMobileRailToggle" aria-controls="editorRail" aria-expanded="false" data-i18n="editor.tree.aria">Content files</button>
 
     <!-- Editor Mode -->
     <div class="editor-layout" id="mode-editor">
@@ -1821,7 +1832,7 @@
           <p data-i18n="editor.empty.body">Select a Markdown file from the tree to start editing.</p>
         </div>
       </div>
-    </div>
+        </div>
       </main>
 
       <div class="editor-modal-layer" id="editorModalLayer" hidden aria-hidden="true">

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -55,8 +55,8 @@ assert.doesNotMatch(
 
 assert.match(
   editorSource,
-  /class="editor-app-shell" id="editorAppShell"[\s\S]*class="editor-rail editor-file-tree-pane" id="editorRail"[\s\S]*id="editorFileTree" role="tree"[\s\S]*class="editor-content-pane" id="editorContentPane"/,
-  'editor should render a fixed two-pane app shell with a left rail and right content pane'
+  /class="editor-app-shell" id="editorAppShell"[\s\S]*class="editor-rail editor-file-tree-pane" id="editorRail"[\s\S]*id="editorFileTree" role="tree"[\s\S]*class="editor-content-pane" id="editorContentPane"[\s\S]*class="editor-content-frame"[\s\S]*class="editor-mobile-rail-toggle"[\s\S]*class="editor-layout" id="mode-editor"/,
+  'editor should render a fixed two-pane app shell with a left rail and a width-limited right content frame'
 );
 
 assert.doesNotMatch(
@@ -1399,6 +1399,12 @@ assert.match(
   editorSource,
   /\.editor-mobile-rail-toggle \{[\s\S]*display:none;[\s\S]*@media \(max-width: 820px\) \{[\s\S]*\.editor-mobile-rail-toggle \{\s*display:inline-flex;/,
   'mobile layout should expose a file tree drawer toggle only on small screens'
+);
+
+assert.match(
+  editorSource,
+  /--editor-content-frame-max-width: 1280px;[\s\S]*--editor-page-max-width: calc\(var\(--editor-rail-width, 340px\) \+ 6px \+ var\(--editor-content-frame-max-width\)\);/,
+  'editor page width should be derived from the rail width plus the shared content frame width'
 );
 
 assert.match(


### PR DESCRIPTION
## What
- Add a shared `editor-content-frame` around the right-side editor area so content no longer stretches full width on large screens.
- Tie the page width variable used by the back-to-top button to the rail width plus the shared content frame width.
- Update the editor identity-grid regression test to cover the new wrapper and width variable.

## Why
- The right-side editor area was too wide on ultrawide and full-screen layouts.
- The change applies to every view rendered inside `main#editorContentPane`, not just Site Settings.

## Validation
- `node scripts/test-composer-identity-grid.js`
- `git diff --check`