### PR TITLE
[codex] Fix quote edge caret placement

### DIFF
--- a/assets/js/editor-blocks.js
+++ b/assets/js/editor-blocks.js
@@ -2419,6 +2419,23 @@ export function createMarkdownBlocksEditor(root, options = {}) {
     } catch (_) {}
   };
 
+  const routeDirectQuoteCaretFromPointer = (editable, index, sync, event) => {
+    if (!event || event.defaultPrevented || event.button !== 0 || event.isPrimary === false) return false;
+    if (!editable || !(editable.classList && editable.classList.contains('blocks-quote-text'))) return false;
+    const details = measuredTextOffsetDetailsFromPoint(editable, event.clientX, event.clientY);
+    if (!details || details.insideTextRect) return false;
+    event.preventDefault();
+    state.suppressNextBlockContainerClickUntil = Date.now() + 500;
+    try { editable.focus({ preventScroll: true }); }
+    catch (_) {
+      try { editable.focus(); } catch (__) {}
+    }
+    placeCaretAtTextOffset(editable, details.offset);
+    setActive(index, editable, sync);
+    updateInlineToolbarState();
+    return true;
+  };
+
   const routeBlocksCaretFromPointer = (event) => {
     if (!event || event.defaultPrevented || event.button !== 0) return;
     if (event.isPrimary === false) return;
@@ -3081,6 +3098,9 @@ export function createMarkdownBlocksEditor(root, options = {}) {
       updateInlineToolbarState();
     });
     editable.addEventListener('focus', () => setActive(index, editable, sync));
+    editable.addEventListener('pointerdown', (event) => {
+      routeDirectQuoteCaretFromPointer(editable, index, sync, event);
+    });
     editable.addEventListener('click', (event) => {
       const clickedLink = event.target && event.target.closest ? event.target.closest('a[href]') : null;
       if (clickedLink) event.preventDefault();

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -377,6 +377,12 @@ assert.match(
 
 assert.match(
   editorBlocksSource,
+  /const routeDirectQuoteCaretFromPointer = \(editable, index, sync, event\) => \{[\s\S]*classList\.contains\('blocks-quote-text'\)[\s\S]*measuredTextOffsetDetailsFromPoint\(editable, event\.clientX, event\.clientY\)[\s\S]*details\.insideTextRect[\s\S]*event\.preventDefault\(\);[\s\S]*placeCaretAtTextOffset\(editable, details\.offset\);[\s\S]*setActive\(index, editable, sync\);/,
+  'direct quote edge pointerdowns should prevent native start/end snaps and use the measured nearest offset'
+);
+
+assert.match(
+  editorBlocksSource,
   /let sourcePointer = null;[\s\S]*area\.addEventListener\('pointerdown', \(event\) => \{[\s\S]*const details = textareaTextOffsetDetailsFromPoint\(area, event\.clientX, event\.clientY\);[\s\S]*if \(details && !details\.insideTextRect\) \{[\s\S]*event\.preventDefault\(\);[\s\S]*sourcePointer = \{ x: event\.clientX, y: event\.clientY, moved: false, corrected: true \};[\s\S]*area\.setSelectionRange\(details\.offset, details\.offset\);[\s\S]*sourcePointer = \{ x: event\.clientX, y: event\.clientY, moved: false, corrected: false \};[\s\S]*area\.addEventListener\('pointermove', \(event\) => \{[\s\S]*> 16\) sourcePointer\.moved = true;[\s\S]*area\.addEventListener\('click', \(event\) => \{[\s\S]*if \(!pointer \|\| pointer\.moved \|\| pointer\.corrected\) return;[\s\S]*const details = textareaTextOffsetDetailsFromPoint\(area, event\.clientX, event\.clientY\);[\s\S]*if \(!details \|\| details\.insideTextRect\) return;[\s\S]*area\.setSelectionRange\(details\.offset, details\.offset\);[\s\S]*area\.addEventListener\('blur', \(\) => \{ sourcePointer = null; \}\);/,
   'direct source markdown textarea blank-edge pointerdowns should prevent native end snaps while text clicks and drags keep native behavior'
 );


### PR DESCRIPTION
## Summary

- route direct quote-block edge pointerdowns through measured text offsets instead of browser-native caret placement
- add a regression assertion covering quote edge clicks so the fix does not silently regress

## Root Cause

Quote blocks render an editable paragraph inside a padded blockquote. Direct clicks on that editable paragraph were excluded from the existing block-level caret router, and the browser-native caret API could snap edge clicks to the start or end of the paragraph.

## Validation

- `node --check assets/js/editor-blocks.js`
- `node scripts/test-composer-identity-grid.js`
- `node scripts/test-editor-blocks-roundtrip.js`
- manually reloaded `http://localhost:8000/index_editor.html` in the in-app browser and checked quote edge clicks