### PR TITLE
[codex] tighten article version paths in editor

### DIFF
--- a/assets/i18n/chs.js
+++ b/assets/i18n/chs.js
@@ -665,6 +665,16 @@ const translations = {
           errorInvalid: '键名只能包含英文字母、数字、下划线或连字符。',
           errorDuplicate: '该键名已存在，请使用其他键名。'
         },
+        versionPrompt: {
+          label: '版本',
+          confirm: '添加版本',
+          placeholder: 'v2.0.0',
+          message: ({ key, lang }) => `请输入 ${key} / ${lang} 的版本号：`,
+          hint: '请使用以 v 开头的版本号，例如 v2.0.0。',
+          errorEmpty: '版本号不能为空。',
+          errorInvalid: '版本号必须以 v 开头，例如 v2.0.0。',
+          errorDuplicate: ({ version }) => `${version} 已存在。`
+        },
         discardConfirm: {
           messageReload: ({ label }) => `丢弃 ${label} 的本地更改并重新加载远程文件？此操作无法撤销。`,
           messageSimple: ({ label }) => `丢弃 ${label} 的本地更改？此操作无法撤销。`,

--- a/assets/i18n/cht-hk.js
+++ b/assets/i18n/cht-hk.js
@@ -1,4 +1,4 @@
-import chtTwTranslations from './cht-tw.js?v=20260430sync';
+import chtTwTranslations from './cht-tw.js?v=20260501versions';
 
 export const languageMeta = { label: '繁體中文（香港）' };
 

--- a/assets/i18n/cht-tw.js
+++ b/assets/i18n/cht-tw.js
@@ -665,6 +665,16 @@ const translations = {
           errorInvalid: '鍵名只能包含英文字母、數字、下劃線或連字元。',
           errorDuplicate: '該鍵名已存在，請使用其他鍵名。'
         },
+        versionPrompt: {
+          label: '版本',
+          confirm: '新增版本',
+          placeholder: 'v2.0.0',
+          message: ({ key, lang }) => `請輸入 ${key} / ${lang} 的版本號：`,
+          hint: '請使用以 v 開頭的版本號，例如 v2.0.0。',
+          errorEmpty: '版本號不能為空。',
+          errorInvalid: '版本號必須以 v 開頭，例如 v2.0.0。',
+          errorDuplicate: ({ version }) => `${version} 已存在。`
+        },
         discardConfirm: {
           messageReload: ({ label }) => `丟棄 ${label} 的本地更改並重新載入遠端檔案？此操作無法撤銷。`,
           messageSimple: ({ label }) => `丟棄 ${label} 的本地更改？此操作無法撤銷。`,

--- a/assets/i18n/en.js
+++ b/assets/i18n/en.js
@@ -664,6 +664,16 @@ const translations = {
           errorInvalid: 'Key must contain only English letters, numbers, underscores, or hyphens.',
           errorDuplicate: 'That key already exists. Choose a different key.'
         },
+        versionPrompt: {
+          label: 'version',
+          confirm: 'Add version',
+          placeholder: 'v2.0.0',
+          message: ({ key, lang }) => `Enter a version for ${key} / ${lang}:`,
+          hint: 'Use a v-prefixed version like v2.0.0.',
+          errorEmpty: 'Version cannot be empty.',
+          errorInvalid: 'Version must start with v, for example v2.0.0.',
+          errorDuplicate: ({ version }) => `${version} already exists.`
+        },
         discardConfirm: {
           messageReload: ({ label }) => `Discard local changes for ${label} and reload the remote file? This action cannot be undone.`,
           messageSimple: ({ label }) => `Discard local changes for ${label}? This action cannot be undone.`,

--- a/assets/i18n/ja.js
+++ b/assets/i18n/ja.js
@@ -665,6 +665,16 @@ const translations = {
           errorInvalid: 'キーには英数字、アンダースコア、ハイフンのみ使用できます。',
           errorDuplicate: 'そのキーは既に存在します。別のキーを選んでください。'
         },
+        versionPrompt: {
+          label: 'バージョン',
+          confirm: 'バージョンを追加',
+          placeholder: 'v2.0.0',
+          message: ({ key, lang }) => `${key} / ${lang} のバージョンを入力してください：`,
+          hint: 'v2.0.0 のように v で始まる形式を使用してください。',
+          errorEmpty: 'バージョンは必須です。',
+          errorInvalid: 'バージョンは v で始めてください。例: v2.0.0。',
+          errorDuplicate: ({ version }) => `${version} は既に存在します。`
+        },
         discardConfirm: {
           messageReload: ({ label }) => `${label} のローカル変更を破棄してリモートファイルを再読み込みしますか？この操作は取り消せません。`,
           messageSimple: ({ label }) => `${label} のローカル変更を破棄しますか？この操作は取り消せません。`,

--- a/assets/i18n/languages.json
+++ b/assets/i18n/languages.json
@@ -1,7 +1,7 @@
 [
-  { "value": "en", "label": "English", "module": "./en.js?v=20260430sync" },
-  { "value": "chs", "label": "简体中文", "module": "./chs.js?v=20260430sync" },
-  { "value": "cht-tw", "label": "正體中文（台灣）", "module": "./cht-tw.js?v=20260430sync" },
-  { "value": "cht-hk", "label": "繁體中文（香港）", "module": "./cht-hk.js?v=20260430sync" },
-  { "value": "ja", "label": "日本語", "module": "./ja.js?v=20260430sync" }
+  { "value": "en", "label": "English", "module": "./en.js?v=20260501versions" },
+  { "value": "chs", "label": "简体中文", "module": "./chs.js?v=20260501versions" },
+  { "value": "cht-tw", "label": "正體中文（台灣）", "module": "./cht-tw.js?v=20260501versions" },
+  { "value": "cht-hk", "label": "繁體中文（香港）", "module": "./cht-hk.js?v=20260501versions" },
+  { "value": "ja", "label": "日本語", "module": "./ja.js?v=20260501versions" }
 ]

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -8,7 +8,7 @@ import {
   resolveSiteRepoConfig,
   parseYAML
 } from './yaml.js';
-import { t, getAvailableLangs, getLanguageLabel } from './i18n.js?v=20260430sync';
+import { t, getAvailableLangs, getLanguageLabel } from './i18n.js?v=20260501versions';
 import { generateSitemapData, resolveSiteBaseUrl } from './seo.js';
 import { initSystemUpdates, getSystemUpdateSummaryEntries, getSystemUpdateCommitFiles, clearSystemUpdateState } from './system-updates.js';
 import { buildEditorContentTree, findEditorContentTreeNode, flattenEditorContentTree } from './editor-content-tree.js';
@@ -7306,13 +7306,19 @@ function showComposerAddEntryPrompt(anchor, options) {
     ? String(options.placeholder)
     : t('editor.composer.addEntryPrompt.placeholder');
   const existingKeys = options && options.existingKeys ? new Set(options.existingKeys) : new Set();
+  const hintText = options && Object.prototype.hasOwnProperty.call(options, 'hint')
+    ? String(options.hint || '')
+    : t('editor.composer.addEntryPrompt.hint');
+  const customValidator = options && typeof options.validate === 'function'
+    ? options.validate
+    : null;
 
   label.textContent = options && options.message
     ? String(options.message)
     : t('editor.composer.addEntryPrompt.message', { label: typeLabel });
   cancelBtn.textContent = cancelLabel;
   confirmBtn.textContent = confirmLabel;
-  hint.textContent = t('editor.composer.addEntryPrompt.hint');
+  hint.textContent = hintText;
   input.value = options && options.initialValue ? String(options.initialValue).trim() : '';
   input.placeholder = placeholder;
   input.setAttribute('aria-invalid', 'false');
@@ -7347,9 +7353,36 @@ function showComposerAddEntryPrompt(anchor, options) {
     }
   };
 
-  const validateKey = () => {
+  const validateValue = () => {
     const raw = input.value || '';
     const value = raw.trim();
+    if (customValidator) {
+      const result = customValidator(value);
+      if (result && typeof result === 'object') {
+        if (result.ok === false) {
+          setError(result.error || t('editor.composer.addEntryPrompt.errorInvalid'));
+          try { input.focus({ preventScroll: true }); input.select(); } catch (_) {}
+          return null;
+        }
+        const nextValue = Object.prototype.hasOwnProperty.call(result, 'value')
+          ? String(result.value || '').trim()
+          : value;
+        setError('');
+        return nextValue;
+      }
+      if (typeof result === 'string' && result) {
+        setError(result);
+        try { input.focus({ preventScroll: true }); input.select(); } catch (_) {}
+        return null;
+      }
+      if (result === false) {
+        setError(t('editor.composer.addEntryPrompt.errorInvalid'));
+        try { input.focus({ preventScroll: true }); input.select(); } catch (_) {}
+        return null;
+      }
+      setError('');
+      return value;
+    }
     if (!value) {
       setError(t('editor.composer.addEntryPrompt.errorEmpty'));
       try { input.focus({ preventScroll: true }); input.select(); } catch (_) {}
@@ -7428,7 +7461,7 @@ function showComposerAddEntryPrompt(anchor, options) {
 
   const onConfirm = (event) => {
     if (event && typeof event.preventDefault === 'function') event.preventDefault();
-    const value = validateKey();
+    const value = validateValue();
     if (value == null) return;
     finish(true, value);
   };
@@ -7437,7 +7470,7 @@ function showComposerAddEntryPrompt(anchor, options) {
     if (!event) return;
     if (event.key === 'Enter') {
       event.preventDefault();
-      const value = validateKey();
+      const value = validateValue();
       if (value == null) return;
       finish(true, value);
     }
@@ -10939,31 +10972,20 @@ function removeEditorLanguage(source, key, lang) {
   refreshEditorContentTree();
 }
 
-function suggestNextVersionPath(key, lang) {
-  const entry = getIndexEntry(key);
-  const arr = Array.isArray(entry[lang]) ? entry[lang] : [];
-  const fallback = buildDefaultLanguagePathFromEntry('index', key, lang, entry);
-  const base = arr[arr.length - 1] || fallback;
-  const nextVersion = `v${arr.length + 1}.0.0`;
-  if (/(^|\/)v\d+(?:\.\d+)*(?=\/|$)/i.test(base)) {
-    return String(base).replace(/(^|\/)v\d+(?:\.\d+)*(?=\/|$)/i, `$1${nextVersion}`);
-  }
-  const normalized = normalizeRelPath(base || fallback);
-  const idx = normalized.lastIndexOf('/');
-  if (idx < 0) return `post/${key}/${nextVersion}/${basenameFromPath(normalized) || `main_${lang}.md`}`;
-  return `${normalized.slice(0, idx)}/${nextVersion}/${normalized.slice(idx + 1)}`;
-}
-
-function addEditorVersion(key, lang) {
+function addEditorVersion(key, lang, anchor = null) {
   const entry = getIndexEntry(key);
   const arr = Array.isArray(entry[lang]) ? entry[lang] : (entry[lang] ? [entry[lang]] : []);
-  arr.push(suggestNextVersionPath(key, lang));
-  entry[lang] = arr;
-  notifyComposerChange('index');
-  expandedEditorTreeNodeIds.add(`index:${key}`);
-  expandedEditorTreeNodeIds.add(`index:${key}:${lang}`);
-  activeEditorTreeNodeId = `index:${key}:${lang}`;
-  refreshEditorContentTree();
+  return promptArticleVersionValue(key, lang, entry, anchor).then((version) => {
+    if (!version) return false;
+    arr.push(buildArticleVersionPath(key, lang, version, entry));
+    entry[lang] = arr;
+    notifyComposerChange('index');
+    expandedEditorTreeNodeIds.add(`index:${key}`);
+    expandedEditorTreeNodeIds.add(`index:${key}:${lang}`);
+    activeEditorTreeNodeId = `index:${key}:${lang}`;
+    refreshEditorContentTree();
+    return true;
+  });
 }
 
 function removeEditorVersion(key, lang, index) {
@@ -11259,7 +11281,7 @@ function renderEditorLanguagePanel(node, refs) {
   refs.title.textContent = `${node.key} / ${displayLangName(node.lang)}`;
   refs.meta.textContent = treeText('languageMeta', `${arr.length} versions`, { count: arr.length });
   const add = makeStructureButton(treeText('addVersion', 'Add version'));
-  add.addEventListener('click', () => addEditorVersion(node.key, node.lang));
+  add.addEventListener('click', () => { void addEditorVersion(node.key, node.lang, add); });
   const removeLang = makeStructureButton(treeText('removeLanguage', 'Remove language'));
   removeLang.addEventListener('click', () => removeEditorLanguage('index', node.key, node.lang));
   refs.actions.appendChild(add);
@@ -11275,17 +11297,7 @@ function renderEditorLanguagePanel(node, refs) {
     const label = document.createElement('span');
     label.className = 'editor-structure-item-title';
     label.textContent = extractVersionFromPath(path) || `${treeText('version', 'Version')} ${index + 1}`;
-    const input = document.createElement('input');
-    input.value = path || '';
-    input.setAttribute('aria-label', treeText('location', 'Location'));
-    input.addEventListener('change', () => {
-      arr[index] = normalizeRelPath(input.value);
-      entry[node.lang] = arr.slice();
-      notifyComposerChange('index');
-      refreshEditorContentTree();
-    });
     main.appendChild(label);
-    main.appendChild(input);
     const controls = document.createElement('div');
     controls.className = 'editor-structure-item-actions';
     const open = makeStructureButton(treeText('open', 'Open'));
@@ -11365,7 +11377,6 @@ function buildIndexUI(root, state) {
       const langs = sortLangKeys(entry);
       const addVersionLabel = tComposerLang('addVersion');
       const removeLangLabel = tComposerLang('removeLanguage');
-      const pathPlaceholder = tComposerLang('placeholders.indexPath');
       const editLabel = tComposerLang('actions.edit');
       const openLabel = tComposerLang('actions.open');
       const moveUpLabel = tComposerLang('actions.moveUp');
@@ -11455,7 +11466,7 @@ function buildIndexUI(root, state) {
             else delete row.dataset.mdPath;
             row.innerHTML = `
               <span class="ci-draft-indicator" aria-hidden="true" hidden></span>
-              <input class="ci-path" type="text" placeholder="${escapeHtml(pathPlaceholder)}" value="${escapeHtml(p || '')}" />
+              <span class="ci-ver-label">${escapeHtml(extractVersionFromPath(p) || `${treeText('version', 'Version')} ${i + 1}`)}</span>
               <span class="ci-ver-actions">
                 <button type="button" class="btn-secondary ci-edit" title="${escapeHtml(openLabel)}">${escapeHtml(editLabel)}</button>
                 <button type="button" class="btn-secondary ci-up" title="${escapeHtml(moveUpLabel)}" aria-label="${escapeHtml(moveUpLabel)}"><span aria-hidden="true">↑</span></button>
@@ -11469,20 +11480,6 @@ function buildIndexUI(root, state) {
             if (i === 0) up.setAttribute('disabled', ''); else up.removeAttribute('disabled');
             if (i === arr.length - 1) down.setAttribute('disabled', ''); else down.removeAttribute('disabled');
             updateComposerMarkdownDraftIndicators({ element: row, path: normalizedPath });
-
-            $('.ci-path', row).addEventListener('input', (e) => {
-              const prevPath = row.dataset.mdPath || '';
-              arr[i] = e.target.value;
-              entry[lang] = arr.slice();
-              row.dataset.value = arr[i] || '';
-              const nextPath = normalizeRelPath(arr[i]);
-              if (nextPath) row.dataset.mdPath = nextPath;
-              else delete row.dataset.mdPath;
-              updateComposerMarkdownDraftIndicators({ element: row });
-              if (prevPath && prevPath !== nextPath) updateComposerMarkdownDraftIndicators({ path: prevPath });
-              if (nextPath) updateComposerMarkdownDraftIndicators({ path: nextPath });
-              markDirty();
-            });
             $('.ci-edit', row).addEventListener('click', () => {
               const rel = normalizeRelPath(arr[i]);
               if (!rel) {
@@ -11523,9 +11520,11 @@ function buildIndexUI(root, state) {
           updateComposerMarkdownDraftContainerState(verList.closest('.ci-item'));
         };
         renderVers();
-        $('.ci-lang-addver', block).addEventListener('click', () => {
+        $('.ci-lang-addver', block).addEventListener('click', async (event) => {
+          const version = await promptArticleVersionValue(key, lang, entry, event.currentTarget);
+          if (!version) return;
           const prev = snapRects();
-          arr.push('');
+          arr.push(buildArticleVersionPath(key, lang, version, entry));
           verIds.push(Math.random().toString(36).slice(2));
           entry[lang] = arr.slice();
           renderVers(prev);
@@ -11893,12 +11892,28 @@ function buildDefaultEntryPath(kind, key, lang) {
   const fallbackLang = String(lang || '').trim() || getDefaultComposerLanguage() || 'en';
   const normalizedLang = fallbackLang.toLowerCase();
   const filename = normalizedLang ? `main_${normalizedLang}.md` : 'main.md';
-  const folder = safeKey ? `${baseFolder}/${safeKey}` : baseFolder;
+  const folder = normalizedKind === 'tabs'
+    ? (safeKey ? `${baseFolder}/${safeKey}` : baseFolder)
+    : (safeKey ? `${baseFolder}/${safeKey}/v1.0.0` : `${baseFolder}/v1.0.0`);
   return `${folder}/${filename}`;
 }
 
 function normalizeComposerLangCode(lang) {
   return String(lang || '').trim().toLowerCase();
+}
+
+function normalizeComposerVersionTag(version) {
+  const raw = String(version || '').trim();
+  if (!raw) return '';
+  return `v${raw.replace(/^v/i, '')}`;
+}
+
+function isComposerVersionTag(version) {
+  return /^v\d+(?:\.\d+)*$/i.test(String(version || '').trim());
+}
+
+function isComposerVersionSegment(segment) {
+  return /^v\d+(?:\.\d+)*$/i.test(String(segment || '').trim());
 }
 
 function stripComposerLangSuffix(name, codes) {
@@ -11969,8 +11984,67 @@ function buildDefaultLanguagePathFromEntry(kind, key, lang, entry) {
   namePart = stripComposerLangSuffix(namePart, codesToStrip);
 
   const finalName = normalizedLang ? `${namePart}_${normalizedLang}` : namePart;
-  segments.push(`${finalName}${extPart}`);
+  filename = `${finalName}${extPart}`;
+  if (normalizedKind === 'index') {
+    const versionIndex = segments.findIndex(isComposerVersionSegment);
+    if (versionIndex >= 0) segments[versionIndex] = 'v1.0.0';
+    else segments.push('v1.0.0');
+  }
+  segments.push(filename);
   return segments.join('/');
+}
+
+function buildArticleVersionPath(key, lang, version, entry) {
+  const normalizedVersion = normalizeComposerVersionTag(version);
+  const normalizedLang = normalizeComposerLangCode(lang);
+  const sourceEntry = entry && typeof entry === 'object' ? entry : getIndexEntry(key);
+  const current = Array.isArray(sourceEntry[lang]) ? sourceEntry[lang] : (sourceEntry[lang] ? [sourceEntry[lang]] : []);
+  const reference = current[current.length - 1] || buildDefaultLanguagePathFromEntry('index', key, normalizedLang, sourceEntry);
+  const fallback = buildDefaultEntryPath('index', key, normalizedLang).replace('/v1.0.0/', `/${normalizedVersion}/`);
+  const normalizedPath = normalizeRelPath(reference || fallback);
+  if (!normalizedPath) return fallback;
+  const segments = normalizedPath.split('/');
+  let filename = segments.pop() || '';
+  if (!filename) filename = normalizedLang ? `main_${normalizedLang}.md` : 'main.md';
+  const versionIndex = segments.findIndex(isComposerVersionSegment);
+  if (versionIndex >= 0) segments[versionIndex] = normalizedVersion;
+  else segments.push(normalizedVersion);
+  segments.push(filename);
+  return segments.join('/');
+}
+
+function collectComposerArticleVersions(paths) {
+  const versions = new Set();
+  const arr = Array.isArray(paths) ? paths : [];
+  arr.forEach((path) => {
+    const explicitVersion = normalizeComposerVersionTag(extractVersionFromPath(path));
+    if (explicitVersion) versions.add(explicitVersion.toLowerCase());
+    else if (normalizeRelPath(path)) versions.add('v1.0.0');
+  });
+  return versions;
+}
+
+async function promptArticleVersionValue(key, lang, entry, anchor) {
+  const arr = Array.isArray(entry && entry[lang]) ? entry[lang] : [];
+  const existingVersions = collectComposerArticleVersions(arr);
+  const langLabel = displayLangName(lang);
+  const result = await showComposerAddEntryPrompt(anchor, {
+    typeLabel: t('editor.composer.versionPrompt.label'),
+    confirmLabel: t('editor.composer.versionPrompt.confirm'),
+    placeholder: t('editor.composer.versionPrompt.placeholder'),
+    message: t('editor.composer.versionPrompt.message', { key, lang: langLabel }),
+    hint: t('editor.composer.versionPrompt.hint'),
+    validate: (value) => {
+      if (!value) return { ok: false, error: t('editor.composer.versionPrompt.errorEmpty') };
+      if (!isComposerVersionTag(value)) return { ok: false, error: t('editor.composer.versionPrompt.errorInvalid') };
+      const normalizedVersion = normalizeComposerVersionTag(value);
+      if (existingVersions.has(normalizedVersion.toLowerCase())) {
+        return { ok: false, error: t('editor.composer.versionPrompt.errorDuplicate', { version: normalizedVersion }) };
+      }
+      return { ok: true, value: normalizedVersion };
+    }
+  });
+  return result && result.confirmed ? String(result.value || '').trim() : '';
 }
 
 async function promptComposerEntryKey(kind, anchor) {
@@ -12031,7 +12105,7 @@ function focusComposerEntry(kind, key) {
   if (expandBtn) expandBtn.setAttribute('aria-expanded', 'true');
   row.classList.add('is-open');
 
-  const preferredFocus = row.querySelector(normalized === 'tabs' ? '.ct-title, .ct-loc' : '.ci-path');
+  const preferredFocus = row.querySelector(normalized === 'tabs' ? '.ct-title, .ct-loc' : '.ci-lang-addver, .ci-edit');
   const fallbackFocus = row.querySelector('input, textarea, button');
   const target = preferredFocus || fallbackFocus;
   if (target && typeof target.focus === 'function') {
@@ -15221,8 +15295,8 @@ function rebuildSiteUI() {
     .ct-field{white-space:normal;}
     .ct-lang-actions{justify-content:flex-start;}
   }
-  .ci-ver-item{display:flex;align-items:center;gap:.4rem;margin:.3rem 0}
-  .ci-ver-item input.ci-path{flex:1 1 auto;min-width:0;height:2rem;border:1px solid var(--border);border-radius:6px;background:var(--card);color:var(--text);padding:.25rem .4rem;transition:border-color .18s ease, background-color .18s ease}
+  .ci-ver-item{display:flex;align-items:center;gap:.55rem;margin:.3rem 0;padding:.4rem .5rem;border:1px solid color-mix(in srgb,var(--border) 88%, transparent);border-radius:8px;background:color-mix(in srgb,var(--text) 2%, transparent)}
+  .ci-ver-label{flex:1 1 auto;min-width:0;font-weight:600;color:var(--text)}
   .ci-ver-actions button:disabled{opacity:.5;cursor:not-allowed}
   /* Add Language row: compact button, keep menu aligned to trigger width */
   .ci-add-lang,.ct-add-lang,.cs-add-lang{display:inline-flex;align-items:center;gap:.5rem;margin-top:.5rem;position:relative;flex:0 0 auto}
@@ -15269,9 +15343,9 @@ function rebuildSiteUI() {
   .ci-lang[data-diff="added"]{border-color:color-mix(in srgb,#16a34a 55%, var(--border));background:color-mix(in srgb,#16a34a 10%, var(--card));}
   .ci-lang[data-diff="removed"]{border-color:color-mix(in srgb,#dc2626 55%, var(--border));background:color-mix(in srgb,#dc2626 8%, var(--card));opacity:.9;}
   .ci-lang[data-diff="modified"]{border-color:color-mix(in srgb,#f59e0b 45%, var(--border));}
-  .ci-ver-item[data-diff="added"] input{border-color:color-mix(in srgb,#16a34a 60%, var(--border));background:color-mix(in srgb,#16a34a 8%, transparent);}
-  .ci-ver-item[data-diff="changed"] input{border-color:color-mix(in srgb,#f59e0b 60%, var(--border));background:color-mix(in srgb,#f59e0b 6%, transparent);}
-  .ci-ver-item[data-diff="moved"] input{border-color:color-mix(in srgb,#2563eb 55%, var(--border));border-style:dashed;}
+  .ci-ver-item[data-diff="added"]{border-color:color-mix(in srgb,#16a34a 60%, var(--border));background:color-mix(in srgb,#16a34a 8%, transparent);}
+  .ci-ver-item[data-diff="changed"]{border-color:color-mix(in srgb,#f59e0b 60%, var(--border));background:color-mix(in srgb,#f59e0b 6%, transparent);}
+  .ci-ver-item[data-diff="moved"]{border-color:color-mix(in srgb,#2563eb 55%, var(--border));border-style:dashed;}
   .ci-ver-removed{margin-top:.2rem;font-size:.78rem;color:#b91c1c;}
   .ct-item.is-dirty{border-color:color-mix(in srgb,#2563eb 42%, var(--border));--ci-ring-shadow:0 0 0 2px color-mix(in srgb,#2563eb 16%, transparent);--ci-depth-shadow:0 10px 20px color-mix(in srgb,#2563eb 14%, transparent);}
   .ct-item[data-diff="added"]{border-color:color-mix(in srgb,#16a34a 55%, var(--border));}

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -10984,7 +10984,7 @@ function removeEditorLanguage(source, key, lang) {
 
 function addEditorVersion(key, lang, anchor = null) {
   const entry = getIndexEntry(key);
-  const arr = Array.isArray(entry[lang]) ? entry[lang] : (entry[lang] ? [entry[lang]] : []);
+  const arr = normalizeComposerVersionPaths(entry[lang]);
   return promptArticleVersionValue(key, lang, entry, anchor).then((version) => {
     if (!version) return false;
     arr.push(buildArticleVersionPath(key, lang, version, entry));
@@ -11918,6 +11918,12 @@ function normalizeComposerVersionTag(version) {
   return `v${raw.replace(/^v/i, '')}`;
 }
 
+function normalizeComposerVersionPaths(value) {
+  if (Array.isArray(value)) return value.filter(path => !!normalizeRelPath(path));
+  const normalized = normalizeRelPath(value);
+  return normalized ? [normalized] : [];
+}
+
 function isComposerVersionTag(version) {
   return /^v\d+(?:\.\d+)*$/i.test(String(version || '').trim());
 }
@@ -12008,7 +12014,7 @@ function buildArticleVersionPath(key, lang, version, entry) {
   const normalizedVersion = normalizeComposerVersionTag(version);
   const normalizedLang = normalizeComposerLangCode(lang);
   const sourceEntry = entry && typeof entry === 'object' ? entry : getIndexEntry(key);
-  const current = Array.isArray(sourceEntry[lang]) ? sourceEntry[lang] : (sourceEntry[lang] ? [sourceEntry[lang]] : []);
+  const current = normalizeComposerVersionPaths(sourceEntry[lang]);
   const reference = current[current.length - 1] || buildDefaultLanguagePathFromEntry('index', key, normalizedLang, sourceEntry);
   const fallback = buildDefaultEntryPath('index', key, normalizedLang).replace('/v1.0.0/', `/${normalizedVersion}/`);
   const normalizedPath = normalizeRelPath(reference || fallback);
@@ -12025,7 +12031,7 @@ function buildArticleVersionPath(key, lang, version, entry) {
 
 function collectComposerArticleVersions(paths) {
   const versions = new Set();
-  const arr = Array.isArray(paths) ? paths : [];
+  const arr = normalizeComposerVersionPaths(paths);
   arr.forEach((path) => {
     const explicitVersion = normalizeComposerVersionTag(extractVersionFromPath(path));
     if (explicitVersion) versions.add(explicitVersion.toLowerCase());
@@ -12035,7 +12041,7 @@ function collectComposerArticleVersions(paths) {
 }
 
 async function promptArticleVersionValue(key, lang, entry, anchor) {
-  const arr = Array.isArray(entry && entry[lang]) ? entry[lang] : [];
+  const arr = normalizeComposerVersionPaths(entry && entry[lang]);
   const existingVersions = collectComposerArticleVersions(arr);
   const langLabel = displayLangName(lang);
   const result = await showComposerAddEntryPrompt(anchor, {

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -7999,12 +7999,14 @@ function dirnameFromPath(relPath) {
   return norm.slice(0, idx);
 }
 
-function findTrailingVersionSegmentIndex(segments) {
+function findExplicitArticleVersionSegmentIndex(segments) {
   const parts = Array.isArray(segments) ? segments : [];
-  for (let i = parts.length - 1; i >= 0; i -= 1) {
-    if (isComposerVersionSegment(parts[i])) return i;
-  }
-  return -1;
+  if (parts.length < 3) return -1;
+  if (String(parts[0] || '').trim().toLowerCase() !== 'post') return -1;
+  const candidateIndex = parts.length - 1;
+  if (candidateIndex < 2) return -1;
+  if (!isComposerVersionSegment(parts[candidateIndex])) return -1;
+  return candidateIndex;
 }
 
 function extractVersionFromPath(relPath) {
@@ -8014,7 +8016,7 @@ function extractVersionFromPath(relPath) {
     const segments = normalized.split('/');
     if (segments.length <= 1) return '';
     segments.pop();
-    const versionIndex = findTrailingVersionSegmentIndex(segments);
+    const versionIndex = findExplicitArticleVersionSegmentIndex(segments);
     return versionIndex >= 0 ? String(segments[versionIndex] || '') : '';
   } catch (_) {
     return '';
@@ -12002,7 +12004,7 @@ function buildDefaultLanguagePathFromEntry(kind, key, lang, entry) {
   const finalName = normalizedLang ? `${namePart}_${normalizedLang}` : namePart;
   filename = `${finalName}${extPart}`;
   if (normalizedKind === 'index') {
-    const versionIndex = findTrailingVersionSegmentIndex(segments);
+    const versionIndex = findExplicitArticleVersionSegmentIndex(segments);
     if (versionIndex >= 0) segments[versionIndex] = 'v1.0.0';
     else segments.push('v1.0.0');
   }
@@ -12022,7 +12024,7 @@ function buildArticleVersionPath(key, lang, version, entry) {
   const segments = normalizedPath.split('/');
   let filename = segments.pop() || '';
   if (!filename) filename = normalizedLang ? `main_${normalizedLang}.md` : 'main.md';
-  const versionIndex = findTrailingVersionSegmentIndex(segments);
+  const versionIndex = findExplicitArticleVersionSegmentIndex(segments);
   if (versionIndex >= 0) segments[versionIndex] = normalizedVersion;
   else segments.push(normalizedVersion);
   segments.push(filename);

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -7999,13 +7999,23 @@ function dirnameFromPath(relPath) {
   return norm.slice(0, idx);
 }
 
+function findTrailingVersionSegmentIndex(segments) {
+  const parts = Array.isArray(segments) ? segments : [];
+  for (let i = parts.length - 1; i >= 0; i -= 1) {
+    if (isComposerVersionSegment(parts[i])) return i;
+  }
+  return -1;
+}
+
 function extractVersionFromPath(relPath) {
   try {
-    const match = String(relPath || '').match(/(?:^|\/)v\d+(?:\.\d+)*(?=\/|$)/i);
-    if (!match || !match[0]) return '';
-    const segment = match[0];
-    const slash = segment.lastIndexOf('/');
-    return slash >= 0 ? segment.slice(slash + 1) : segment;
+    const normalized = normalizeRelPath(relPath);
+    if (!normalized) return '';
+    const segments = normalized.split('/');
+    if (segments.length <= 1) return '';
+    segments.pop();
+    const versionIndex = findTrailingVersionSegmentIndex(segments);
+    return versionIndex >= 0 ? String(segments[versionIndex] || '') : '';
   } catch (_) {
     return '';
   }
@@ -11986,7 +11996,7 @@ function buildDefaultLanguagePathFromEntry(kind, key, lang, entry) {
   const finalName = normalizedLang ? `${namePart}_${normalizedLang}` : namePart;
   filename = `${finalName}${extPart}`;
   if (normalizedKind === 'index') {
-    const versionIndex = segments.findIndex(isComposerVersionSegment);
+    const versionIndex = findTrailingVersionSegmentIndex(segments);
     if (versionIndex >= 0) segments[versionIndex] = 'v1.0.0';
     else segments.push('v1.0.0');
   }
@@ -12006,7 +12016,7 @@ function buildArticleVersionPath(key, lang, version, entry) {
   const segments = normalizedPath.split('/');
   let filename = segments.pop() || '';
   if (!filename) filename = normalizedLang ? `main_${normalizedLang}.md` : 'main.md';
-  const versionIndex = segments.findIndex(isComposerVersionSegment);
+  const versionIndex = findTrailingVersionSegmentIndex(segments);
   if (versionIndex >= 0) segments[versionIndex] = normalizedVersion;
   else segments.push(normalizedVersion);
   segments.push(filename);

--- a/assets/js/editor-boot.js
+++ b/assets/js/editor-boot.js
@@ -1,5 +1,5 @@
 import './cache-control.js';
-import { initI18n, t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=20260430sync';
+import { initI18n, t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=20260501versions';
 
 function applyAttributeTranslation(el, target, value) {
   if (value == null) return;

--- a/assets/js/editor-content-tree.js
+++ b/assets/js/editor-content-tree.js
@@ -112,10 +112,21 @@ function filenameLabel(path, fallback) {
   return parts[parts.length - 1] || fallback;
 }
 
-function versionLabel(path, index) {
+function trailingVersionLabel(path) {
   const normalized = normalizeEditorTreePath(path);
-  const match = normalized.match(/(?:^|\/)(v\d+(?:\.\d+)*)(?=\/|$)/i);
-  if (match && match[1]) return match[1];
+  if (!normalized) return '';
+  const segments = normalized.split('/');
+  if (segments.length <= 1) return '';
+  segments.pop();
+  for (let i = segments.length - 1; i >= 0; i -= 1) {
+    if (/^v\d+(?:\.\d+)*$/i.test(String(segments[i] || '').trim())) return segments[i];
+  }
+  return '';
+}
+
+function versionLabel(path, index) {
+  const version = trailingVersionLabel(path);
+  if (version) return version;
   return `Version ${index + 1}`;
 }
 

--- a/assets/js/editor-content-tree.js
+++ b/assets/js/editor-content-tree.js
@@ -112,20 +112,22 @@ function filenameLabel(path, fallback) {
   return parts[parts.length - 1] || fallback;
 }
 
-function trailingVersionLabel(path) {
+function explicitArticleVersionLabel(path) {
   const normalized = normalizeEditorTreePath(path);
   if (!normalized) return '';
   const segments = normalized.split('/');
   if (segments.length <= 1) return '';
   segments.pop();
-  for (let i = segments.length - 1; i >= 0; i -= 1) {
-    if (/^v\d+(?:\.\d+)*$/i.test(String(segments[i] || '').trim())) return segments[i];
-  }
+  if (segments.length < 3) return '';
+  if (String(segments[0] || '').trim().toLowerCase() !== 'post') return '';
+  const candidate = String(segments[segments.length - 1] || '').trim();
+  if (!/^v\d+(?:\.\d+)*$/i.test(candidate)) return '';
+  return candidate;
   return '';
 }
 
 function versionLabel(path, index) {
-  const version = trailingVersionLabel(path);
+  const version = explicitArticleVersionLabel(path);
   if (version) return version;
   return `Version ${index + 1}`;
 }

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -17,7 +17,7 @@ import { applyLazyLoadingIn, hydratePostImages, hydratePostVideos } from './post
 import { hydrateInternalLinkCards } from './link-cards.js';
 import { applyLangHints } from './typography.js';
 import { fetchConfigWithYamlFallback, fetchMergedSiteConfig } from './yaml.js';
-import { t, withLangParam, loadContentJsonWithRaw, getCurrentLang, normalizeLangKey } from './i18n.js?v=20260430sync';
+import { t, withLangParam, loadContentJsonWithRaw, getCurrentLang, normalizeLangKey } from './i18n.js?v=20260501versions';
 
 const LS_WRAP_KEY = 'ns_editor_wrap_enabled';
 const FORCE_MARKDOWN_WRAP = true;

--- a/assets/js/errors.js
+++ b/assets/js/errors.js
@@ -1,5 +1,5 @@
 // errors.js — lightweight global error overlay and reporter
-import { t } from './i18n.js?v=20260430sync';
+import { t } from './i18n.js?v=20260501versions';
 
 let reporterConfig = {
   reportUrl: null,

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -12,7 +12,7 @@
 import { parseFrontMatter } from './content.js';
 import { getContentRoot } from './utils.js';
 import { fetchConfigWithYamlFallback } from './yaml.js';
-import enTranslations, { languageMeta as enLanguageMeta } from '../i18n/en.js?v=20260430sync';
+import enTranslations, { languageMeta as enLanguageMeta } from '../i18n/en.js?v=20260501versions';
 
 // Content fetch cache modes are normalized by cache-control.js.
 

--- a/assets/js/post-nav.js
+++ b/assets/js/post-nav.js
@@ -1,4 +1,4 @@
-import { withLangParam, t } from './i18n.js?v=20260430sync';
+import { withLangParam, t } from './i18n.js?v=20260501versions';
 import { escapeHtml } from './utils.js';
 
 export function renderPostNav(container, postsIndex, postname) {

--- a/assets/js/seo.js
+++ b/assets/js/seo.js
@@ -1,8 +1,8 @@
 // seo.js - Dynamic SEO meta tag management for client-side routing
 // This maintains SEO benefits while keeping the "no compilation needed" philosophy
 
-import { getCurrentLang, DEFAULT_LANG } from './i18n.js?v=20260430sync';
-import { getAvailableLangs } from './i18n.js?v=20260430sync';
+import { getCurrentLang, DEFAULT_LANG } from './i18n.js?v=20260501versions';
+import { getAvailableLangs } from './i18n.js?v=20260501versions';
 import { parseFrontMatter } from './content.js';
 
 function ensureTrailingSlash(value) {

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -1,6 +1,6 @@
 import { mdParse } from './markdown.js';
 import { setSafeHtml } from './utils.js';
-import { t } from './i18n.js?v=20260430sync';
+import { t } from './i18n.js?v=20260501versions';
 import { unzipSync, strFromU8 } from './vendor/fflate.browser.js';
 
 const TEXT_EXTENSIONS = new Set([

--- a/assets/js/tags.js
+++ b/assets/js/tags.js
@@ -1,5 +1,5 @@
 // Tag utilities: aggregation, rendering (collapsible), and tooltips for truncated tags
-import { t, withLangParam } from './i18n.js?v=20260430sync';
+import { t, withLangParam } from './i18n.js?v=20260501versions';
 import { getQueryVariable, escapeHtml } from './utils.js';
 
 // Build a sorted list of tags with counts from an index map

--- a/assets/js/templates.js
+++ b/assets/js/templates.js
@@ -1,5 +1,5 @@
 // Template renderers (pure functions returning HTML strings)
-import { t } from './i18n.js?v=20260430sync';
+import { t } from './i18n.js?v=20260501versions';
 import { computeReadTime } from './content.js';
 import { escapeHtml, renderTags, formatDisplayDate } from './utils.js';
 

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,4 +1,4 @@
-import { t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=20260430sync';
+import { t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=20260501versions';
 
 const PACK_LINK_ID = 'theme-pack';
 

--- a/assets/js/toc.js
+++ b/assets/js/toc.js
@@ -1,4 +1,4 @@
-import { t } from './i18n.js?v=20260430sync';
+import { t } from './i18n.js?v=20260501versions';
 
 // Anchors and Table of Contents enhancements
 export function setupAnchors() {

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -168,19 +168,19 @@ assert.match(
 
 assert.match(
   chtHkI18nSource,
-  /import chtTwTranslations from '\.\/cht-tw\.js\?v=20260430sync';/,
+  /import chtTwTranslations from '\.\/cht-tw\.js\?v=20260501versions';/,
   'Hong Kong Traditional Chinese should inherit the cache-busted Traditional Chinese article action'
 );
 
 assert.match(
   languagesManifestSource,
-  /"\.\/en\.js\?v=20260430sync"[\s\S]*"\.\/chs\.js\?v=20260430sync"[\s\S]*"\.\/cht-tw\.js\?v=20260430sync"[\s\S]*"\.\/cht-hk\.js\?v=20260430sync"[\s\S]*"\.\/ja\.js\?v=20260430sync"/,
+  /"\.\/en\.js\?v=20260501versions"[\s\S]*"\.\/chs\.js\?v=20260501versions"[\s\S]*"\.\/cht-tw\.js\?v=20260501versions"[\s\S]*"\.\/cht-hk\.js\?v=20260501versions"[\s\S]*"\.\/ja\.js\?v=20260501versions"/,
   'language manifest should cache-bust language bundles changed by editor action labels'
 );
 
 assert.match(
   i18nSource,
-  /from '\.\.\/i18n\/en\.js\?v=20260430sync'/,
+  /from '\.\.\/i18n\/en\.js\?v=20260501versions'/,
   'default English bundle import should be cache-busted when editor action labels change'
 );
 
@@ -1411,6 +1411,36 @@ assert.match(
   editorSource,
   /\.editor-content-pane \{[\s\S]*--editor-content-pane-padding:1rem;[\s\S]*padding:var\(--editor-content-pane-padding\);[\s\S]*\.toolbar \{[\s\S]*top:calc\(var\(--editor-content-pane-padding, 0px\) \* -1\);[\s\S]*background:var\(--card\);[\s\S]*\.editor-markdown-panel > \.toolbar \{[\s\S]*margin-top:calc\(var\(--editor-content-pane-padding, 1rem\) \* -1\);[\s\S]*\.editor-tools \{[\s\S]*top:calc\(var\(--editor-toolbar-offset, 0px\) - var\(--editor-content-pane-padding, 0px\)\);[\s\S]*background:var\(--card\);[\s\S]*@media \(max-width: 820px\) \{[\s\S]*\.editor-content-pane \{[\s\S]*--editor-content-pane-padding:\.75rem;/,
   'markdown file toolbar should stick flush to the editor content pane top while preserving pane padding'
+);
+
+assert.match(
+  source,
+  /function buildDefaultEntryPath\(kind, key, lang\) \{[\s\S]*const baseFolder = normalizedKind === 'tabs' \? 'tab' : 'post';[\s\S]*normalizedKind === 'tabs'[\s\S]*`\$\{baseFolder\}\/\$\{safeKey\}\/v1\.0\.0`[\s\S]*`\$\{baseFolder\}\/v1\.0\.0`[\s\S]*return `\$\{folder\}\/\$\{filename\}`;/,
+  'new article defaults should place the first markdown file inside a v1.0.0 directory'
+);
+
+assert.match(
+  source,
+  /async function promptArticleVersionValue\(key, lang, entry, anchor\) \{[\s\S]*showComposerAddEntryPrompt\(anchor, \{[\s\S]*editor\.composer\.versionPrompt\.placeholder[\s\S]*if \(!isComposerVersionTag\(value\)\)[\s\S]*normalizeComposerVersionTag\(value\)[\s\S]*editor\.composer\.versionPrompt\.errorDuplicate/,
+  'adding an article version should prompt for a v-prefixed version string before creating the new path'
+);
+
+assert.match(
+  source,
+  /function buildDefaultLanguagePathFromEntry\(kind, key, lang, entry\) \{[\s\S]*if \(normalizedKind === 'index'\) \{[\s\S]*const versionIndex = segments\.findIndex\(isComposerVersionSegment\);[\s\S]*segments\[versionIndex\] = 'v1\.0\.0'[\s\S]*else segments\.push\('v1\.0\.0'\);/,
+  'adding a new article language should normalize its first file into the v1.0.0 directory'
+);
+
+assert.doesNotMatch(
+  source,
+  /<input class="ci-path" type="text" placeholder="\$\{escapeHtml\(pathPlaceholder\)\}" value="\$\{escapeHtml\(p \|\| ''\)\}" \/>/,
+  'article version cards should not render an editable path input in the composer list'
+);
+
+assert.doesNotMatch(
+  source,
+  /const input = document\.createElement\('input'\);[\s\S]*input\.setAttribute\('aria-label', treeText\('location', 'Location'\)\);[\s\S]*main\.appendChild\(label\);[\s\S]*main\.appendChild\(input\);/,
+  'article language structure panel should not render an editable location input for version rows'
 );
 
 assert.doesNotMatch(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -1427,8 +1427,20 @@ assert.match(
 
 assert.match(
   source,
-  /function buildDefaultLanguagePathFromEntry\(kind, key, lang, entry\) \{[\s\S]*if \(normalizedKind === 'index'\) \{[\s\S]*const versionIndex = segments\.findIndex\(isComposerVersionSegment\);[\s\S]*segments\[versionIndex\] = 'v1\.0\.0'[\s\S]*else segments\.push\('v1\.0\.0'\);/,
-  'adding a new article language should normalize its first file into the v1.0.0 directory'
+  /function findTrailingVersionSegmentIndex\(segments\) \{[\s\S]*for \(let i = parts\.length - 1; i >= 0; i -= 1\) \{[\s\S]*if \(isComposerVersionSegment\(parts\[i\]\)\) return i;[\s\S]*function buildDefaultLanguagePathFromEntry\(kind, key, lang, entry\) \{[\s\S]*const versionIndex = findTrailingVersionSegmentIndex\(segments\);[\s\S]*segments\[versionIndex\] = 'v1\.0\.0'[\s\S]*else segments\.push\('v1\.0\.0'\);/,
+  'adding a new article language should rewrite only the trailing version folder nearest the filename'
+);
+
+assert.match(
+  source,
+  /function buildArticleVersionPath\(key, lang, version, entry\) \{[\s\S]*const versionIndex = findTrailingVersionSegmentIndex\(segments\);[\s\S]*segments\[versionIndex\] = normalizedVersion[\s\S]*else segments\.push\(normalizedVersion\);/,
+  'adding a version should replace only the trailing version folder nearest the filename'
+);
+
+assert.match(
+  source,
+  /function extractVersionFromPath\(relPath\) \{[\s\S]*const segments = normalized\.split\('\/'\);[\s\S]*segments\.pop\(\);[\s\S]*const versionIndex = findTrailingVersionSegmentIndex\(segments\);[\s\S]*return versionIndex >= 0 \? String\(segments\[versionIndex\] \|\| ''\) : '';/,
+  'article version extraction should read the version folder nearest the filename so version-like keys stay intact'
 );
 
 assert.doesNotMatch(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -1427,6 +1427,12 @@ assert.match(
 
 assert.match(
   source,
+  /function normalizeComposerVersionPaths\(value\) \{[\s\S]*Array\.isArray\(value\)[\s\S]*normalizeRelPath\(value\)[\s\S]*return normalized \? \[normalized\] : \[\];[\s\S]*function collectComposerArticleVersions\(paths\) \{[\s\S]*const arr = normalizeComposerVersionPaths\(paths\);[\s\S]*async function promptArticleVersionValue\(key, lang, entry, anchor\) \{[\s\S]*const arr = normalizeComposerVersionPaths\(entry && entry\[lang\]\);/,
+  'legacy scalar article language paths should be normalized before version dedupe runs'
+);
+
+assert.match(
+  source,
   /function findTrailingVersionSegmentIndex\(segments\) \{[\s\S]*for \(let i = parts\.length - 1; i >= 0; i -= 1\) \{[\s\S]*if \(isComposerVersionSegment\(parts\[i\]\)\) return i;[\s\S]*function buildDefaultLanguagePathFromEntry\(kind, key, lang, entry\) \{[\s\S]*const versionIndex = findTrailingVersionSegmentIndex\(segments\);[\s\S]*segments\[versionIndex\] = 'v1\.0\.0'[\s\S]*else segments\.push\('v1\.0\.0'\);/,
   'adding a new article language should rewrite only the trailing version folder nearest the filename'
 );

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -1433,20 +1433,20 @@ assert.match(
 
 assert.match(
   source,
-  /function findTrailingVersionSegmentIndex\(segments\) \{[\s\S]*for \(let i = parts\.length - 1; i >= 0; i -= 1\) \{[\s\S]*if \(isComposerVersionSegment\(parts\[i\]\)\) return i;[\s\S]*function buildDefaultLanguagePathFromEntry\(kind, key, lang, entry\) \{[\s\S]*const versionIndex = findTrailingVersionSegmentIndex\(segments\);[\s\S]*segments\[versionIndex\] = 'v1\.0\.0'[\s\S]*else segments\.push\('v1\.0\.0'\);/,
-  'adding a new article language should rewrite only the trailing version folder nearest the filename'
+  /function findExplicitArticleVersionSegmentIndex\(segments\) \{[\s\S]*if \(parts\.length < 3\) return -1;[\s\S]*parts\[0\][\s\S]*!== 'post'[\s\S]*const candidateIndex = parts\.length - 1;[\s\S]*if \(!isComposerVersionSegment\(parts\[candidateIndex\]\)\) return -1;[\s\S]*return candidateIndex;[\s\S]*function buildDefaultLanguagePathFromEntry\(kind, key, lang, entry\) \{[\s\S]*const versionIndex = findExplicitArticleVersionSegmentIndex\(segments\);[\s\S]*segments\[versionIndex\] = 'v1\.0\.0'[\s\S]*else segments\.push\('v1\.0\.0'\);/,
+  'adding a new article language should rewrite only an explicit post/<key>/<version>/<file> version folder'
 );
 
 assert.match(
   source,
-  /function buildArticleVersionPath\(key, lang, version, entry\) \{[\s\S]*const versionIndex = findTrailingVersionSegmentIndex\(segments\);[\s\S]*segments\[versionIndex\] = normalizedVersion[\s\S]*else segments\.push\(normalizedVersion\);/,
-  'adding a version should replace only the trailing version folder nearest the filename'
+  /function buildArticleVersionPath\(key, lang, version, entry\) \{[\s\S]*const versionIndex = findExplicitArticleVersionSegmentIndex\(segments\);[\s\S]*segments\[versionIndex\] = normalizedVersion[\s\S]*else segments\.push\(normalizedVersion\);/,
+  'adding a version should replace only an explicit post/<key>/<version>/<file> version folder'
 );
 
 assert.match(
   source,
-  /function extractVersionFromPath\(relPath\) \{[\s\S]*const segments = normalized\.split\('\/'\);[\s\S]*segments\.pop\(\);[\s\S]*const versionIndex = findTrailingVersionSegmentIndex\(segments\);[\s\S]*return versionIndex >= 0 \? String\(segments\[versionIndex\] \|\| ''\) : '';/,
-  'article version extraction should read the version folder nearest the filename so version-like keys stay intact'
+  /function extractVersionFromPath\(relPath\) \{[\s\S]*const segments = normalized\.split\('\/'\);[\s\S]*segments\.pop\(\);[\s\S]*const versionIndex = findExplicitArticleVersionSegmentIndex\(segments\);[\s\S]*return versionIndex >= 0 \? String\(segments\[versionIndex\] \|\| ''\) : '';/,
+  'article version extraction should ignore legacy root-style keys that only look like versions'
 );
 
 assert.doesNotMatch(

--- a/scripts/test-editor-content-tree.js
+++ b/scripts/test-editor-content-tree.js
@@ -9,7 +9,7 @@ import {
 
 const sample = {
   index: {
-    __order: ['nanoSite', 'guide'],
+    __order: ['nanoSite', 'guide', 'v2'],
     nanoSite: {
       en: [
         'post/main/main_en.md',
@@ -19,6 +19,12 @@ const sample = {
     },
     guide: {
       ja: ['post/guide/v1.0.0/guide_ja.md']
+    },
+    v2: {
+      en: [
+        'post/v2/v1.0.0/main_en.md',
+        'post/v2/v3.0.0/main_en.md'
+      ]
     }
   },
   tabs: {
@@ -71,7 +77,7 @@ assert.deepEqual(
 
 const articles = tree[1];
 assert.equal(articles.source, 'index');
-assert.deepEqual(articles.children.map(node => node.id), ['index:nanoSite', 'index:guide'], 'article entry order should follow __order');
+assert.deepEqual(articles.children.map(node => node.id), ['index:nanoSite', 'index:guide', 'index:v2'], 'article entry order should follow __order');
 
 const articleLangs = findEditorContentTreeNode(tree, 'index:nanoSite').children;
 assert.deepEqual(articleLangs.map(node => node.id), ['index:nanoSite:en', 'index:nanoSite:chs'], 'article languages should follow preferred language order');
@@ -90,6 +96,16 @@ assert.equal(findEditorContentTreeNode(tree, 'index:nanoSite:en:1').draftState, 
 assert.equal(findEditorContentTreeNode(tree, 'index:nanoSite:en:1').diffState, 'modified');
 assert.equal(findEditorContentTreeNode(tree, 'index:nanoSite:en:0').fileState, 'existing');
 assert.equal(findEditorContentTreeNode(tree, 'index:nanoSite:en').draftState, 'dirty', 'language nodes should aggregate child draft state');
+
+const versionKeyVersions = findEditorContentTreeNode(tree, 'index:v2:en').children;
+assert.deepEqual(
+  versionKeyVersions.map(node => [node.id, node.path, node.label]),
+  [
+    ['index:v2:en:0', 'post/v2/v1.0.0/main_en.md', 'v1.0.0'],
+    ['index:v2:en:1', 'post/v2/v3.0.0/main_en.md', 'v3.0.0']
+  ],
+  'article version labels should use the version folder nearest the filename even when the article key looks like a version'
+);
 
 const pages = tree[2];
 assert.equal(pages.source, 'tabs');

--- a/scripts/test-editor-content-tree.js
+++ b/scripts/test-editor-content-tree.js
@@ -12,7 +12,7 @@ const sample = {
     __order: ['nanoSite', 'guide'],
     nanoSite: {
       en: [
-        'post/main/v1.0.0/main_en.md',
+        'post/main/main_en.md',
         'post/main/v2.0.0/main_en.md'
       ],
       chs: 'post/main/v2.0.0/main_chs.md'
@@ -38,7 +38,7 @@ const draftStates = new Map([
   ['tabs:History:chs', 'saved']
 ]);
 const fileStates = new Map([
-  ['post/main/v1.0.0/main_en.md', 'existing'],
+  ['post/main/main_en.md', 'existing'],
   ['tab/history/chs.md', 'missing']
 ]);
 const diffStates = {
@@ -80,10 +80,10 @@ const enVersions = findEditorContentTreeNode(tree, 'index:nanoSite:en').children
 assert.deepEqual(
   enVersions.map(node => [node.id, node.kind, node.path, node.label]),
   [
-    ['index:nanoSite:en:0', 'file', 'post/main/v1.0.0/main_en.md', 'v1.0.0'],
+    ['index:nanoSite:en:0', 'file', 'post/main/main_en.md', 'Version 1'],
     ['index:nanoSite:en:1', 'file', 'post/main/v2.0.0/main_en.md', 'v2.0.0']
   ],
-  'article language nodes should expose version/file leaves'
+  'article language nodes should expose version/file leaves while tolerating legacy root-level first versions'
 );
 
 assert.equal(findEditorContentTreeNode(tree, 'index:nanoSite:en:1').draftState, 'dirty');

--- a/scripts/test-editor-content-tree.js
+++ b/scripts/test-editor-content-tree.js
@@ -9,7 +9,7 @@ import {
 
 const sample = {
   index: {
-    __order: ['nanoSite', 'guide', 'v2'],
+    __order: ['nanoSite', 'guide', 'v2', 'v3'],
     nanoSite: {
       en: [
         'post/main/main_en.md',
@@ -25,6 +25,9 @@ const sample = {
         'post/v2/v1.0.0/main_en.md',
         'post/v2/v3.0.0/main_en.md'
       ]
+    },
+    v3: {
+      en: ['post/v3/main_en.md']
     }
   },
   tabs: {
@@ -77,7 +80,7 @@ assert.deepEqual(
 
 const articles = tree[1];
 assert.equal(articles.source, 'index');
-assert.deepEqual(articles.children.map(node => node.id), ['index:nanoSite', 'index:guide', 'index:v2'], 'article entry order should follow __order');
+assert.deepEqual(articles.children.map(node => node.id), ['index:nanoSite', 'index:guide', 'index:v2', 'index:v3'], 'article entry order should follow __order');
 
 const articleLangs = findEditorContentTreeNode(tree, 'index:nanoSite').children;
 assert.deepEqual(articleLangs.map(node => node.id), ['index:nanoSite:en', 'index:nanoSite:chs'], 'article languages should follow preferred language order');
@@ -105,6 +108,15 @@ assert.deepEqual(
     ['index:v2:en:1', 'post/v2/v3.0.0/main_en.md', 'v3.0.0']
   ],
   'article version labels should use the version folder nearest the filename even when the article key looks like a version'
+);
+
+const legacyVersionLikeKeyVersions = findEditorContentTreeNode(tree, 'index:v3:en').children;
+assert.deepEqual(
+  legacyVersionLikeKeyVersions.map(node => [node.id, node.path, node.label]),
+  [
+    ['index:v3:en:0', 'post/v3/main_en.md', 'Version 1']
+  ],
+  'legacy root-style article paths should not treat a version-like article key as an explicit version folder'
 );
 
 const pages = tree[2];


### PR DESCRIPTION
## Summary
- version new article files from `v1.0.0` instead of creating the first file at the article root
- prompt for explicit `v...` version tags when adding article versions and keep legacy root-level article paths compatible
- remove article version path inputs from the editor UI and add regression coverage for the new versioning rules

## Test Plan
- node --check assets/js/composer.js
- node scripts/test-editor-content-tree.js
- node scripts/test-composer-identity-grid.js
- git diff --check
