### PR TITLE
[codex] Fix editor preview image sanitization

### DIFF
--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -12,7 +12,7 @@ import {
   resolveFrontMatterBindings,
   valueIsPresent
 } from './frontmatter-document.js';
-import { getContentRoot, resolveImageSrc, setSafeHtml } from './utils.js';
+import { getContentRoot, resolveImageSrc, setSafeHtml } from './utils.js?v=editor-preview-images-20260504';
 import { initSyntaxHighlighting } from './syntax-highlight.js';
 import { applyLazyLoadingIn, hydratePostImages, hydratePostVideos } from './post-render.js';
 import { hydrateInternalLinkCards } from './link-cards.js';

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -218,15 +218,6 @@ export function setSafeHtml(target, html, baseDir, options = {}) {
     try { target.textContent = input; } catch (_) {}
     return;
   }
-  try {
-    // Prefer native Sanitizer API when available
-    if (typeof window !== 'undefined' && 'Sanitizer' in window && typeof Element.prototype.setHTML === 'function') {
-      const s = new window.Sanitizer();
-      target.setHTML(input, { sanitizer: s });
-      return;
-    }
-  } catch (_) { /* fall through to manual sanitizer */ }
-
   // Build a DOM fragment by tokenizing the renderer output and creating
   // elements/attributes programmatically.
   try {

--- a/index_editor.html
+++ b/index_editor.html
@@ -2201,7 +2201,7 @@
     })();
   </script>
   <script type="module" src="assets/js/editor-boot.js?v=editor-i18n-20260504"></script>
-  <script type="module" src="assets/js/editor-main.js?v=editor-i18n-20260504"></script>
+  <script type="module" src="assets/js/editor-main.js?v=editor-preview-images-20260504"></script>
   <script type="module" src="assets/js/composer.js?v=editor-i18n-20260504"></script>
   <!-- Back to top button -->
   <button id="backToTop" class="back-to-top" aria-label="返回顶部" title="返回顶部" type="button" hidden>

--- a/scripts/test-editor-preview-images.js
+++ b/scripts/test-editor-preview-images.js
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+class TestNode {
+  constructor() {
+    this.childNodes = [];
+    this.parentNode = null;
+  }
+
+  appendChild(node) {
+    if (!node) return node;
+    this.childNodes.push(node);
+    node.parentNode = this;
+    return node;
+  }
+}
+
+class TestElement extends TestNode {
+  constructor(tagName) {
+    super();
+    this.tagName = String(tagName || '').toUpperCase();
+    this.attributes = new Map();
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(String(name), String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.has(String(name)) ? this.attributes.get(String(name)) : null;
+  }
+
+  replaceChildren(...nodes) {
+    this.childNodes = [];
+    nodes.forEach(node => this.appendChild(node));
+  }
+}
+
+class TestTextNode extends TestNode {
+  constructor(text) {
+    super();
+    this.textContent = String(text || '');
+  }
+}
+
+class TestDocumentFragment extends TestNode {}
+
+const documentRef = {
+  baseURI: 'http://127.0.0.1:8000/index_editor.html',
+  createDocumentFragment() {
+    return new TestDocumentFragment();
+  },
+  createElement(tagName) {
+    return new TestElement(tagName);
+  },
+  createTextNode(text) {
+    return new TestTextNode(text);
+  }
+};
+
+globalThis.window = {
+  __ns_content_root: 'wwwroot',
+  location: { protocol: 'http:' }
+};
+globalThis.document = documentRef;
+globalThis.location = { origin: 'http://127.0.0.1:8000' };
+
+const utilsSource = readFileSync('assets/js/utils.js', 'utf8');
+assert.equal(
+  utilsSource.includes('target.setHTML(input'),
+  false,
+  'editor preview should not bypass NanoSite sanitizer with native setHTML'
+);
+assert.equal(
+  utilsSource.includes("'Sanitizer' in window"),
+  false,
+  'editor preview should not use native Sanitizer defaults that can drop rendered media'
+);
+
+const { mdParse } = await import('../assets/js/markdown.js?editor-preview-images');
+const { setSafeHtml } = await import('../assets/js/utils.js?editor-preview-images');
+
+function collectElements(node, tagName, out = []) {
+  if (!node) return out;
+  if (node.tagName && node.tagName.toLowerCase() === tagName) out.push(node);
+  (node.childNodes || []).forEach(child => collectElements(child, tagName, out));
+  return out;
+}
+
+const markdown = readFileSync('wwwroot/post/page/githubpages_chs.md', 'utf8');
+const baseDir = 'wwwroot/post/page/';
+const parsed = mdParse(markdown, baseDir).post;
+assert.equal((parsed.match(/<img\b/g) || []).length, 2);
+
+const target = documentRef.createElement('div');
+setSafeHtml(target, parsed, baseDir, { alreadySanitized: true });
+
+const images = collectElements(target, 'img');
+assert.equal(images.length, 2);
+assert.equal(images[0].getAttribute('src'), 'wwwroot/post/page/page.jpeg');
+assert.equal(images[0].getAttribute('alt'), 'page');
+assert.equal(images[1].getAttribute('src'), 'wwwroot/post/page/step.jpeg');
+assert.equal(images[1].getAttribute('alt'), 'step');
+
+console.log('ok - editor preview sanitizer preserves rendered article images');


### PR DESCRIPTION
## Summary

Fixes a preview-only rendering bug where Markdown images were present in source and the block editor but disappeared from the editor preview.

## Root Cause

The editor preview sends rendered Markdown through `setSafeHtml()`. In browsers with native `Sanitizer` and `Element.setHTML()`, that function took the native sanitizer shortcut before NanoSite's controlled Markdown allowlist ran. The native default sanitizer removed the rendered `<img>` elements, leaving empty paragraphs in preview.

## Changes

- Route rendered Markdown through NanoSite's own sanitizer path so allowed Markdown media tags are preserved and URL rewriting still applies.
- Add cache-busting to the editor module and its `utils.js` import so deployed/static editor previews pick up the fix reliably.
- Add a regression test covering `wwwroot/post/page/githubpages_chs.md`, asserting both `page.jpeg` and `step.jpeg` survive `mdParse()` plus `setSafeHtml()`.

## Validation

- `node scripts/test-editor-preview-images.js`
- `node scripts/test-native-image-cache.js`
- `node scripts/test-progressive-image-visibility.js`
- `node scripts/test-composer-identity-grid.js`
- `node scripts/test-editor-blocks-roundtrip.js`
- `node scripts/test-editor-content-tree.js`
- Browser verified: preview now has 2 images, 2 figures, and 2 post image wrappers for the affected article.