### PR TITLE
[codex] Align editor toolbar background

### DIFF
--- a/index_editor.html
+++ b/index_editor.html
@@ -836,7 +836,7 @@
       position:sticky;
       top:calc(var(--editor-content-pane-padding, 0px) * -1);
       z-index:120;
-      background:var(--card);
+      background:color-mix(in srgb, var(--bg) 96%, var(--card) 4%);
     }
     .editor-markdown-panel > .toolbar {
       margin-top:calc(var(--editor-content-pane-padding, 1rem) * -1);


### PR DESCRIPTION
## Summary
- Match the Markdown editor top toolbar background to the editor content pane background
- Keep the change scoped to the toolbar CSS only

## Validation
- git diff --check
- Browser verification on http://127.0.0.1:8000/index_editor.html