### PR TITLE
[codex] Fix stale tabs metadata panel state

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -11556,7 +11556,7 @@ function renderEditorEntryPanel(node, refs) {
   refs.kicker.textContent = isPages ? treeText('pageEntry', 'Page') : treeText('articleEntry', 'Article');
   refs.title.textContent = node.key;
   refs.meta.textContent = isPages
-    ? treeText('pageEntryMeta', 'Manage page languages, titles, and files.')
+    ? treeText('pageEntryMeta', 'Manage page languages and open files for editing.')
     : treeText('articleEntryMeta', 'Manage article languages and versions.');
   appendLanguageSelector(refs.actions, node.source, node.key, entry);
   const del = makeStructureButton(treeText('delete', 'Delete'));
@@ -11591,37 +11591,22 @@ function renderPageLanguageStructure(key, lang, value) {
   main.appendChild(meta);
   const controls = document.createElement('div');
   controls.className = 'editor-structure-item-actions';
-  const titleInput = document.createElement('input');
-  titleInput.value = entry.title || '';
-  titleInput.setAttribute('aria-label', treeText('fieldTitle', 'Title'));
-  titleInput.addEventListener('change', () => {
-    const tabEntry = getTabsEntry(key);
-    tabEntry[lang] = tabEntry[lang] || {};
-    tabEntry[lang].title = titleInput.value;
-    notifyComposerChange('tabs');
-    refreshEditorContentTree();
-  });
-  const pathInput = document.createElement('input');
-  pathInput.value = entry.location || '';
-  pathInput.setAttribute('aria-label', treeText('location', 'Location'));
-  pathInput.addEventListener('change', () => {
-    const tabEntry = getTabsEntry(key);
-    tabEntry[lang] = tabEntry[lang] || {};
-    tabEntry[lang].location = normalizeRelPath(pathInput.value);
-    notifyComposerChange('tabs');
-    refreshEditorContentTree();
-  });
   const open = makeStructureButton(treeText('open', 'Open'));
-  open.addEventListener('click', () => openMarkdownInEditor(entry.location || pathInput.value, {
-    source: 'tabs',
-    key,
-    lang,
-    editorTreeNodeId: `tabs:${key}:${lang}`
-  }));
+  open.addEventListener('click', () => {
+    const rel = normalizeRelPath(entry.location);
+    if (!rel) {
+      alert(tComposer('markdown.openBeforeEditor'));
+      return;
+    }
+    openMarkdownInEditor(rel, {
+      source: 'tabs',
+      key,
+      lang,
+      editorTreeNodeId: `tabs:${key}:${lang}`
+    });
+  });
   const remove = makeStructureButton(treeText('remove', 'Remove'));
   remove.addEventListener('click', () => removeEditorLanguage('tabs', key, lang));
-  controls.appendChild(titleInput);
-  controls.appendChild(pathInput);
   controls.appendChild(open);
   controls.appendChild(remove);
   item.appendChild(main);
@@ -12053,8 +12038,6 @@ function buildTabsUI(root, state) {
     const renderBody = () => {
       bodyInner.innerHTML = '';
       const langs = sortLangKeys(entry);
-      const locationLabel = tComposerLang('fields.location');
-      const pathPlaceholder = tComposerLang('placeholders.tabPath');
       const editLabel = tComposerLang('actions.edit');
       const openLabel = tComposerLang('actions.open');
       const removeLangLabel = tComposerLang('removeLanguage');
@@ -12078,38 +12061,21 @@ function buildTabsUI(root, state) {
             <span class="ct-lang-code" aria-hidden="true">${escapeHtml(lang.toUpperCase())}</span>
           </div>
           <div class="ct-lang-main">
-            <label class="ct-field ct-field-location"><span class="ct-field-label">${escapeHtml(locationLabel)}</span> <input class="ct-loc" type="text" placeholder="${escapeHtml(pathPlaceholder)}" value="${escapeHtml(v.location || '')}" /></label>
+            <div class="ct-field ct-field-location"><span class="ct-field-label">${escapeHtml(v.location || '')}</span></div>
             <div class="ct-lang-actions">
               <button type="button" class="btn-secondary ct-edit" title="${escapeHtml(openLabel)}">${escapeHtml(editLabel)}</button>
               <button type="button" class="btn-secondary ct-lang-del">${escapeHtml(removeLangLabel)}</button>
             </div>
           </div>
         `;
-        const locInput = $('.ct-loc', block);
-        if (locInput) {
-          locInput.dataset.lang = lang;
-          locInput.dataset.field = 'location';
-        }
         const langRemoveBtn = $('.ct-lang-del', block);
         if (langRemoveBtn) {
           langRemoveBtn.setAttribute('title', removeLangLabel);
           langRemoveBtn.setAttribute('aria-label', removeLangLabel);
         }
         updateComposerMarkdownDraftIndicators({ element: block, path: initialPath });
-        locInput.addEventListener('input', (e) => {
-          const prevPath = block.dataset.mdPath || '';
-          entry[lang] = entry[lang] || {};
-          entry[lang].location = e.target.value;
-          const nextPath = normalizeRelPath(e.target.value);
-          if (nextPath) block.dataset.mdPath = nextPath;
-          else delete block.dataset.mdPath;
-          updateComposerMarkdownDraftIndicators({ element: block });
-          if (prevPath && prevPath !== nextPath) updateComposerMarkdownDraftIndicators({ path: prevPath });
-          if (nextPath) updateComposerMarkdownDraftIndicators({ path: nextPath });
-          markDirty();
-        });
         $('.ct-edit', block).addEventListener('click', () => {
-          const rel = normalizeRelPath(locInput.value);
+          const rel = normalizeRelPath(v.location);
           if (!rel) {
             alert(tComposer('markdown.openBeforeEditor'));
             return;
@@ -12465,7 +12431,7 @@ function focusComposerEntry(kind, key) {
   if (expandBtn) expandBtn.setAttribute('aria-expanded', 'true');
   row.classList.add('is-open');
 
-  const preferredFocus = row.querySelector(normalized === 'tabs' ? '.ct-loc' : '.ci-lang-addver, .ci-edit');
+  const preferredFocus = row.querySelector(normalized === 'tabs' ? '.ct-edit' : '.ci-lang-addver, .ci-edit');
   const fallbackFocus = row.querySelector('input, textarea, button');
   const target = preferredFocus || fallbackFocus;
   if (target && typeof target.focus === 'function') {

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -80,6 +80,7 @@ let currentMode = null;
 let activeDynamicMode = null;
 let activeMarkdownDocument = null;
 let detachPrimaryEditorListener = null;
+let detachPrimaryEditorTabsMetadataListener = null;
 let allowEditorStatePersist = false;
 let editorContentTree = [];
 let activeEditorTreeNodeId = 'articles';
@@ -7963,6 +7964,45 @@ function ensurePrimaryEditorListener() {
   });
 }
 
+function getTabsMetadataForPath(path) {
+  const node = getEditorTreeFileNodeByPath(path);
+  if (!node || node.source !== 'tabs' || !node.key || !node.lang) return { title: '' };
+  const entry = getTabsEntry(node.key);
+  const langEntry = entry && entry[node.lang] && typeof entry[node.lang] === 'object'
+    ? entry[node.lang]
+    : {};
+  return { title: String(langEntry.title || '') };
+}
+
+function updateTabsEntryTitleFromPath(path, metadata) {
+  const node = getEditorTreeFileNodeByPath(path);
+  if (!node || node.source !== 'tabs' || !node.key || !node.lang) return false;
+  const entry = getTabsEntry(node.key);
+  entry[node.lang] = entry[node.lang] && typeof entry[node.lang] === 'object'
+    ? entry[node.lang]
+    : {};
+  const nextTitle = metadata && typeof metadata === 'object'
+    ? String(metadata.title || '')
+    : '';
+  if (String(entry[node.lang].title || '') === nextTitle) return false;
+  entry[node.lang].title = nextTitle;
+  notifyComposerChange('tabs');
+  return true;
+}
+
+function ensurePrimaryEditorTabsMetadataListener() {
+  if (detachPrimaryEditorTabsMetadataListener) return;
+  const api = getPrimaryEditorApi();
+  if (!api || typeof api.onTabsMetadataChange !== 'function') return;
+  detachPrimaryEditorTabsMetadataListener = api.onTabsMetadataChange((metadata) => {
+    if (!activeDynamicMode) return;
+    const tab = dynamicEditorTabs.get(activeDynamicMode);
+    if (tab && tab.source === 'tabs') {
+      updateTabsEntryTitleFromPath(tab.path, metadata);
+    }
+  });
+}
+
 function normalizeRelPath(path) {
   const raw = String(path || '').trim();
   if (!raw) return '';
@@ -9262,6 +9302,11 @@ function pushEditorCurrentFileInfo(tab) {
     : { path: '', status: null, dirty: false, draft: null };
   try { editorApi.setCurrentFileLabel(payload); }
   catch (_) {}
+  if (typeof editorApi.setTabsMetadata === 'function') {
+    try {
+      editorApi.setTabsMetadata(tab && tab.source === 'tabs' ? getTabsMetadataForPath(tab.path) : null, { silent: true });
+    } catch (_) {}
+  }
   const activeTab = (tab && tab.mode && tab.mode === currentMode) ? tab : getActiveDynamicTab();
   updateMarkdownPushButton(activeTab);
   updateMarkdownDiscardButton(activeTab);
@@ -9368,6 +9413,10 @@ async function closeDynamicTab(modeId, options = {}) {
   if (!dynamicEditorTabs.size && detachPrimaryEditorListener) {
     try { detachPrimaryEditorListener(); } catch (_) {}
     detachPrimaryEditorListener = null;
+  }
+  if (!dynamicEditorTabs.size && detachPrimaryEditorTabsMetadataListener) {
+    try { detachPrimaryEditorTabsMetadataListener(); } catch (_) {}
+    detachPrimaryEditorTabsMetadataListener = null;
   }
 
   if (wasActive) {
@@ -9665,6 +9714,7 @@ function applyMode(mode, options = {}) {
   if (isDynamicMode(nextMode)) {
     activeDynamicMode = nextMode;
     ensurePrimaryEditorListener();
+    ensurePrimaryEditorTabsMetadataListener();
     const tab = dynamicEditorTabs.get(nextMode);
     activeMarkdownDocument = tab || null;
     setEditorDetailPanelMode('markdown');
@@ -11871,7 +11921,6 @@ function buildTabsUI(root, state) {
     const renderBody = () => {
       bodyInner.innerHTML = '';
       const langs = sortLangKeys(entry);
-      const titleLabel = tComposerLang('fields.title');
       const locationLabel = tComposerLang('fields.location');
       const pathPlaceholder = tComposerLang('placeholders.tabPath');
       const editLabel = tComposerLang('actions.edit');
@@ -11897,7 +11946,6 @@ function buildTabsUI(root, state) {
             <span class="ct-lang-code" aria-hidden="true">${escapeHtml(lang.toUpperCase())}</span>
           </div>
           <div class="ct-lang-main">
-            <label class="ct-field ct-field-title"><span class="ct-field-label">${escapeHtml(titleLabel)}</span> <input class="ct-title" type="text" value="${escapeHtml(v.title || '')}" /></label>
             <label class="ct-field ct-field-location"><span class="ct-field-label">${escapeHtml(locationLabel)}</span> <input class="ct-loc" type="text" placeholder="${escapeHtml(pathPlaceholder)}" value="${escapeHtml(v.location || '')}" /></label>
             <div class="ct-lang-actions">
               <button type="button" class="btn-secondary ct-edit" title="${escapeHtml(openLabel)}">${escapeHtml(editLabel)}</button>
@@ -11905,12 +11953,7 @@ function buildTabsUI(root, state) {
             </div>
           </div>
         `;
-        const titleInput = $('.ct-title', block);
         const locInput = $('.ct-loc', block);
-        if (titleInput) {
-          titleInput.dataset.lang = lang;
-          titleInput.dataset.field = 'title';
-        }
         if (locInput) {
           locInput.dataset.lang = lang;
           locInput.dataset.field = 'location';
@@ -11921,11 +11964,6 @@ function buildTabsUI(root, state) {
           langRemoveBtn.setAttribute('aria-label', removeLangLabel);
         }
         updateComposerMarkdownDraftIndicators({ element: block, path: initialPath });
-        titleInput.addEventListener('input', (e) => {
-          entry[lang] = entry[lang] || {};
-          entry[lang].title = e.target.value;
-          markDirty();
-        });
         locInput.addEventListener('input', (e) => {
           const prevPath = block.dataset.mdPath || '';
           entry[lang] = entry[lang] || {};
@@ -12290,7 +12328,7 @@ function focusComposerEntry(kind, key) {
   if (expandBtn) expandBtn.setAttribute('aria-expanded', 'true');
   row.classList.add('is-open');
 
-  const preferredFocus = row.querySelector(normalized === 'tabs' ? '.ct-title, .ct-loc' : '.ci-lang-addver, .ci-edit');
+  const preferredFocus = row.querySelector(normalized === 'tabs' ? '.ct-loc' : '.ci-lang-addver, .ci-edit');
   const fallbackFocus = row.querySelector('input, textarea, button');
   const target = preferredFocus || fallbackFocus;
   if (target && typeof target.focus === 'function') {

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -11212,18 +11212,6 @@ function renderEditorEntryPanel(node, refs) {
   del.addEventListener('click', () => deleteEditorEntry(node.source, node.key));
   refs.actions.appendChild(del);
 
-  const keyRow = document.createElement('div');
-  keyRow.className = 'editor-structure-row';
-  const keyLabel = document.createElement('label');
-  keyLabel.textContent = treeText('key', 'Key');
-  const keyInput = document.createElement('input');
-  keyInput.value = node.key;
-  keyInput.addEventListener('change', () => renameEditorEntry(node.source, node.key, keyInput.value));
-  keyRow.appendChild(keyLabel);
-  keyRow.appendChild(keyInput);
-  keyRow.appendChild(document.createElement('span'));
-  refs.body.appendChild(keyRow);
-
   const list = document.createElement('div');
   list.className = 'editor-structure-list';
   sortLangKeys(entry).forEach((lang) => {

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -73,8 +73,8 @@ const EDITOR_STATE_VERSION = 3;
 const EDITOR_SCROLL_SAVE_DELAY = 120;
 
 // Track additional markdown editor tabs spawned from Composer
-const dynamicEditorTabs = new Map();       // modeId -> { path, button, content, loaded, baseDir }
-const dynamicEditorTabsByPath = new Map(); // normalizedPath -> modeId
+const dynamicEditorTabs = new Map();            // modeId -> { path, button, content, loaded, baseDir }
+const dynamicEditorTabsByLookupKey = new Map(); // lookupKey -> modeId
 let dynamicTabCounter = 0;
 let currentMode = null;
 let activeDynamicMode = null;
@@ -3967,9 +3967,10 @@ function updateUnsyncedSummary(options = {}) {
 function findDynamicTabByPath(path) {
   const normalized = normalizeRelPath(path);
   if (!normalized) return null;
-  const modeId = dynamicEditorTabsByPath.get(normalized);
-  if (!modeId) return null;
-  return dynamicEditorTabs.get(modeId) || null;
+  for (const tab of dynamicEditorTabs.values()) {
+    if (tab && normalizeRelPath(tab.path) === normalized) return tab;
+  }
+  return null;
 }
 
 function encodeContentToBase64(text) {
@@ -7974,6 +7975,17 @@ function getTabsMetadataForPath(path) {
   return { title: String(langEntry.title || '') };
 }
 
+function getTabsMetadataForTab(tab) {
+  if (tab && tab.tabsKey && tab.tabsLang) {
+    const entry = getTabsEntry(tab.tabsKey);
+    const langEntry = entry && entry[tab.tabsLang] && typeof entry[tab.tabsLang] === 'object'
+      ? entry[tab.tabsLang]
+      : {};
+    return { title: String(langEntry.title || '') };
+  }
+  return getTabsMetadataForPath(tab && tab.path ? tab.path : '');
+}
+
 function updateTabsEntryTitleFromPath(path, metadata) {
   const node = getEditorTreeFileNodeByPath(path);
   if (!node || node.source !== 'tabs' || !node.key || !node.lang) return false;
@@ -7990,6 +8002,23 @@ function updateTabsEntryTitleFromPath(path, metadata) {
   return true;
 }
 
+function updateTabsEntryTitleForTab(tab, metadata) {
+  if (tab && tab.tabsKey && tab.tabsLang) {
+    const entry = getTabsEntry(tab.tabsKey);
+    entry[tab.tabsLang] = entry[tab.tabsLang] && typeof entry[tab.tabsLang] === 'object'
+      ? entry[tab.tabsLang]
+      : {};
+    const nextTitle = metadata && typeof metadata === 'object'
+      ? String(metadata.title || '')
+      : '';
+    if (String(entry[tab.tabsLang].title || '') === nextTitle) return false;
+    entry[tab.tabsLang].title = nextTitle;
+    notifyComposerChange('tabs');
+    return true;
+  }
+  return updateTabsEntryTitleFromPath(tab && tab.path ? tab.path : '', metadata);
+}
+
 function ensurePrimaryEditorTabsMetadataListener() {
   if (detachPrimaryEditorTabsMetadataListener) return;
   const api = getPrimaryEditorApi();
@@ -7998,7 +8027,7 @@ function ensurePrimaryEditorTabsMetadataListener() {
     if (!activeDynamicMode) return;
     const tab = dynamicEditorTabs.get(activeDynamicMode);
     if (tab && tab.source === 'tabs') {
-      updateTabsEntryTitleFromPath(tab.path, metadata);
+      updateTabsEntryTitleForTab(tab, metadata);
     }
   });
 }
@@ -8111,6 +8140,27 @@ function getActiveDynamicTab() {
   if (!activeDynamicMode) return null;
   const tab = dynamicEditorTabs.get(activeDynamicMode);
   return tab || null;
+}
+
+function deriveDynamicTabIdentity(path, options = {}) {
+  const normalizedPath = normalizeRelPath(path);
+  const opts = options && typeof options === 'object' ? options : {};
+  const node = opts.node && typeof opts.node === 'object' ? opts.node : null;
+  const source = String(opts.source || (node && node.source) || inferMarkdownSourceFromPath(normalizedPath) || '').trim().toLowerCase();
+  const key = String(opts.key || (node && node.key) || '').trim();
+  const lang = normalizeLangCode(opts.lang || (node && node.lang) || '');
+  const editorTreeNodeId = String(opts.editorTreeNodeId || opts.nodeId || (node && node.id) || '').trim();
+  const lookupKey = (source === 'tabs' && key && lang)
+    ? `tabs:${key}:${lang}`
+    : normalizedPath;
+  return {
+    path: normalizedPath,
+    source,
+    key,
+    lang,
+    editorTreeNodeId,
+    lookupKey
+  };
 }
 
 function getEditorContentPane() {
@@ -8796,7 +8846,7 @@ function restoreDynamicEditorState() {
 
   const activePath = data.activePath ? normalizeRelPath(data.activePath) : '';
   if ((isV3 ? data.mode === 'markdown' : true) && activePath) {
-    const modeId = dynamicEditorTabsByPath.get(activePath) || getOrCreateDynamicMode(activePath);
+    const modeId = dynamicEditorTabsByLookupKey.get(activePath) || getOrCreateDynamicMode(activePath);
     if (modeId) {
       applyMode(modeId, { preserveTreeExpansion: true, restoreScroll: true });
       return finishRestore(modeId);
@@ -9304,7 +9354,7 @@ function pushEditorCurrentFileInfo(tab) {
   catch (_) {}
   if (typeof editorApi.setTabsMetadata === 'function') {
     try {
-      editorApi.setTabsMetadata(tab && tab.source === 'tabs' ? getTabsMetadataForPath(tab.path) : null, { silent: true });
+      editorApi.setTabsMetadata(tab && tab.source === 'tabs' ? getTabsMetadataForTab(tab) : null, { silent: true });
     } catch (_) {}
   }
   const activeTab = (tab && tab.mode && tab.mode === currentMode) ? tab : getActiveDynamicTab();
@@ -9403,7 +9453,7 @@ async function closeDynamicTab(modeId, options = {}) {
   clearMarkdownDraftForTab(tab);
 
   dynamicEditorTabs.delete(modeId);
-  if (tab.path) dynamicEditorTabsByPath.delete(tab.path);
+  if (tab.lookupKey) dynamicEditorTabsByLookupKey.delete(tab.lookupKey);
   try { tab.button?.remove(); } catch (_) {}
   updateDynamicTabsGroupState();
 
@@ -9433,10 +9483,11 @@ async function closeDynamicTab(modeId, options = {}) {
   return true;
 }
 
-function getOrCreateDynamicMode(path) {
-  const normalized = normalizeRelPath(path);
+function getOrCreateDynamicMode(path, options = {}) {
+  const identity = deriveDynamicTabIdentity(path, options);
+  const normalized = identity.path;
   if (!normalized) return null;
-  const existing = dynamicEditorTabsByPath.get(normalized);
+  const existing = dynamicEditorTabsByLookupKey.get(identity.lookupKey);
   if (existing) return existing;
 
   dynamicTabCounter += 1;
@@ -9446,7 +9497,11 @@ function getOrCreateDynamicMode(path) {
   const data = {
     mode: modeId,
     path: normalized,
-    source: inferMarkdownSourceFromPath(normalized),
+    source: identity.source,
+    tabsKey: identity.key || '',
+    tabsLang: identity.lang || '',
+    editorTreeNodeId: identity.editorTreeNodeId || '',
+    lookupKey: identity.lookupKey,
     button: null,
     label,
     baseDir: computeBaseDirForPath(normalized),
@@ -9464,7 +9519,7 @@ function getOrCreateDynamicMode(path) {
   };
   restoreMarkdownDraftForTab(data);
   dynamicEditorTabs.set(modeId, data);
-  dynamicEditorTabsByPath.set(normalized, modeId);
+  dynamicEditorTabsByLookupKey.set(identity.lookupKey, modeId);
 
   loadDynamicTabContent(data).catch(() => {});
 
@@ -9552,12 +9607,12 @@ async function loadDynamicTabContent(tab) {
   return tab.pending;
 }
 
-function openMarkdownInEditor(path) {
+function openMarkdownInEditor(path, options = {}) {
   const active = getActiveDynamicTab();
   if (active && active.path && normalizeRelPath(active.path) !== normalizeRelPath(path)) {
     try { flushMarkdownDraft(active); } catch (_) {}
   }
-  const modeId = getOrCreateDynamicMode(path);
+  const modeId = getOrCreateDynamicMode(path, options);
   if (!modeId) {
     alert('Unable to open editor tab.');
     return;
@@ -9651,7 +9706,7 @@ function applyMode(mode, options = {}) {
       const tab = dynamicEditorTabs.get(nextMode);
       activeMarkdownDocument = tab || null;
       if (tab) {
-        try { selectEditorTreeNodeByPath(tab.path, { expandAncestors: !options.preserveTreeExpansion }); } catch (_) {}
+        try { selectEditorTreeNodeForTab(tab, { expandAncestors: !options.preserveTreeExpansion }); } catch (_) {}
       }
       setEditorDetailPanelMode('markdown');
       if (options.restoreScroll) restoreEditorContentScrollForMode(nextMode);
@@ -9719,7 +9774,7 @@ function applyMode(mode, options = {}) {
     activeMarkdownDocument = tab || null;
     setEditorDetailPanelMode('markdown');
     if (tab && editorApi) {
-      try { selectEditorTreeNodeByPath(tab.path, { expandAncestors: !options.preserveTreeExpansion }); } catch (_) {}
+      try { selectEditorTreeNodeForTab(tab, { expandAncestors: !options.preserveTreeExpansion }); } catch (_) {}
       try { editorApi.setView('edit'); } catch (_) {}
       try {
         const baseDir = computeBaseDirForPath(tab.path);
@@ -10633,10 +10688,22 @@ function getEditorTreeFileNodeByPath(path) {
     .find(item => item && item.kind === 'file' && item.path === normalized) || null;
 }
 
+function getEditorTreeFileNodeForTab(tab) {
+  if (tab && tab.editorTreeNodeId) {
+    const byId = getEditorTreeNodeById(tab.editorTreeNodeId);
+    if (byId && byId.kind === 'file') return byId;
+  }
+  if (tab && tab.tabsKey && tab.tabsLang) {
+    const byIdentity = getEditorTreeNodeById(`tabs:${tab.tabsKey}:${tab.tabsLang}`);
+    if (byIdentity && byIdentity.kind === 'file') return byIdentity;
+  }
+  return getEditorTreeFileNodeByPath(tab && tab.path ? tab.path : '');
+}
+
 function buildCurrentFileBreadcrumb(tab) {
   if (!tab || !tab.path) return [];
   const normalizedPath = normalizeRelPath(tab.path);
-  const node = getEditorTreeFileNodeByPath(normalizedPath);
+  const node = getEditorTreeFileNodeForTab(tab);
   if (!node) return normalizedPath ? [{ label: normalizedPath, path: normalizedPath }] : [];
   const ids = [];
   if (node.source === 'tabs') {
@@ -10684,6 +10751,17 @@ function selectEditorTreeNodeByPath(path, options = {}) {
   if (!options || options.expandAncestors !== false) expandEditorAncestors(node);
   refreshEditorContentTree({ preserveStructure: currentMode && isDynamicMode(currentMode) });
   return node;
+}
+
+function selectEditorTreeNodeForTab(tab, options = {}) {
+  const node = getEditorTreeFileNodeForTab(tab);
+  if (node && node.id) {
+    activeEditorTreeNodeId = node.id;
+    if (!options || options.expandAncestors !== false) expandEditorAncestors(node);
+    refreshEditorContentTree({ preserveStructure: currentMode && isDynamicMode(currentMode) });
+    return node;
+  }
+  return selectEditorTreeNodeByPath(tab && tab.path ? tab.path : '', options);
 }
 
 function refreshEditorContentTree(options = {}) {
@@ -10930,7 +11008,7 @@ function handleEditorTreeSelection(nodeId) {
   }
   if (node.kind === 'file' && node.path) {
     refreshEditorContentTree({ preserveStructure: true });
-    openMarkdownInEditor(node.path);
+    openMarkdownInEditor(node.path, { node });
     closeEditorRailDrawer();
     scheduleEditorStatePersist();
     return;
@@ -11490,7 +11568,12 @@ function renderPageLanguageStructure(key, lang, value) {
     refreshEditorContentTree();
   });
   const open = makeStructureButton(treeText('open', 'Open'));
-  open.addEventListener('click', () => openMarkdownInEditor(entry.location || pathInput.value));
+  open.addEventListener('click', () => openMarkdownInEditor(entry.location || pathInput.value, {
+    source: 'tabs',
+    key,
+    lang,
+    editorTreeNodeId: `tabs:${key}:${lang}`
+  }));
   const remove = makeStructureButton(treeText('remove', 'Remove'));
   remove.addEventListener('click', () => removeEditorLanguage('tabs', key, lang));
   controls.appendChild(titleInput);
@@ -11530,7 +11613,12 @@ function renderEditorLanguagePanel(node, refs) {
     const controls = document.createElement('div');
     controls.className = 'editor-structure-item-actions';
     const open = makeStructureButton(treeText('open', 'Open'));
-    open.addEventListener('click', () => openMarkdownInEditor(arr[index]));
+    open.addEventListener('click', () => openMarkdownInEditor(arr[index], {
+      source: 'index',
+      key: node.key,
+      lang: node.lang,
+      editorTreeNodeId: `index:${node.key}:${node.lang}:${index}`
+    }));
     const up = makeStructureButton('↑');
     up.disabled = index === 0;
     up.addEventListener('click', () => moveEditorVersion(node.key, node.lang, index, -1));

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -11058,6 +11058,18 @@ function renderStructureItem(label, detail, onOpen) {
   return item;
 }
 
+const moveStructureRootEntry = (source, from, to) => {
+  const state = getStateSlice(source) || {};
+  const order = Array.isArray(state.__order) ? state.__order : [];
+  if (from === to || from < 0 || to < 0 || from >= order.length || to >= order.length) return false;
+  const [key] = order.splice(from, 1);
+  order.splice(to, 0, key);
+  activeEditorTreeNodeId = source === 'tabs' ? 'pages' : 'articles';
+  notifyComposerChange(source);
+  refreshEditorContentTree();
+  return true;
+};
+
 function appendEditorLanguageControl(body) {
   if (!body) return;
   const item = document.createElement('div');
@@ -11173,7 +11185,173 @@ function renderEditorStructurePanel(node) {
     actions.appendChild(add);
     const list = document.createElement('div');
     list.className = 'editor-structure-list';
-    node.children.forEach((child) => list.appendChild(renderStructureItem(child.label, `${child.children.length} ${treeText('languages', 'languages')}`, () => handleEditorTreeSelection(child.id))));
+    if (node.source === 'index') {
+      let structureDragState = null;
+
+      const getAnimatedStructureRows = () => Array.from(list.children)
+        .filter((row) => row !== structureDragState?.placeholder && row.classList?.contains('editor-structure-item--draggable') && row !== structureDragState?.dragItem);
+
+      const animateStructureRows = (callback) => {
+        const previousRects = new Map();
+        getAnimatedStructureRows().forEach((row) => {
+          previousRects.set(row, row.getBoundingClientRect());
+        });
+
+        callback();
+
+        getAnimatedStructureRows().forEach((row) => {
+          const previous = previousRects.get(row);
+          if (!previous) return;
+          const next = row.getBoundingClientRect();
+          const deltaY = previous.top - next.top;
+          if (!deltaY) return;
+          row.style.transition = 'none';
+          row.style.transform = `translate3d(0, ${previous.top - next.top}px, 0)`;
+          requestAnimationFrame(() => {
+            row.style.transition = 'transform .18s cubic-bezier(.2,.8,.2,1)';
+            row.style.transform = '';
+          });
+        });
+      };
+
+      const createStructureDragPlaceholder = (item) => {
+        const itemRect = item.getBoundingClientRect();
+        const placeholder = document.createElement('div');
+        placeholder.className = 'editor-structure-drop-placeholder';
+        placeholder.style.height = `${itemRect.height}px`;
+        return placeholder;
+      };
+
+      const getStructureDropIndex = () => {
+        if (!structureDragState || !structureDragState.placeholder) return -1;
+        const rows = Array.from(list.children)
+          .filter((childNode) => childNode === structureDragState.placeholder || (childNode !== structureDragState.dragItem && childNode.classList?.contains('editor-structure-item--draggable')));
+        return rows.indexOf(structureDragState.placeholder);
+      };
+
+      const updateStructureDragItemState = () => {
+        list.querySelectorAll('.editor-structure-item--draggable').forEach((item) => {
+          item.classList.toggle('is-dragging', !!structureDragState && item === structureDragState.dragItem);
+        });
+      };
+
+      const applyStructureDragPreview = (clientY) => {
+        if (!structureDragState) return;
+        structureDragState.dragItem.style.transform = `translate3d(0, ${clientY - structureDragState.startY}px, 0)`;
+        const rows = getAnimatedStructureRows();
+        let nextNode = null;
+        for (const row of rows) {
+          const rect = row.getBoundingClientRect();
+          const midpoint = rect.top + rect.height / 2;
+          if (clientY < midpoint) {
+            nextNode = row;
+            break;
+          }
+        }
+        if (nextNode === structureDragState.placeholder.nextSibling) return;
+        animateStructureRows(() => {
+          list.insertBefore(structureDragState.placeholder, nextNode);
+        });
+      };
+
+      const handleStructureDragPointerMove = (event) => {
+        if (!structureDragState) return;
+        event.preventDefault();
+        applyStructureDragPreview(event.clientY);
+      };
+
+      const endStructureDrag = () => {
+        document.removeEventListener('pointermove', handleStructureDragPointerMove, true);
+        document.removeEventListener('pointerup', endStructureDrag, true);
+        document.removeEventListener('pointercancel', endStructureDrag, true);
+        if (structureDragState) {
+          const { fromIndex, dragItem, placeholder } = structureDragState;
+          const toIndex = getStructureDropIndex();
+          dragItem.classList.remove('is-dragging');
+          dragItem.style.position = '';
+          dragItem.style.left = '';
+          dragItem.style.top = '';
+          dragItem.style.width = '';
+          dragItem.style.zIndex = '';
+          dragItem.style.transform = '';
+          if (placeholder && placeholder.parentNode) placeholder.parentNode.removeChild(placeholder);
+          if (toIndex >= 0) moveStructureRootEntry(node.source, fromIndex, toIndex);
+        }
+        structureDragState = null;
+        updateStructureDragItemState();
+      };
+
+      const createStructureDragHandle = (child, index) => {
+        const handle = document.createElement('span');
+        handle.setAttribute('role', 'button');
+        handle.tabIndex = 0;
+        handle.className = 'editor-structure-drag-handle';
+        handle.setAttribute('aria-label', treeText('reorderArticle', 'Reorder article'));
+        handle.innerHTML = '<span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span>';
+        handle.addEventListener('pointerdown', (event) => {
+          if (event.button != null && event.button !== 0) return;
+          event.preventDefault();
+          const item = handle.closest('.editor-structure-item--draggable');
+          if (!item) return;
+          const itemRect = item.getBoundingClientRect();
+          const placeholder = createStructureDragPlaceholder(item);
+          list.insertBefore(placeholder, item);
+          structureDragState = {
+            childId: child.id,
+            fromIndex: index,
+            dragItem: item,
+            placeholder,
+            startY: event.clientY
+          };
+          item.classList.add('is-dragging');
+          item.style.position = 'fixed';
+          item.style.left = `${itemRect.left}px`;
+          item.style.top = `${itemRect.top}px`;
+          item.style.width = `${itemRect.width}px`;
+          item.style.zIndex = '1000';
+          item.style.transform = 'translate3d(0, 0, 0)';
+          updateStructureDragItemState();
+          document.addEventListener('pointermove', handleStructureDragPointerMove, true);
+          document.addEventListener('pointerup', endStructureDrag, true);
+          document.addEventListener('pointercancel', endStructureDrag, true);
+        });
+        handle.addEventListener('keydown', (event) => {
+          if (!event.altKey || (event.key !== 'ArrowUp' && event.key !== 'ArrowDown')) return;
+          event.preventDefault();
+          moveStructureRootEntry(node.source, index, event.key === 'ArrowUp' ? index - 1 : index + 1);
+        });
+        return handle;
+      };
+
+      const renderStructureDraggableItem = (child, detail, index) => {
+        const item = document.createElement('div');
+        item.className = 'editor-structure-item editor-structure-item--draggable';
+        item.dataset.index = String(index);
+        const handle = createStructureDragHandle(child, index);
+        const main = document.createElement('div');
+        main.className = 'editor-structure-item-main';
+        const title = document.createElement('span');
+        title.className = 'editor-structure-item-title';
+        title.textContent = child.label || '';
+        const metaText = document.createElement('span');
+        metaText.className = 'editor-structure-item-meta';
+        metaText.textContent = detail || '';
+        main.append(title, metaText);
+        const controls = document.createElement('div');
+        controls.className = 'editor-structure-item-actions';
+        const open = makeStructureButton(treeText('select', 'Select'));
+        open.addEventListener('click', () => handleEditorTreeSelection(child.id));
+        controls.appendChild(open);
+        item.append(handle, main, controls);
+        return item;
+      };
+
+      node.children.forEach((child, index) => {
+        list.appendChild(renderStructureDraggableItem(child, `${child.children.length} ${treeText('languages', 'languages')}`, index));
+      });
+    } else {
+      node.children.forEach((child) => list.appendChild(renderStructureItem(child.label, `${child.children.length} ${treeText('languages', 'languages')}`, () => handleEditorTreeSelection(child.id))));
+    }
     body.appendChild(list);
     animate();
     return;

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -11185,7 +11185,7 @@ function renderEditorStructurePanel(node) {
     actions.appendChild(add);
     const list = document.createElement('div');
     list.className = 'editor-structure-list';
-    if (node.source === 'index') {
+    if (node.source === 'index' || node.source === 'tabs') {
       let structureDragState = null;
 
       const getAnimatedStructureRows = () => Array.from(list.children)
@@ -11281,12 +11281,13 @@ function renderEditorStructurePanel(node) {
         updateStructureDragItemState();
       };
 
-      const createStructureDragHandle = (child, index) => {
+      const createStructureDragHandle = (child, index, source) => {
+        const labelKey = source === 'tabs' ? 'reorderPage' : 'reorderArticle';
         const handle = document.createElement('span');
         handle.setAttribute('role', 'button');
         handle.tabIndex = 0;
         handle.className = 'editor-structure-drag-handle';
-        handle.setAttribute('aria-label', treeText('reorderArticle', 'Reorder article'));
+        handle.setAttribute('aria-label', treeText(labelKey, source === 'tabs' ? 'Reorder page' : 'Reorder article'));
         handle.innerHTML = '<span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span>';
         handle.addEventListener('pointerdown', (event) => {
           if (event.button != null && event.button !== 0) return;
@@ -11318,16 +11319,16 @@ function renderEditorStructurePanel(node) {
         handle.addEventListener('keydown', (event) => {
           if (!event.altKey || (event.key !== 'ArrowUp' && event.key !== 'ArrowDown')) return;
           event.preventDefault();
-          moveStructureRootEntry(node.source, index, event.key === 'ArrowUp' ? index - 1 : index + 1);
+          moveStructureRootEntry(source, index, event.key === 'ArrowUp' ? index - 1 : index + 1);
         });
         return handle;
       };
 
-      const renderStructureDraggableItem = (child, detail, index) => {
+      const renderStructureDraggableItem = (child, detail, index, source) => {
         const item = document.createElement('div');
         item.className = 'editor-structure-item editor-structure-item--draggable';
         item.dataset.index = String(index);
-        const handle = createStructureDragHandle(child, index);
+        const handle = createStructureDragHandle(child, index, source);
         const main = document.createElement('div');
         main.className = 'editor-structure-item-main';
         const title = document.createElement('span');
@@ -11347,7 +11348,7 @@ function renderEditorStructurePanel(node) {
       };
 
       node.children.forEach((child, index) => {
-        list.appendChild(renderStructureDraggableItem(child, `${child.children.length} ${treeText('languages', 'languages')}`, index));
+        list.appendChild(renderStructureDraggableItem(child, `${child.children.length} ${treeText('languages', 'languages')}`, index, node.source));
       });
     } else {
       node.children.forEach((child) => list.appendChild(renderStructureItem(child.label, `${child.children.length} ${treeText('languages', 'languages')}`, () => handleEditorTreeSelection(child.id))));

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -12114,7 +12114,12 @@ function buildTabsUI(root, state) {
             alert(tComposer('markdown.openBeforeEditor'));
             return;
           }
-          openMarkdownInEditor(rel);
+          openMarkdownInEditor(rel, {
+            source: 'tabs',
+            key,
+            lang,
+            editorTreeNodeId: `tabs:${key}:${lang}`
+          });
         });
         $('.ct-lang-del', block).addEventListener('click', () => {
           delete entry[lang];

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -8146,13 +8146,30 @@ function deriveDynamicTabIdentity(path, options = {}) {
   const normalizedPath = normalizeRelPath(path);
   const opts = options && typeof options === 'object' ? options : {};
   const node = opts.node && typeof opts.node === 'object' ? opts.node : null;
-  const source = String(opts.source || (node && node.source) || inferMarkdownSourceFromPath(normalizedPath) || '').trim().toLowerCase();
-  const key = String(opts.key || (node && node.key) || '').trim();
-  const lang = normalizeLangCode(opts.lang || (node && node.lang) || '');
+  const explicitLookupKey = String(opts.lookupKey || '').trim();
+  const lookupKeyParts = explicitLookupKey.startsWith('tabs:') ? explicitLookupKey.split(':') : null;
+  const source = String(
+    opts.source
+    || (node && node.source)
+    || (lookupKeyParts && lookupKeyParts.length >= 3 ? 'tabs' : '')
+    || inferMarkdownSourceFromPath(normalizedPath)
+    || ''
+  ).trim().toLowerCase();
+  const key = String(
+    opts.key
+    || (node && node.key)
+    || (lookupKeyParts && lookupKeyParts.length >= 3 ? lookupKeyParts.slice(1, -1).join(':') : '')
+    || ''
+  ).trim();
+  const lang = normalizeLangCode(
+    opts.lang
+    || (node && node.lang)
+    || (lookupKeyParts && lookupKeyParts.length >= 3 ? lookupKeyParts[lookupKeyParts.length - 1] : '')
+  );
   const editorTreeNodeId = String(opts.editorTreeNodeId || opts.nodeId || (node && node.id) || '').trim();
-  const lookupKey = (source === 'tabs' && key && lang)
+  const lookupKey = explicitLookupKey || ((source === 'tabs' && key && lang)
     ? `tabs:${key}:${lang}`
-    : normalizedPath;
+    : normalizedPath);
   return {
     path: normalizedPath,
     source,
@@ -8767,7 +8784,17 @@ function persistDynamicEditorState() {
     if (!store) return;
     captureEditorContentScroll(currentMode);
     const open = Array.from(dynamicEditorTabs.values())
-      .map((tab) => (tab && tab.path) ? tab.path : '')
+      .map((tab) => {
+        if (!tab || !tab.path) return null;
+        return {
+          lookupKey: tab.lookupKey || tab.path,
+          path: tab.path,
+          source: tab.source || '',
+          key: tab.tabsKey || '',
+          lang: tab.tabsLang || '',
+          editorTreeNodeId: tab.editorTreeNodeId || ''
+        };
+      })
       .filter(Boolean);
     const active = currentMode && isDynamicMode(currentMode) ? dynamicEditorTabs.get(currentMode) : null;
     const systemMode = (currentMode === 'composer' || currentMode === 'updates' || currentMode === 'sync')
@@ -8777,6 +8804,7 @@ function persistDynamicEditorState() {
       v: EDITOR_STATE_VERSION,
       mode: active ? 'markdown' : systemMode,
       activeNodeId: activeEditorTreeNodeId || 'articles',
+      activeLookupKey: active && (active.lookupKey || active.path) ? (active.lookupKey || active.path) : null,
       activePath: active && active.path ? active.path : null,
       open,
       expandedNodeIds: Array.from(expandedEditorTreeNodeIds).filter(Boolean),
@@ -8785,6 +8813,7 @@ function persistDynamicEditorState() {
       updatedAt: Date.now()
     };
     if (currentMode && isDynamicMode(currentMode)) {
+      state.activeLookupKey = active && (active.lookupKey || active.path) ? (active.lookupKey || active.path) : null;
       state.activePath = active && active.path ? active.path : null;
     }
     store.setItem(LS_KEYS.editorState, JSON.stringify(state));
@@ -8812,10 +8841,22 @@ function restoreDynamicEditorState() {
   const open = Array.isArray(data.open) ? data.open : [];
   const seen = new Set();
   open.forEach((item) => {
-    const norm = normalizeRelPath(item);
-    if (!norm || seen.has(norm)) return;
-    seen.add(norm);
-    getOrCreateDynamicMode(norm);
+    const lookupKey = item && typeof item === 'object'
+      ? String(item.lookupKey || '').trim()
+      : '';
+    const path = item && typeof item === 'object'
+      ? normalizeRelPath(item.path)
+      : normalizeRelPath(item);
+    const seenKey = lookupKey || path;
+    if (!path || !seenKey || seen.has(seenKey)) return;
+    seen.add(seenKey);
+    getOrCreateDynamicMode(path, {
+      source: item && typeof item === 'object' ? item.source : '',
+      key: item && typeof item === 'object' ? item.key : '',
+      lang: item && typeof item === 'object' ? item.lang : '',
+      editorTreeNodeId: item && typeof item === 'object' ? item.editorTreeNodeId : '',
+      lookupKey
+    });
   });
 
   if (isV3 && Array.isArray(data.expandedNodeIds)) {
@@ -8844,9 +8885,12 @@ function restoreDynamicEditorState() {
     return true;
   };
 
+  const activeLookupKey = String(data.activeLookupKey || '').trim();
   const activePath = data.activePath ? normalizeRelPath(data.activePath) : '';
-  if ((isV3 ? data.mode === 'markdown' : true) && activePath) {
-    const modeId = dynamicEditorTabsByLookupKey.get(activePath) || getOrCreateDynamicMode(activePath);
+  if ((isV3 ? data.mode === 'markdown' : true) && (activeLookupKey || activePath)) {
+    const modeId = (activeLookupKey && dynamicEditorTabsByLookupKey.get(activeLookupKey))
+      || (activePath && dynamicEditorTabsByLookupKey.get(activePath))
+      || (activePath ? getOrCreateDynamicMode(activePath) : null);
     if (modeId) {
       applyMode(modeId, { preserveTreeExpansion: true, restoreScroll: true });
       return finishRestore(modeId);

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -1363,8 +1363,10 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const setFrontMatterVisible = (visible) => {
-    frontMatterVisible = !!visible;
-    if (!frontMatterVisible && frontMatterManager && typeof frontMatterManager.clear === 'function') frontMatterManager.clear();
+    const nextVisible = !!visible;
+    const shouldClear = !nextVisible && frontMatterVisible;
+    frontMatterVisible = nextVisible;
+    if (shouldClear && frontMatterManager && typeof frontMatterManager.clear === 'function') frontMatterManager.clear();
     const commonSection = document.getElementById('frontMatterCommonSection');
     const extraSection = document.getElementById('frontMatterExtraSection');
     if (commonSection) commonSection.hidden = !frontMatterVisible;

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -1161,6 +1161,19 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     };
 
+    const clear = () => {
+      state = {
+        data: {},
+        order: [],
+        eol: '\n',
+        trailingNewline: false,
+        bindings: new Map(),
+        hasFrontMatter: false,
+        document: null
+      };
+      rebuildBindings();
+    };
+
     ensureBaseFields();
     updateSummary();
     applySectionDescriptions();
@@ -1171,6 +1184,7 @@ document.addEventListener('DOMContentLoaded', () => {
       setChangeHandler: (fn) => { changeHandler = typeof fn === 'function' ? fn : () => {}; },
       setFromMarkdown,
       buildMarkdown,
+      clear,
       updateSummary,
       applySectionDescriptions
     };
@@ -1350,6 +1364,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const setFrontMatterVisible = (visible) => {
     frontMatterVisible = !!visible;
+    if (!frontMatterVisible && frontMatterManager && typeof frontMatterManager.clear === 'function') frontMatterManager.clear();
     const commonSection = document.getElementById('frontMatterCommonSection');
     const extraSection = document.getElementById('frontMatterExtraSection');
     if (commonSection) commonSection.hidden = !frontMatterVisible;

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -1057,6 +1057,155 @@ document.addEventListener('DOMContentLoaded', () => {
   })();
 
   let frontMatterVisible = true;
+  let tabsMetadataVisible = false;
+  const tabsMetadataChangeListeners = new Set();
+
+  const tabsMetadataManager = (() => {
+    const panel = document.getElementById('frontMatterPanel');
+    const body = document.getElementById('frontMatterBody');
+    if (!panel || !body) return null;
+
+    const translate = (key, fallback) => {
+      if (!key) return fallback;
+      const translated = t(key);
+      if (translated == null || translated === key) return fallback != null ? fallback : key;
+      return translated;
+    };
+
+    const translateWithLocaleFallback = (key, fallbacks = {}) => {
+      const translated = translate(key, null);
+      if (translated != null && translated !== key) return translated;
+      let lang = 'en';
+      try {
+        lang = normalizeLangKey(getCurrentLang()) || 'en';
+      } catch (_) {
+        lang = 'en';
+      }
+      if (fallbacks[lang]) return fallbacks[lang];
+      if (lang === 'cht-hk' && fallbacks['cht-tw']) return fallbacks['cht-tw'];
+      if (lang.startsWith('cht') && fallbacks['cht-tw']) return fallbacks['cht-tw'];
+      if (lang.startsWith('ch') && fallbacks.chs) return fallbacks.chs;
+      if (lang.startsWith('ja') && fallbacks.ja) return fallbacks.ja;
+      return fallbacks.en || key;
+    };
+
+    const section = document.createElement('div');
+    section.className = 'frontmatter-section';
+    section.id = 'tabsMetadataSection';
+    section.hidden = true;
+
+    const head = document.createElement('div');
+    head.className = 'frontmatter-section-head';
+    const title = document.createElement('h3');
+    title.className = 'frontmatter-section-title';
+    title.textContent = translateWithLocaleFallback('editor.tabsMetadata.title', {
+      en: 'Page attributes',
+      chs: '页面属性',
+      'cht-tw': '頁面屬性',
+      'cht-hk': '頁面屬性',
+      ja: 'ページ属性'
+    });
+    const description = document.createElement('p');
+    description.className = 'frontmatter-section-description';
+    description.textContent = translateWithLocaleFallback('editor.tabsMetadata.description', {
+      en: 'Metadata stored in tabs.yaml for the current page language.',
+      chs: '当前页面语言在 tabs.yaml 中保存的元数据。',
+      'cht-tw': '目前頁面語言在 tabs.yaml 中儲存的中繼資料。',
+      'cht-hk': '目前頁面語言在 tabs.yaml 中儲存的中繼資料。',
+      ja: '現在のページ言語について tabs.yaml に保存されるメタデータ。'
+    });
+    head.append(title, description);
+
+    const grid = document.createElement('div');
+    grid.className = 'frontmatter-grid';
+
+    const field = document.createElement('div');
+    field.className = 'frontmatter-field frontmatter-field-text';
+    field.dataset.fieldId = 'tabs-title';
+
+    const fieldHead = document.createElement('div');
+    fieldHead.className = 'frontmatter-field-head';
+    const labelWrap = document.createElement('div');
+    labelWrap.className = 'frontmatter-field-label-wrap';
+    const label = document.createElement('span');
+    label.className = 'frontmatter-field-title';
+    label.textContent = translateWithLocaleFallback('editor.tabsMetadata.fields.title', {
+      en: 'Title',
+      chs: '标题',
+      'cht-tw': '標題',
+      'cht-hk': '標題',
+      ja: 'タイトル'
+    });
+    labelWrap.appendChild(label);
+    fieldHead.appendChild(labelWrap);
+
+    const controls = document.createElement('div');
+    controls.className = 'frontmatter-field-controls';
+    const input = document.createElement('input');
+    input.type = 'text';
+    controls.appendChild(input);
+    field.append(fieldHead, controls);
+    grid.appendChild(field);
+    section.append(head, grid);
+    body.appendChild(section);
+
+    let suppressEvents = false;
+    let changeHandler = () => {};
+    let state = { title: '' };
+
+    const getState = () => ({ title: state.title || '' });
+
+    const emitChange = () => {
+      try { changeHandler(getState()); }
+      catch (_) {}
+    };
+
+    input.addEventListener('input', () => {
+      if (suppressEvents) return;
+      state = { title: input.value };
+      emitChange();
+    });
+
+    return {
+      panel,
+      section,
+      setVisible: (visible) => {
+        section.hidden = !visible;
+      },
+      setChangeHandler: (fn) => {
+        changeHandler = typeof fn === 'function' ? fn : () => {};
+      },
+      setValue: (value, opts = {}) => {
+        const nextTitle = value && typeof value === 'object'
+          ? String(value.title || '')
+          : String(value || '');
+        state = { title: nextTitle };
+        suppressEvents = true;
+        try {
+          input.value = nextTitle;
+        } finally {
+          suppressEvents = false;
+        }
+        if (!opts.silent) emitChange();
+      }
+    };
+  })();
+
+  const updateMetadataPanelVisibility = () => {
+    const panel = (frontMatterManager && frontMatterManager.panel) || (tabsMetadataManager && tabsMetadataManager.panel);
+    if (!panel) return;
+    const visible = !!frontMatterVisible || !!tabsMetadataVisible;
+    panel.hidden = !visible;
+    panel.dataset.state = visible ? 'ready' : 'hidden';
+    panel.dataset.frontmatterVisible = frontMatterVisible ? 'true' : 'false';
+    panel.dataset.tabsMetadataVisible = tabsMetadataVisible ? 'true' : 'false';
+    panel.dataset.tabsVisible = tabsMetadataVisible ? 'true' : 'false';
+    panel.setAttribute('aria-hidden', visible ? 'false' : 'true');
+    panel.style.display = visible ? '' : 'none';
+    if (tabsMetadataManager && typeof tabsMetadataManager.setVisible === 'function') {
+      tabsMetadataManager.setVisible(tabsMetadataVisible);
+    }
+  };
 
   const normalizeCurrentFilePathForMode = (path) => {
     const raw = String(path || '').trim().replace(/\\+/g, '/').replace(/^\/+/, '');
@@ -1079,12 +1228,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const setFrontMatterVisible = (visible) => {
     frontMatterVisible = !!visible;
-    const panel = frontMatterManager && frontMatterManager.panel;
-    if (!panel) return;
-    panel.hidden = !frontMatterVisible;
-    panel.dataset.frontmatterVisible = frontMatterVisible ? 'true' : 'false';
-    panel.setAttribute('aria-hidden', frontMatterVisible ? 'false' : 'true');
-    panel.style.display = frontMatterVisible ? '' : 'none';
+    const commonSection = document.getElementById('frontMatterCommonSection');
+    const extraSection = document.getElementById('frontMatterExtraSection');
+    if (commonSection) commonSection.hidden = !frontMatterVisible;
+    if (extraSection) extraSection.hidden = !frontMatterVisible;
+    updateMetadataPanelVisibility();
+  };
+
+  const setTabsMetadataVisible = (visible) => {
+    tabsMetadataVisible = !!visible;
+    updateMetadataPanelVisibility();
   };
 
   const changeListeners = new Set();
@@ -1100,6 +1253,16 @@ document.addEventListener('DOMContentLoaded', () => {
       notifyChange();
     });
   }
+
+  if (tabsMetadataManager) {
+    tabsMetadataManager.setChangeHandler((value) => {
+      tabsMetadataChangeListeners.forEach((fn) => {
+        try { fn(value); } catch (_) {}
+      });
+    });
+  }
+
+  updateMetadataPanelVisibility();
 
   const handleAssetPreviewEvent = (event) => {
     if (!event || !event.detail) return;
@@ -2293,6 +2456,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const assignCurrentFileLabel = (input) => {
     currentFileInfo = normalizeCurrentFilePayload(input);
     setFrontMatterVisible(currentFileInfo.source !== 'tabs');
+    setTabsMetadataVisible(currentFileInfo.source === 'tabs');
     previewAssetCurrentPath = normalizePreviewPath(currentFileInfo.path || '');
     renderCurrentFileIndicator();
     refreshPreviewAssetOverrides();
@@ -2397,10 +2561,16 @@ document.addEventListener('DOMContentLoaded', () => {
     setBaseDir: (dir) => setBaseDir(dir),
     setCurrentFileLabel: (label) => assignCurrentFileLabel(label),
     setFrontMatterVisible: (visible) => setFrontMatterVisible(visible),
+    setTabsMetadata: (value, opts = {}) => tabsMetadataManager && tabsMetadataManager.setValue(value, opts),
     onChange: (fn) => {
       if (typeof fn !== 'function') return () => {};
       changeListeners.add(fn);
       return () => { changeListeners.delete(fn); };
+    },
+    onTabsMetadataChange: (fn) => {
+      if (typeof fn !== 'function') return () => {};
+      tabsMetadataChangeListeners.add(fn);
+      return () => { tabsMetadataChangeListeners.delete(fn); };
     },
     refreshPreview: () => { renderPreview(getValue()); },
     requestLayout: () => { requestLayout(); },

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -68,6 +68,123 @@ const getContentRootPrefix = () => {
   }
 };
 
+function syncFrontMatterLabelWidth(root) {
+  if (!root || typeof root.querySelectorAll !== 'function') return;
+  try {
+    if (typeof root.__nsFrontMatterLabelWidthCleanup === 'function') root.__nsFrontMatterLabelWidthCleanup();
+  } catch (_) {}
+  try { root.__nsFrontMatterLabelWidthCleanup = null; } catch (_) {}
+
+  const labels = Array.from(root.querySelectorAll('.frontmatter-field-title'));
+  if (!labels.length) {
+    try { root.style.removeProperty('--frontmatter-single-label-width'); } catch (_) {}
+    return;
+  }
+
+  let frame = 0;
+  let observer = null;
+  const requestFrame = (fn) => {
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      return window.requestAnimationFrame(fn);
+    }
+    if (typeof requestAnimationFrame === 'function') return requestAnimationFrame(fn);
+    return setTimeout(fn, 0);
+  };
+  const cancelFrame = (id) => {
+    if (!id) return;
+    if (typeof window !== 'undefined' && typeof window.cancelAnimationFrame === 'function') {
+      window.cancelAnimationFrame(id);
+      return;
+    }
+    if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(id);
+    else clearTimeout(id);
+  };
+  const measureLabelText = (label) => {
+    let width = label.scrollWidth || 0;
+    try {
+      const doc = label.ownerDocument || document;
+      if (!doc || !doc.body) return width;
+      const probe = doc.createElement('span');
+      probe.textContent = label.textContent || '';
+      probe.style.position = 'absolute';
+      probe.style.visibility = 'hidden';
+      probe.style.pointerEvents = 'none';
+      probe.style.whiteSpace = 'nowrap';
+      probe.style.left = '-9999px';
+      probe.style.top = '0';
+      const sourceStyle = typeof window !== 'undefined' && typeof window.getComputedStyle === 'function'
+        ? window.getComputedStyle(label)
+        : null;
+      if (sourceStyle) {
+        probe.style.fontFamily = sourceStyle.fontFamily;
+        probe.style.fontSize = sourceStyle.fontSize;
+        probe.style.fontStyle = sourceStyle.fontStyle;
+        probe.style.fontWeight = sourceStyle.fontWeight;
+        probe.style.letterSpacing = sourceStyle.letterSpacing;
+        probe.style.textTransform = sourceStyle.textTransform;
+      }
+      doc.body.appendChild(probe);
+      width = Math.max(width, probe.scrollWidth || Math.ceil(probe.getBoundingClientRect().width) || 0);
+      probe.remove();
+    } catch (_) {}
+    return width;
+  };
+  const measure = () => {
+    frame = 0;
+    let width = 88;
+    labels.forEach((label) => {
+      const target = label.closest ? label.closest('.frontmatter-field-label-wrap') : label;
+      let measured = 0;
+      try {
+        const tooltip = target && target.querySelector ? target.querySelector('.frontmatter-help-tooltip') : null;
+        const tooltipWidth = tooltip ? tooltip.scrollWidth || 0 : 0;
+        const labelWidth = measureLabelText(label);
+        const targetStyle = typeof window !== 'undefined' && typeof window.getComputedStyle === 'function'
+          ? window.getComputedStyle(target || label)
+          : null;
+        const gap = targetStyle ? parseFloat(targetStyle.gap || targetStyle.columnGap || '0') || 0 : 0;
+        measured = labelWidth + tooltipWidth + gap;
+      } catch (_) {
+        try {
+          const tooltip = target && target.querySelector ? target.querySelector('.frontmatter-help-tooltip') : null;
+          measured = measureLabelText(label) + (tooltip ? tooltip.scrollWidth || 0 : 0);
+        } catch (_) {}
+      }
+      width = Math.max(width, measured);
+    });
+    try { root.style.setProperty('--frontmatter-single-label-width', `${Math.ceil(width)}px`); } catch (_) {}
+  };
+  const schedule = () => {
+    if (frame) return;
+    frame = requestFrame(measure);
+  };
+
+  if (typeof ResizeObserver === 'function') {
+    try {
+      observer = new ResizeObserver(schedule);
+      observer.observe(root);
+      labels.forEach((label) => {
+        const cell = label.closest ? label.closest('.frontmatter-field-label-wrap') : label;
+        observer.observe(cell || label);
+      });
+    } catch (_) {
+      observer = null;
+    }
+  }
+
+  try {
+    if (document.fonts && typeof document.fonts.ready?.then === 'function') document.fonts.ready.then(schedule).catch(() => {});
+  } catch (_) {}
+  schedule();
+
+  root.__nsFrontMatterLabelWidthCleanup = () => {
+    cancelFrame(frame);
+    frame = 0;
+    try { if (observer) observer.disconnect(); } catch (_) {}
+    observer = null;
+  };
+}
+
 const safePreviewMime = (mime) => {
   try {
     const raw = String(mime || '').trim().toLowerCase();
@@ -993,6 +1110,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (parent) parent.appendChild(entry.container);
       });
       if (extraSection) extraSection.hidden = false;
+      syncFrontMatterLabelWidth(panel);
     };
 
     const updateSummary = () => {
@@ -1014,6 +1132,7 @@ document.addEventListener('DOMContentLoaded', () => {
         applyValueToEntry(entry, state.data[nextKey]);
       });
       updateSummary();
+      syncFrontMatterLabelWidth(panel);
     };
 
     const setFromMarkdown = (raw, opts = {}) => {
@@ -1045,6 +1164,7 @@ document.addEventListener('DOMContentLoaded', () => {
     ensureBaseFields();
     updateSummary();
     applySectionDescriptions();
+    syncFrontMatterLabelWidth(panel);
 
     return {
       panel,
@@ -1148,6 +1268,7 @@ document.addEventListener('DOMContentLoaded', () => {
     grid.appendChild(field);
     section.append(head, grid);
     body.appendChild(section);
+    syncFrontMatterLabelWidth(panel);
 
     let suppressEvents = false;
     let changeHandler = () => {};
@@ -1205,6 +1326,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (tabsMetadataManager && typeof tabsMetadataManager.setVisible === 'function') {
       tabsMetadataManager.setVisible(tabsMetadataVisible);
     }
+    syncFrontMatterLabelWidth(panel);
   };
 
   const normalizeCurrentFilePathForMode = (path) => {
@@ -1896,6 +2018,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (frontMatterManager) {
       frontMatterManager.updateSummary();
       frontMatterManager.applySectionDescriptions();
+      syncFrontMatterLabelWidth(frontMatterManager.panel);
     }
   });
 

--- a/index_editor.html
+++ b/index_editor.html
@@ -869,7 +869,7 @@
       width:100%;
     }
     .frontmatter-panel[data-state="hidden"] { display: none; }
-    .frontmatter-panel[data-frontmatter-visible="false"] { display: none !important; }
+    .frontmatter-panel[data-frontmatter-visible="false"][data-tabs-visible="false"] { display: none !important; }
     .frontmatter-body {
       display: flex;
       flex-direction: column;
@@ -1976,9 +1976,9 @@
       updateOffset();
     })();
   </script>
-  <script type="module" src="assets/js/editor-boot.js?v=editor-system-sync-20260430a"></script>
-  <script type="module" src="assets/js/editor-main.js?v=editor-system-sync-20260430a"></script>
-  <script type="module" src="assets/js/composer.js?v=editor-system-sync-20260430a"></script>
+  <script type="module" src="assets/js/editor-boot.js?v=editor-tabs-meta-20260501a"></script>
+  <script type="module" src="assets/js/editor-main.js?v=editor-tabs-meta-20260501a"></script>
+  <script type="module" src="assets/js/composer.js?v=editor-tabs-meta-20260501a"></script>
   <!-- Back to top button -->
   <button id="backToTop" class="back-to-top" aria-label="返回顶部" title="返回顶部" type="button" hidden>
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/index_editor.html
+++ b/index_editor.html
@@ -244,14 +244,25 @@
     .editor-structure-row input, .editor-structure-row select { width:100%; min-width:0; height:2rem; border:1px solid var(--border); border-radius:6px; background:var(--card); color:var(--text); padding:.25rem .45rem; }
     .editor-structure-list { display:flex; flex-direction:column; gap:.4rem; }
     .editor-structure-item { display:grid; grid-template-columns:minmax(0, 1fr) auto; align-items:center; gap:.5rem; padding:.4rem .55rem; border:1px solid color-mix(in srgb, var(--border) 88%, transparent); border-radius:8px; background:color-mix(in srgb, var(--text) 2%, transparent); }
+    .editor-structure-item--draggable { grid-template-columns:1.95rem minmax(0, 1fr) auto; }
+    .editor-structure-item--draggable.is-dragging { pointer-events:none; background:color-mix(in srgb, var(--card) 98%, transparent); box-shadow:0 14px 30px rgba(15,23,42,0.16),0 4px 12px rgba(15,23,42,0.12); }
     .editor-structure-item-main { min-width:0; display:flex; flex-direction:column; gap:.1rem; }
     .editor-structure-item-title { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-weight:700; color:var(--text); }
     .editor-structure-item-meta { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--muted); font-size:.82rem; }
     .editor-structure-item-actions { display:flex; gap:.35rem; flex-wrap:wrap; justify-content:flex-end; }
+    .editor-structure-drag-handle { width:1.95rem; min-height:2.2rem; display:inline-flex; flex-direction:column; align-items:center; justify-content:center; gap:.16rem; padding:.25rem .45rem; border:0; background:transparent; border-radius:8px; cursor:grab; touch-action:none; color:color-mix(in srgb, var(--muted) 86%, transparent); box-sizing:border-box; user-select:none; }
+    .editor-structure-drag-handle:hover { background:color-mix(in srgb, var(--text) 4%, transparent); }
+    .editor-structure-drag-handle:focus-visible { outline:2px solid color-mix(in srgb, var(--primary) 36%, transparent); outline-offset:2px; background:color-mix(in srgb, var(--primary) 8%, transparent); }
+    .editor-structure-drag-handle:active { cursor:grabbing; }
+    .editor-structure-drag-handle span { display:block; width:.9rem; height:1px; border-radius:999px; background:currentColor; }
+    .editor-structure-item--draggable.is-dragging .editor-structure-drag-handle { background:color-mix(in srgb, var(--primary) 12%, transparent); color:color-mix(in srgb, var(--primary) 92%, var(--text)); }
+    .editor-structure-drop-placeholder { border:1px dashed color-mix(in srgb, var(--primary) 48%, var(--border)); border-radius:10px; background:color-mix(in srgb, var(--primary) 8%, transparent); min-height:2.2rem; box-sizing:border-box; }
     .site-settings-title { font-size:1rem; color:var(--text); }
     @media (max-width: 980px) {
       .editor-structure-row { grid-template-columns:1fr; }
       .editor-structure-actions, .editor-structure-item-actions { justify-content:flex-start; }
+      .editor-structure-item--draggable { grid-template-columns:1.95rem minmax(0, 1fr); }
+      .editor-structure-item--draggable .editor-structure-item-actions { grid-column:1 / -1; padding-left:calc(1.95rem + .5rem); }
     }
     @media (prefers-reduced-motion: reduce) {
       .editor-structure-panel.is-content-entering .editor-structure-head,

--- a/index_editor.html
+++ b/index_editor.html
@@ -1031,6 +1031,9 @@
       flex-direction: column;
       gap: 0.6rem;
     }
+    .frontmatter-section[hidden] {
+      display: none !important;
+    }
     .frontmatter-section-head {
       display: flex;
       align-items: baseline;

--- a/index_editor.html
+++ b/index_editor.html
@@ -888,7 +888,7 @@
       margin: 0;
       padding: 0;
       display: grid;
-      grid-template-columns: minmax(88px, 88px) minmax(0, var(--frontmatter-single-control-width));
+      grid-template-columns: var(--frontmatter-single-label-width, 88px) minmax(0, var(--frontmatter-single-control-width));
       align-items: center;
       justify-content: start;
       column-gap: var(--frontmatter-row-column-gap);

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -297,20 +297,32 @@ assert.doesNotMatch(
 
 assert.match(
   editorSource,
-  /\.frontmatter-panel\[data-frontmatter-visible="false"\] \{ display: none !important; \}/,
-  'front matter panel should have a hard hidden state for page markdown files'
+  /\.frontmatter-panel\[data-frontmatter-visible="false"\]\[data-tabs-visible="false"\] \{ display: none !important; \}/,
+  'front matter panel should only fully hide when neither article nor tabs metadata is active'
 );
 
 assert.match(
   editorMainSource,
-  /let frontMatterVisible = true;[\s\S]*const inferCurrentFileSource = \(path\) => \{[\s\S]*normalized\.startsWith\('tab\/'\) \? 'tabs' : '';[\s\S]*const setFrontMatterVisible = \(visible\) => \{[\s\S]*panel\.dataset\.frontmatterVisible = frontMatterVisible \? 'true' : 'false';[\s\S]*panel\.style\.display = frontMatterVisible \? '' : 'none';[\s\S]*setFrontMatterVisible\(currentFileInfo\.source !== 'tabs'\);/,
-  'markdown editor should hide the front matter panel for tabs.yaml page markdown files'
+  /let frontMatterVisible = true;[\s\S]*let tabsMetadataVisible = false;[\s\S]*const inferCurrentFileSource = \(path\) => \{[\s\S]*normalized\.startsWith\('tab\/'\) \? 'tabs' : '';[\s\S]*const setFrontMatterVisible = \(visible\) => \{[\s\S]*frontMatterVisible = !!visible;[\s\S]*updateMetadataPanelVisibility\(\);[\s\S]*const setTabsMetadataVisible = \(visible\) => \{[\s\S]*tabsMetadataVisible = !!visible;[\s\S]*updateMetadataPanelVisibility\(\);[\s\S]*assignCurrentFileLabel = \(input\) => \{[\s\S]*setFrontMatterVisible\(currentFileInfo\.source !== 'tabs'\);[\s\S]*setTabsMetadataVisible\(currentFileInfo\.source === 'tabs'\);/,
+  'markdown editor should swap between article front matter and tabs metadata visibility by file source'
 );
 
 assert.match(
   editorMainSource,
   /const getValue = \(\) => \{[\s\S]*if \(frontMatterVisible && frontMatterManager\) return frontMatterManager\.buildMarkdown\(body\);[\s\S]*const setValue = \(value, opts = \{\}\) => \{[\s\S]*if \(frontMatterVisible && frontMatterManager\) \{/,
   'page markdown should bypass front matter parsing and rebuilding while the panel is hidden'
+);
+
+assert.match(
+  editorMainSource,
+  /const tabsMetadataManager = \(\(\) => \{[\s\S]*className = 'frontmatter-section';[\s\S]*className = 'frontmatter-grid';[\s\S]*className = 'frontmatter-field frontmatter-field-text';[\s\S]*dataset\.fieldId = 'tabs-title';[\s\S]*setChangeHandler: \(fn\) => \{[\s\S]*setValue: \(value, opts = \{\}\) => \{[\s\S]*emitChange\(\);/,
+  'markdown editor should define a tabs metadata manager that reuses the frontmatter panel shell and field styling'
+);
+
+assert.match(
+  editorMainSource,
+  /const primaryEditorApi = \{[\s\S]*setTabsMetadata: \(value, opts = \{\}\) => tabsMetadataManager && tabsMetadataManager\.setValue\(value, opts\),[\s\S]*onTabsMetadataChange: \(fn\) => \{[\s\S]*tabsMetadataChangeListeners\.add\(fn\);/,
+  'primary editor API should expose tabs metadata setters and change subscriptions'
 );
 
 assert.match(
@@ -323,6 +335,12 @@ assert.match(
   source,
   /source: tab\.source \|\| inferMarkdownSourceFromPath\(tab\.path\),[\s\S]*source: inferMarkdownSourceFromPath\(normalized\),/,
   'composer should pass the inferred markdown source to the primary editor'
+);
+
+assert.match(
+  source,
+  /if \(!api \|\| typeof api\.onTabsMetadataChange !== 'function'\) return;[\s\S]*detachPrimaryEditorTabsMetadataListener = api\.onTabsMetadataChange\(\(metadata\) => \{[\s\S]*if \(tab && tab\.source === 'tabs'\) \{[\s\S]*updateTabsEntryTitleFromPath\(tab\.path, metadata\);/,
+  'composer should subscribe to tabs metadata changes and write title edits back into tabs state'
 );
 
 assert.match(
@@ -853,6 +871,12 @@ assert.match(
   source,
   /if \(node\.source === 'index' \|\| node\.source === 'tabs'\) \{[\s\S]*node\.children\.forEach\(\(child, index\) => \{[\s\S]*renderStructureDraggableItem\(child, `\$\{child\.children\.length\} \$\{treeText\('languages', 'languages'\)\}`, index, node\.source\)/,
   'articles and pages root panels should both use draggable structure rows'
+);
+
+assert.doesNotMatch(
+  source,
+  /class="ct-field ct-field-title"|const titleLabel = tComposerLang\('fields\.title'\)|const titleInput = \$\('\.ct-title', block\)|entry\[lang\]\.title = e\.target\.value/,
+  'page entry structure rows should no longer render editable title inputs once title moves into the markdown editor metadata panel'
 );
 
 assert.doesNotMatch(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -243,8 +243,14 @@ assert.match(
 
 assert.match(
   editorSource,
-  /\.frontmatter-panel \{[\s\S]*border: 0;[\s\S]*background: transparent;[\s\S]*\.frontmatter-grid \{[\s\S]*--frontmatter-row-gap: 0\.35rem;[\s\S]*display: flex;[\s\S]*gap: var\(--frontmatter-row-gap\);[\s\S]*\.frontmatter-field \{[\s\S]*padding: 0;[\s\S]*display: grid;[\s\S]*grid-template-columns: minmax\(88px, 88px\) minmax\(0, var\(--frontmatter-single-control-width\)\);/,
-  'front matter fields should use compact Site Settings-style label/control rows'
+  /\.frontmatter-panel \{[\s\S]*border: 0;[\s\S]*background: transparent;[\s\S]*\.frontmatter-grid \{[\s\S]*--frontmatter-row-gap: 0\.35rem;[\s\S]*display: flex;[\s\S]*gap: var\(--frontmatter-row-gap\);[\s\S]*\.frontmatter-field \{[\s\S]*padding: 0;[\s\S]*display: grid;[\s\S]*grid-template-columns: var\(--frontmatter-single-label-width, 88px\) minmax\(0, var\(--frontmatter-single-control-width\)\);/,
+  'front matter fields should use compact Site Settings-style rows with measured label width'
+);
+
+assert.doesNotMatch(
+  editorSource,
+  /\.frontmatter-field \{[\s\S]*grid-template-columns: minmax\(88px, 88px\) minmax\(0, var\(--frontmatter-single-control-width\)\);/,
+  'front matter label column should not stay fixed to the old 88px width'
 );
 
 assert.match(
@@ -263,6 +269,42 @@ assert.match(
   editorMainSource,
   /head\.className = 'frontmatter-field-head';[\s\S]*labelWrap\.className = 'frontmatter-field-label-wrap';[\s\S]*labelSpan\.className = 'frontmatter-field-title';[\s\S]*controls\.className = 'frontmatter-field-controls';[\s\S]*controls\.appendChild\([\s\S]*entry\.container\.appendChild\(controls\);/,
   'front matter field DOM should include field head, label wrap, and controls wrapper'
+);
+
+assert.match(
+  editorMainSource,
+  /function syncFrontMatterLabelWidth\(root\) \{[\s\S]*querySelectorAll\('\.frontmatter-field-title'\)[\s\S]*requestAnimationFrame[\s\S]*ResizeObserver/,
+  'front matter labels should be measured after render and shared through a CSS variable'
+);
+
+assert.match(
+  editorMainSource,
+  /function syncFrontMatterLabelWidth\(root\) \{[\s\S]*root\.style\.setProperty\('--frontmatter-single-label-width'/,
+  'front matter label measurement should write the shared label width CSS variable'
+);
+
+assert.match(
+  editorMainSource,
+  /const measureLabelText = \(label\) => \{[\s\S]*label\.scrollWidth[\s\S]*probe\.textContent = label\.textContent \|\| '';[\s\S]*probe\.style\.whiteSpace = 'nowrap';/,
+  'front matter label measurement should probe intrinsic text width when current layout is constrained'
+);
+
+assert.match(
+  editorMainSource,
+  /querySelector\('\.frontmatter-help-tooltip'\)[\s\S]*measureLabelText\(label\)[\s\S]*getComputedStyle\(target \|\| label\)[\s\S]*gap/,
+  'front matter label measurement should use intrinsic label width plus the visible help button and gap'
+);
+
+assert.match(
+  editorMainSource,
+  /document\.addEventListener\('ns-editor-language-applied'[\s\S]*frontMatterManager\.applySectionDescriptions\(\);[\s\S]*syncFrontMatterLabelWidth\(frontMatterManager\.panel\);/,
+  'front matter labels should resync after editor language changes update localized labels'
+);
+
+assert.match(
+  editorMainSource,
+  /const updateMetadataPanelVisibility = \(\) => \{[\s\S]*tabsMetadataManager\.setVisible\(tabsMetadataVisible\);[\s\S]*syncFrontMatterLabelWidth\(panel\);/,
+  'front matter labels should resync after article/page metadata visibility changes'
 );
 
 assert.doesNotMatch(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -423,7 +423,7 @@ assert.match(
 
 assert.match(
   source,
-  /\$\('\.ct-edit', block\)\.addEventListener\('click', \(\) => \{[\s\S]*const rel = normalizeRelPath\(locInput\.value\);[\s\S]*openMarkdownInEditor\(rel, \{[\s\S]*source: 'tabs',[\s\S]*key,[\s\S]*lang,[\s\S]*editorTreeNodeId: `tabs:\$\{key\}:\$\{lang\}`[\s\S]*\}\);/,
+  /\$\('\.ct-edit', block\)\.addEventListener\('click', \(\) => \{[\s\S]*const rel = normalizeRelPath\(v\.location\);[\s\S]*openMarkdownInEditor\(rel, \{[\s\S]*source: 'tabs',[\s\S]*key,[\s\S]*lang,[\s\S]*editorTreeNodeId: `tabs:\$\{key\}:\$\{lang\}`[\s\S]*\}\);/,
   'page list edit actions should pass tabs identity when opening the markdown editor'
 );
 
@@ -655,10 +655,10 @@ assert.match(
   'markdown editor should track a single active document instead of visible tab state'
 );
 
-assert.match(
+assert.doesNotMatch(
   source,
-  /treeText\('fieldTitle', 'Title'\)/,
-  'page language title fields should not reuse the tree heading translation key'
+  /function renderPageLanguageStructure\(key, lang, value\) \{[\s\S]*treeText\('fieldTitle', 'Title'\)/,
+  'page structure rows should no longer render a standalone title field label'
 );
 
 const initialBootIndex = source.indexOf('Apply initial state as early as possible');
@@ -967,6 +967,12 @@ assert.doesNotMatch(
   source,
   /class="ct-field ct-field-title"|const titleLabel = tComposerLang\('fields\.title'\)|const titleInput = \$\('\.ct-title', block\)|entry\[lang\]\.title = e\.target\.value/,
   'page entry structure rows should no longer render editable title inputs once title moves into the markdown editor metadata panel'
+);
+
+assert.doesNotMatch(
+  source,
+  /<input class="ct-loc"|const pathPlaceholder = tComposerLang\('placeholders\.tabPath'\)|const locInput = \$\('\.ct-loc', block\)|entry\[lang\]\.location = e\.target\.value/,
+  'page entry lists should no longer render editable location inputs for tabs languages'
 );
 
 assert.doesNotMatch(
@@ -1615,6 +1621,12 @@ assert.doesNotMatch(
   source,
   /const input = document\.createElement\('input'\);[\s\S]*input\.setAttribute\('aria-label', treeText\('location', 'Location'\)\);[\s\S]*main\.appendChild\(label\);[\s\S]*main\.appendChild\(input\);/,
   'article language structure panel should not render an editable location input for version rows'
+);
+
+assert.doesNotMatch(
+  source,
+  /function renderPageLanguageStructure\(key, lang, value\) \{[\s\S]*const titleInput = document\.createElement\('input'\);[\s\S]*const pathInput = document\.createElement\('input'\);[\s\S]*controls\.appendChild\(titleInput\);[\s\S]*controls\.appendChild\(pathInput\);/,
+  'page structure rows should not render editable title or location inputs'
 );
 
 assert.doesNotMatch(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -325,6 +325,30 @@ assert.match(
   'front matter labels should resync after article/page metadata visibility changes'
 );
 
+assert.match(
+  source,
+  /function getTabsMetadataForTab\(tab\) \{[\s\S]*tab\.tabsKey[\s\S]*tab\.tabsLang[\s\S]*getTabsEntry\(tab\.tabsKey\)[\s\S]*entry && entry\[tab\.tabsLang\][\s\S]*title/,
+  'tabs metadata reads should prefer the dynamic tab stable identity over path-only lookup'
+);
+
+assert.match(
+  source,
+  /function updateTabsEntryTitleForTab\(tab, metadata\) \{[\s\S]*tab\.tabsKey[\s\S]*tab\.tabsLang[\s\S]*getTabsEntry\(tab\.tabsKey\)[\s\S]*entry\[tab\.tabsLang\]\.title = nextTitle;/,
+  'tabs metadata writes should target the dynamic tab stable identity instead of the first matching path'
+);
+
+assert.match(
+  source,
+  /detachPrimaryEditorTabsMetadataListener = api\.onTabsMetadataChange\(\(metadata\) => \{[\s\S]*if \(tab && tab\.source === 'tabs'\) \{[\s\S]*updateTabsEntryTitleForTab\(tab, metadata\);/,
+  'tabs metadata bridge should write through the active dynamic tab identity'
+);
+
+assert.match(
+  source,
+  /const data = \{[\s\S]*path: normalized,[\s\S]*tabsKey:[\s\S]*tabsLang:[\s\S]*editorTreeNodeId:[\s\S]*lookupKey:/,
+  'dynamic markdown tabs should persist a stable identity for shared-path tabs content'
+);
+
 assert.doesNotMatch(
   editorSource,
   /\.frontmatter-field \+ \.frontmatter-field|frontmatter-pill|frontmatter-field-hint/,
@@ -393,13 +417,13 @@ assert.match(
 
 assert.match(
   source,
-  /source: tab\.source \|\| inferMarkdownSourceFromPath\(tab\.path\),[\s\S]*source: inferMarkdownSourceFromPath\(normalized\),/,
-  'composer should pass the inferred markdown source to the primary editor'
+  /function deriveDynamicTabIdentity\(path, options = \{\}\) \{[\s\S]*const source = String\(opts\.source \|\|[\s\S]*inferMarkdownSourceFromPath\(normalizedPath\)/,
+  'composer should preserve explicit file-source identity for dynamic markdown tabs'
 );
 
 assert.match(
   source,
-  /if \(!api \|\| typeof api\.onTabsMetadataChange !== 'function'\) return;[\s\S]*detachPrimaryEditorTabsMetadataListener = api\.onTabsMetadataChange\(\(metadata\) => \{[\s\S]*if \(tab && tab\.source === 'tabs'\) \{[\s\S]*updateTabsEntryTitleFromPath\(tab\.path, metadata\);/,
+  /if \(!api \|\| typeof api\.onTabsMetadataChange !== 'function'\) return;[\s\S]*detachPrimaryEditorTabsMetadataListener = api\.onTabsMetadataChange\(\(metadata\) => \{[\s\S]*if \(tab && tab\.source === 'tabs'\) \{[\s\S]*updateTabsEntryTitleForTab\(tab, metadata\);/,
   'composer should subscribe to tabs metadata changes and write title edits back into tabs state'
 );
 
@@ -643,13 +667,13 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /function getOrCreateDynamicMode\(path\) \{[\s\S]*button: null,[\s\S]*dynamicEditorTabs\.set\(modeId, data\);/,
+  /function getOrCreateDynamicMode\(path, options = \{\}\) \{[\s\S]*const identity = deriveDynamicTabIdentity\(path, options\);[\s\S]*const existing = dynamicEditorTabsByLookupKey\.get\(identity\.lookupKey\);[\s\S]*button: null,[\s\S]*dynamicEditorTabs\.set\(modeId, data\);[\s\S]*dynamicEditorTabsByLookupKey\.set\(identity\.lookupKey, modeId\);/,
   'markdown document state should no longer create visible dynamic tab buttons'
 );
 
 assert.match(
   source,
-  /function openMarkdownInEditor\(path\) \{[\s\S]*flushMarkdownDraft\(active\);[\s\S]*applyMode\(modeId\);/,
+  /function openMarkdownInEditor\(path, options = \{\}\) \{[\s\S]*flushMarkdownDraft\(active\);[\s\S]*const modeId = getOrCreateDynamicMode\(path, options\);[\s\S]*applyMode\(modeId\);/,
   'switching files from the tree should flush the current markdown draft before opening the next file'
 );
 
@@ -661,7 +685,7 @@ assert.match(
 
 assert.match(
   source,
-  /function restoreDynamicEditorState\(\) \{[\s\S]*const open = Array\.isArray\(data\.open\) \? data\.open : \[\];[\s\S]*getOrCreateDynamicMode\(norm\);[\s\S]*expandedEditorTreeNodeIds\.clear\(\);[\s\S]*const activePath = data\.activePath \? normalizeRelPath\(data\.activePath\) : '';[\s\S]*applyMode\(modeId, \{ preserveTreeExpansion: true, restoreScroll: true \}\);/,
+  /function restoreDynamicEditorState\(\) \{[\s\S]*const open = Array\.isArray\(data\.open\) \? data\.open : \[\];[\s\S]*getOrCreateDynamicMode\(norm\);[\s\S]*expandedEditorTreeNodeIds\.clear\(\);[\s\S]*const activePath = data\.activePath \? normalizeRelPath\(data\.activePath\) : '';[\s\S]*const modeId = dynamicEditorTabsByLookupKey\.get\(activePath\) \|\| getOrCreateDynamicMode\(activePath\);[\s\S]*applyMode\(modeId, \{ preserveTreeExpansion: true, restoreScroll: true \}\);/,
   'dynamic markdown session restore should recreate open files, exact expansion, and active file path'
 );
 

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -285,8 +285,8 @@ assert.match(
 
 assert.match(
   editorMainSource,
-  /const setFrontMatterVisible = \(visible\) => \{[\s\S]*frontMatterVisible = !!visible;[\s\S]*if \(!frontMatterVisible && frontMatterManager && typeof frontMatterManager\.clear === 'function'\) frontMatterManager\.clear\(\);[\s\S]*updateMetadataPanelVisibility\(\);[\s\S]*\};/,
-  'switching into page metadata mode should clear stale article front matter state before updating visibility'
+  /const setFrontMatterVisible = \(visible\) => \{[\s\S]*const nextVisible = !!visible;[\s\S]*const shouldClear = !nextVisible && frontMatterVisible;[\s\S]*frontMatterVisible = nextVisible;[\s\S]*if \(shouldClear && frontMatterManager && typeof frontMatterManager\.clear === 'function'\) frontMatterManager\.clear\(\);[\s\S]*updateMetadataPanelVisibility\(\);[\s\S]*\};/,
+  'switching into page metadata mode should clear stale article front matter state only on visibility transitions'
 );
 
 assert.match(
@@ -363,7 +363,7 @@ assert.match(
 
 assert.match(
   editorMainSource,
-  /let frontMatterVisible = true;[\s\S]*let tabsMetadataVisible = false;[\s\S]*const inferCurrentFileSource = \(path\) => \{[\s\S]*normalized\.startsWith\('tab\/'\) \? 'tabs' : '';[\s\S]*const setFrontMatterVisible = \(visible\) => \{[\s\S]*frontMatterVisible = !!visible;[\s\S]*updateMetadataPanelVisibility\(\);[\s\S]*const setTabsMetadataVisible = \(visible\) => \{[\s\S]*tabsMetadataVisible = !!visible;[\s\S]*updateMetadataPanelVisibility\(\);[\s\S]*assignCurrentFileLabel = \(input\) => \{[\s\S]*setFrontMatterVisible\(currentFileInfo\.source !== 'tabs'\);[\s\S]*setTabsMetadataVisible\(currentFileInfo\.source === 'tabs'\);/,
+  /let frontMatterVisible = true;[\s\S]*let tabsMetadataVisible = false;[\s\S]*const inferCurrentFileSource = \(path\) => \{[\s\S]*normalized\.startsWith\('tab\/'\) \? 'tabs' : '';[\s\S]*const setFrontMatterVisible = \(visible\) => \{[\s\S]*const nextVisible = !!visible;[\s\S]*const shouldClear = !nextVisible && frontMatterVisible;[\s\S]*frontMatterVisible = nextVisible;[\s\S]*if \(shouldClear && frontMatterManager && typeof frontMatterManager\.clear === 'function'\) frontMatterManager\.clear\(\);[\s\S]*updateMetadataPanelVisibility\(\);[\s\S]*const setTabsMetadataVisible = \(visible\) => \{[\s\S]*tabsMetadataVisible = !!visible;[\s\S]*updateMetadataPanelVisibility\(\);[\s\S]*assignCurrentFileLabel = \(input\) => \{[\s\S]*setFrontMatterVisible\(currentFileInfo\.source !== 'tabs'\);[\s\S]*setTabsMetadataVisible\(currentFileInfo\.source === 'tabs'\);/,
   'markdown editor should swap between article front matter and tabs metadata visibility by file source'
 );
 

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -822,19 +822,19 @@ assert.doesNotMatch(
 assert.match(
   source,
   /const moveStructureRootEntry = \(source, from, to\) => \{[\s\S]*const order = Array\.isArray\(state\.__order\) \? state\.__order : \[\];[\s\S]*const \[key\] = order\.splice\(from, 1\);[\s\S]*order\.splice\(to, 0, key\);[\s\S]*notifyComposerChange\(source\);[\s\S]*refreshEditorContentTree\(\);/,
-  'article structure panel should reorder the backing index order and refresh the content tree'
+  'structure panels should reorder the backing root order and refresh the content tree'
 );
 
 assert.match(
   source,
-  /const createStructureDragHandle = \(child, index\) => \{[\s\S]*handle\.className = 'editor-structure-drag-handle';[\s\S]*handle\.setAttribute\('aria-label', treeText\('reorderArticle', 'Reorder article'\)\);[\s\S]*handle\.addEventListener\('pointerdown',[\s\S]*handle\.addEventListener\('keydown',/,
-  'article structure rows should render a standalone drag handle with pointer and keyboard reorder hooks'
+  /const createStructureDragHandle = \(child, index, source\) => \{[\s\S]*const labelKey = source === 'tabs' \? 'reorderPage' : 'reorderArticle';[\s\S]*handle\.className = 'editor-structure-drag-handle';[\s\S]*handle\.setAttribute\('aria-label', treeText\(labelKey, source === 'tabs' \? 'Reorder page' : 'Reorder article'\)\);[\s\S]*handle\.addEventListener\('pointerdown',[\s\S]*handle\.addEventListener\('keydown',/,
+  'article and page structure rows should render a standalone drag handle with pointer and keyboard reorder hooks'
 );
 
 assert.match(
   source,
-  /const renderStructureDraggableItem = \(child, detail, index\) => \{[\s\S]*item\.className = 'editor-structure-item editor-structure-item--draggable';[\s\S]*const handle = createStructureDragHandle\(child, index\);[\s\S]*item\.append\(handle, main, controls\);/,
-  'article structure rows should compose handle, content, and actions as separate elements'
+  /const renderStructureDraggableItem = \(child, detail, index, source\) => \{[\s\S]*item\.className = 'editor-structure-item editor-structure-item--draggable';[\s\S]*const handle = createStructureDragHandle\(child, index, source\);[\s\S]*item\.append\(handle, main, controls\);/,
+  'article and page structure rows should compose handle, content, and actions as separate elements'
 );
 
 assert.match(
@@ -846,13 +846,19 @@ assert.match(
 assert.match(
   source,
   /const applyStructureDragPreview = \(clientY\) => \{[\s\S]*structureDragState\.dragItem\.style\.transform = `translate3d\(0, \$\{clientY - structureDragState\.startY\}px, 0\)`[\s\S]*animateStructureRows\(\(\) => \{/,
-  'article structure drag should move the dragged row with the pointer while previewing the drop position'
+  'structure drag should move the dragged row with the pointer while previewing the drop position'
+);
+
+assert.match(
+  source,
+  /if \(node\.source === 'index' \|\| node\.source === 'tabs'\) \{[\s\S]*node\.children\.forEach\(\(child, index\) => \{[\s\S]*renderStructureDraggableItem\(child, `\$\{child\.children\.length\} \$\{treeText\('languages', 'languages'\)\}`, index, node\.source\)/,
+  'articles and pages root panels should both use draggable structure rows'
 );
 
 assert.doesNotMatch(
   source,
   /editor-structure-item[^\\n]*addEventListener\('pointerdown'|item\.setAttribute\('draggable', 'true'\)|className = 'btn-secondary editor-structure-move'/,
-  'article structure reordering should not start from the whole row or restore legacy move buttons'
+  'structure reordering should not start from the whole row or restore legacy move buttons'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -417,8 +417,8 @@ assert.match(
 
 assert.match(
   source,
-  /function deriveDynamicTabIdentity\(path, options = \{\}\) \{[\s\S]*const source = String\(opts\.source \|\|[\s\S]*inferMarkdownSourceFromPath\(normalizedPath\)/,
-  'composer should preserve explicit file-source identity for dynamic markdown tabs'
+  /function deriveDynamicTabIdentity\(path, options = \{\}\) \{[\s\S]*const explicitLookupKey = String\(opts\.lookupKey \|\| ''\)\.trim\(\);[\s\S]*const source = String\([\s\S]*opts\.source[\s\S]*inferMarkdownSourceFromPath\(normalizedPath\)[\s\S]*const lookupKey = explicitLookupKey \|\| \(\(source === 'tabs' && key && lang\)/,
+  'composer should preserve explicit file-source identity and persisted lookup keys for dynamic markdown tabs'
 );
 
 assert.match(
@@ -679,14 +679,14 @@ assert.match(
 
 assert.match(
   source,
-  /function persistDynamicEditorState\(\) \{[\s\S]*const open = Array\.from\(dynamicEditorTabs\.values\(\)\)[\s\S]*v: EDITOR_STATE_VERSION,[\s\S]*activePath: active && active\.path \? active\.path : null,[\s\S]*expandedNodeIds: Array\.from\(expandedEditorTreeNodeIds\)\.filter\(Boolean\),/,
-  'dynamic markdown session state should persist opened files, active file path, and exact tree expansion'
+  /function persistDynamicEditorState\(\) \{[\s\S]*const open = Array\.from\(dynamicEditorTabs\.values\(\)\)[\s\S]*lookupKey: tab\.lookupKey \|\| tab\.path,[\s\S]*path: tab\.path,[\s\S]*activeLookupKey: active && \(active\.lookupKey \|\| active\.path\) \? \(active\.lookupKey \|\| active\.path\) : null,[\s\S]*activePath: active && active\.path \? active\.path : null,[\s\S]*expandedNodeIds: Array\.from\(expandedEditorTreeNodeIds\)\.filter\(Boolean\),/,
+  'dynamic markdown session state should persist opened files with stable lookup keys, plus active file identity and exact tree expansion'
 );
 
 assert.match(
   source,
-  /function restoreDynamicEditorState\(\) \{[\s\S]*const open = Array\.isArray\(data\.open\) \? data\.open : \[\];[\s\S]*getOrCreateDynamicMode\(norm\);[\s\S]*expandedEditorTreeNodeIds\.clear\(\);[\s\S]*const activePath = data\.activePath \? normalizeRelPath\(data\.activePath\) : '';[\s\S]*const modeId = dynamicEditorTabsByLookupKey\.get\(activePath\) \|\| getOrCreateDynamicMode\(activePath\);[\s\S]*applyMode\(modeId, \{ preserveTreeExpansion: true, restoreScroll: true \}\);/,
-  'dynamic markdown session restore should recreate open files, exact expansion, and active file path'
+  /function restoreDynamicEditorState\(\) \{[\s\S]*const open = Array\.isArray\(data\.open\) \? data\.open : \[\];[\s\S]*const lookupKey = item && typeof item === 'object'[\s\S]*const path = item && typeof item === 'object'[\s\S]*getOrCreateDynamicMode\(path, \{[\s\S]*source:[\s\S]*key:[\s\S]*lang:[\s\S]*editorTreeNodeId:[\s\S]*lookupKey[\s\S]*\}\);[\s\S]*expandedEditorTreeNodeIds\.clear\(\);[\s\S]*const activeLookupKey = String\(data\.activeLookupKey \|\| ''\)\.trim\(\);[\s\S]*const activePath = data\.activePath \? normalizeRelPath\(data\.activePath\) : '';[\s\S]*if \(\(isV3 \? data\.mode === 'markdown' : true\) && \(activeLookupKey \|\| activePath\)\) \{[\s\S]*const modeId = \(activeLookupKey && dynamicEditorTabsByLookupKey\.get\(activeLookupKey\)\)[\s\S]*\|\| \(activePath && dynamicEditorTabsByLookupKey\.get\(activePath\)\)[\s\S]*\|\| \(activePath \? getOrCreateDynamicMode\(activePath\) : null\);[\s\S]*applyMode\(modeId, \{ preserveTreeExpansion: true, restoreScroll: true \}\);/,
+  'dynamic markdown session restore should recreate open files and active file identity with stable lookup keys'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -423,6 +423,12 @@ assert.match(
 
 assert.match(
   source,
+  /\$\('\.ct-edit', block\)\.addEventListener\('click', \(\) => \{[\s\S]*const rel = normalizeRelPath\(locInput\.value\);[\s\S]*openMarkdownInEditor\(rel, \{[\s\S]*source: 'tabs',[\s\S]*key,[\s\S]*lang,[\s\S]*editorTreeNodeId: `tabs:\$\{key\}:\$\{lang\}`[\s\S]*\}\);/,
+  'page list edit actions should pass tabs identity when opening the markdown editor'
+);
+
+assert.match(
+  source,
   /if \(!api \|\| typeof api\.onTabsMetadataChange !== 'function'\) return;[\s\S]*detachPrimaryEditorTabsMetadataListener = api\.onTabsMetadataChange\(\(metadata\) => \{[\s\S]*if \(tab && tab\.source === 'tabs'\) \{[\s\S]*updateTabsEntryTitleForTab\(tab, metadata\);/,
   'composer should subscribe to tabs metadata changes and write title edits back into tabs state'
 );

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -261,6 +261,12 @@ assert.match(
 
 assert.match(
   editorSource,
+  /\.frontmatter-section\[hidden\]\s*\{\s*display:\s*none\s*!important;\s*\}/,
+  'front matter sections should honor hidden state so page files can suppress article-only metadata groups'
+);
+
+assert.match(
+  editorSource,
   /frontMatterCommonSection[\s\S]*frontmatter-section-head[\s\S]*data-i18n="editor\.frontMatter\.commonDescription"[\s\S]*frontMatterExtraSection[\s\S]*frontmatter-section-head[\s\S]*data-i18n="editor\.frontMatter\.advancedDescription"/,
   'front matter common and advanced sections should include localized section descriptions'
 );
@@ -269,6 +275,18 @@ assert.match(
   editorMainSource,
   /head\.className = 'frontmatter-field-head';[\s\S]*labelWrap\.className = 'frontmatter-field-label-wrap';[\s\S]*labelSpan\.className = 'frontmatter-field-title';[\s\S]*controls\.className = 'frontmatter-field-controls';[\s\S]*controls\.appendChild\([\s\S]*entry\.container\.appendChild\(controls\);/,
   'front matter field DOM should include field head, label wrap, and controls wrapper'
+);
+
+assert.match(
+  editorMainSource,
+  /const clear = \(\) => \{[\s\S]*state = \{[\s\S]*data:\s*\{\}[\s\S]*hasFrontMatter:\s*false[\s\S]*rebuildBindings\(\);[\s\S]*\};[\s\S]*return \{[\s\S]*clear,/,
+  'front matter manager should expose a clear helper to reset stale article metadata state'
+);
+
+assert.match(
+  editorMainSource,
+  /const setFrontMatterVisible = \(visible\) => \{[\s\S]*frontMatterVisible = !!visible;[\s\S]*if \(!frontMatterVisible && frontMatterManager && typeof frontMatterManager\.clear === 'function'\) frontMatterManager\.clear\(\);[\s\S]*updateMetadataPanelVisibility\(\);[\s\S]*\};/,
+  'switching into page metadata mode should clear stale article front matter state before updating visibility'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -821,6 +821,42 @@ assert.doesNotMatch(
 
 assert.match(
   source,
+  /const moveStructureRootEntry = \(source, from, to\) => \{[\s\S]*const order = Array\.isArray\(state\.__order\) \? state\.__order : \[\];[\s\S]*const \[key\] = order\.splice\(from, 1\);[\s\S]*order\.splice\(to, 0, key\);[\s\S]*notifyComposerChange\(source\);[\s\S]*refreshEditorContentTree\(\);/,
+  'article structure panel should reorder the backing index order and refresh the content tree'
+);
+
+assert.match(
+  source,
+  /const createStructureDragHandle = \(child, index\) => \{[\s\S]*handle\.className = 'editor-structure-drag-handle';[\s\S]*handle\.setAttribute\('aria-label', treeText\('reorderArticle', 'Reorder article'\)\);[\s\S]*handle\.addEventListener\('pointerdown',[\s\S]*handle\.addEventListener\('keydown',/,
+  'article structure rows should render a standalone drag handle with pointer and keyboard reorder hooks'
+);
+
+assert.match(
+  source,
+  /const renderStructureDraggableItem = \(child, detail, index\) => \{[\s\S]*item\.className = 'editor-structure-item editor-structure-item--draggable';[\s\S]*const handle = createStructureDragHandle\(child, index\);[\s\S]*item\.append\(handle, main, controls\);/,
+  'article structure rows should compose handle, content, and actions as separate elements'
+);
+
+assert.match(
+  source,
+  /const createStructureDragPlaceholder = \(item\) => \{[\s\S]*placeholder\.className = 'editor-structure-drop-placeholder';[\s\S]*placeholder\.style\.height = `\$\{itemRect\.height\}px`;/,
+  'article structure drag should create an in-list placeholder matching the dragged row height'
+);
+
+assert.match(
+  source,
+  /const applyStructureDragPreview = \(clientY\) => \{[\s\S]*structureDragState\.dragItem\.style\.transform = `translate3d\(0, \$\{clientY - structureDragState\.startY\}px, 0\)`[\s\S]*animateStructureRows\(\(\) => \{/,
+  'article structure drag should move the dragged row with the pointer while previewing the drop position'
+);
+
+assert.doesNotMatch(
+  source,
+  /editor-structure-item[^\\n]*addEventListener\('pointerdown'|item\.setAttribute\('draggable', 'true'\)|className = 'btn-secondary editor-structure-move'/,
+  'article structure reordering should not start from the whole row or restore legacy move buttons'
+);
+
+assert.match(
+  source,
   /renderLocalizedField\(seoSection, 'siteDescription', \{[\s\S]*subheading: true[\s\S]*\}\);[\s\S]*renderLocalizedField\(seoSection, 'siteKeywords', \{[\s\S]*subheading: true[\s\S]*\}\);/,
   'SEO localized fields should opt into the shared subsection heading style'
 );


### PR DESCRIPTION
## Summary
- hide article-only front matter sections when editing tab page files
- clear stale article front matter state when switching into page metadata mode
- add regression coverage for both the hidden-section behavior and the front matter reset path

## Why
Tabs files were incorrectly showing stale article metadata UI after switching from a post, and the empty-state hint could disappear because cached front matter state was still counted.

## Validation
- `node scripts/test-composer-identity-grid.js`
- `git diff --check`
