### PR TITLE
[codex] Fix block editor scroll affordances

### DIFF
--- a/assets/js/editor-blocks.js
+++ b/assets/js/editor-blocks.js
@@ -2111,6 +2111,40 @@ export function createMarkdownBlocksEditor(root, options = {}) {
     return window.innerHeight || document.documentElement.clientHeight || 0;
   };
 
+  const findVerticalScrollParent = (node) => {
+    let el = node && node.parentElement;
+    while (el && el !== document.body && el !== document.documentElement) {
+      try {
+        const cs = window.getComputedStyle(el);
+        if (/(auto|scroll|overlay)/.test(cs.overflowY || '') && el.scrollHeight > el.clientHeight + 1) return el;
+      } catch (_) {}
+      el = el.parentElement;
+    }
+    return document.getElementById('editorContentPane') || document.scrollingElement || document.documentElement;
+  };
+
+  const wheelDeltaYForScroll = (event, scrollParent) => {
+    let deltaY = event && Number.isFinite(event.deltaY) ? event.deltaY : 0;
+    if (!deltaY) return 0;
+    if (event.deltaMode === 1) deltaY *= 16;
+    else if (event.deltaMode === 2) deltaY *= (scrollParent && scrollParent.clientHeight) || window.innerHeight || 600;
+    return deltaY;
+  };
+
+  const forwardBlockHeadWheel = (event) => {
+    if (!event || !event.deltaY) return;
+    const absX = Math.abs(event.deltaX || 0);
+    const absY = Math.abs(event.deltaY || 0);
+    if (absX > absY) return;
+    const scrollParent = findVerticalScrollParent(root);
+    if (!scrollParent) return;
+    const deltaY = wheelDeltaYForScroll(event, scrollParent);
+    if (!deltaY) return;
+    const before = scrollParent.scrollTop;
+    scrollParent.scrollTop = before + deltaY;
+    if (scrollParent.scrollTop !== before) event.preventDefault();
+  };
+
   const updateStickyBlockHead = () => {
     const blockNodes = Array.from(list.querySelectorAll('.blocks-block'));
     const activeBlock = blockNodes[state.activeIndex] || null;
@@ -3504,6 +3538,7 @@ export function createMarkdownBlocksEditor(root, options = {}) {
     type.textContent = text(block.type, block.type);
     const actions = createBlockActionMenu(index);
     head.appendChild(type);
+    head.addEventListener('wheel', forwardBlockHeadWheel, { passive: false });
     if (block.type === 'source') {
       head.appendChild(createSourceReasonHelp(block, index));
       if (canAutofixSourceBlock(block)) head.appendChild(createSourceAutofixButton(block, index));

--- a/assets/js/editor-blocks.js
+++ b/assets/js/editor-blocks.js
@@ -3426,6 +3426,7 @@ export function createMarkdownBlocksEditor(root, options = {}) {
       const area = document.createElement('textarea');
       area.className = 'blocks-textarea blocks-source-textarea';
       area.spellcheck = false;
+      area.rows = 1;
       area.value = block.data.text != null ? block.data.text : block.raw || '';
       const sync = () => updateFromControl(block, { text: area.value });
       let sourcePointer = null;

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -1,5 +1,5 @@
 import { configureFetchCachePolicy } from './cache-control.js';
-import { createMarkdownBlocksEditor } from './editor-blocks.js';
+import { createMarkdownBlocksEditor } from './editor-blocks.js?v=editor-block-height-20260504';
 import { createHiEditor } from './hieditor.js';
 import { mdParse } from './markdown.js';
 import { insertImageMarkdownAtSelection, normalizeDateInputValue } from './editor-markdown-ops.js';

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -1,5 +1,5 @@
 import { configureFetchCachePolicy } from './cache-control.js';
-import { createMarkdownBlocksEditor } from './editor-blocks.js?v=editor-block-height-20260504';
+import { createMarkdownBlocksEditor } from './editor-blocks.js?v=editor-block-head-wheel-20260504';
 import { createHiEditor } from './hieditor.js';
 import { mdParse } from './markdown.js';
 import { insertImageMarkdownAtSelection, normalizeDateInputValue } from './editor-markdown-ops.js';

--- a/index_editor.html
+++ b/index_editor.html
@@ -1318,7 +1318,7 @@
     .blocks-rich-editable, .blocks-code-preview code, .blocks-block input, .blocks-block textarea, .blocks-link-editor input, .blocks-card-search { cursor:text; }
     .blocks-block select { cursor:default; }
     .blocks-inspector input { min-width:min(18rem, 100%); flex:1 1 12rem; }
-    .blocks-rich-editable { outline:none; line-height:1.65; border-radius:6px; padding:.2rem .25rem; }
+    .blocks-rich-editable { outline:none; min-height:1.65em; line-height:1.65; border-radius:6px; padding:.2rem .25rem; }
     .blocks-rich-editable:focus, .blocks-textarea:focus, .blocks-block input:focus, .blocks-block select:focus, .blocks-card-search:focus { outline:2px solid color-mix(in srgb, var(--primary) 45%, transparent); outline-offset:2px; border-color:color-mix(in srgb, var(--primary) 45%, var(--border)); }
     .blocks-rich-editable a { color:var(--primary); text-decoration:underline; cursor:text; }
     .blocks-paragraph-text, .blocks-list-text, .blocks-quote-text { font-family:var(--serif, var(--article-serif-stack, Georgia, "Times New Roman", Times, serif)); }
@@ -1350,7 +1350,7 @@
     .blocks-list-text:focus { outline:none; box-shadow:none; }
     .blocks-visual-list-task .blocks-list-text { grid-column:2; display:block; }
     .blocks-code-preview { margin:0; padding:.85rem; border-radius:8px; overflow:auto; background:color-mix(in srgb, var(--code-bg) 88%, #020617); border:1px solid color-mix(in srgb, var(--border) 80%, transparent); color:var(--text); }
-    .blocks-code-preview code { display:block; outline:none; white-space:pre; font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Ubuntu Mono", monospace; font-size:.9rem; line-height:1.55; }
+    .blocks-code-preview code { display:block; min-height:1.55em; outline:none; white-space:pre; font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Ubuntu Mono", monospace; font-size:.9rem; line-height:1.55; }
     .blocks-code-preview code:focus { outline:none; box-shadow:none; border-color:inherit; }
     .blocks-card-preview .link-card-wrap { margin:.1rem 0; }
     .blocks-card-preview a { cursor:pointer; }

--- a/index_editor.html
+++ b/index_editor.html
@@ -1318,7 +1318,7 @@
     .blocks-rich-editable, .blocks-code-preview code, .blocks-block input, .blocks-block textarea, .blocks-link-editor input, .blocks-card-search { cursor:text; }
     .blocks-block select { cursor:default; }
     .blocks-inspector input { min-width:min(18rem, 100%); flex:1 1 12rem; }
-    .blocks-rich-editable { outline:none; min-height:1.8rem; line-height:1.65; border-radius:6px; padding:.2rem .25rem; }
+    .blocks-rich-editable { outline:none; line-height:1.65; border-radius:6px; padding:.2rem .25rem; }
     .blocks-rich-editable:focus, .blocks-textarea:focus, .blocks-block input:focus, .blocks-block select:focus, .blocks-card-search:focus { outline:2px solid color-mix(in srgb, var(--primary) 45%, transparent); outline-offset:2px; border-color:color-mix(in srgb, var(--primary) 45%, var(--border)); }
     .blocks-rich-editable a { color:var(--primary); text-decoration:underline; cursor:text; }
     .blocks-paragraph-text, .blocks-list-text, .blocks-quote-text { font-family:var(--serif, var(--article-serif-stack, Georgia, "Times New Roman", Times, serif)); }
@@ -1335,8 +1335,8 @@
     .blocks-quote-preview { margin:0; padding:.35rem .85rem; border-left:4px solid color-mix(in srgb, var(--primary) 58%, var(--border)); background:color-mix(in srgb, var(--primary) 6%, var(--card)); color:color-mix(in srgb, var(--text) 92%, var(--muted)); }
     .blocks-quote-preview p { margin:0; }
     .blocks-quote-text:focus { outline:none; box-shadow:none; }
-    .blocks-textarea { min-height:6.5rem; resize:vertical; font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Ubuntu Mono", monospace; font-size:.9rem; }
-    .blocks-source-textarea { min-height:0; width:100%; resize:none; overflow:hidden; }
+    .blocks-textarea { resize:vertical; font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Ubuntu Mono", monospace; font-size:.9rem; }
+    .blocks-source-textarea { min-height:0; width:100%; resize:none; overflow:hidden; padding-block:0; }
     .blocks-source-textarea:focus { outline:none; box-shadow:none; border-color:color-mix(in srgb, var(--border) 82%, transparent); }
     .blocks-image-figure { margin:0; display:flex; flex-direction:column; gap:.45rem; align-items:flex-start; }
     .blocks-image-preview { display:block; max-width:100%; max-height:28rem; height:auto; border-radius:8px; border:1px solid color-mix(in srgb, var(--border) 72%, transparent); background:color-mix(in srgb, var(--text) 3%, transparent); box-shadow:0 1px 2px rgba(15,23,42,.08); object-fit:contain; }
@@ -1350,7 +1350,7 @@
     .blocks-list-text:focus { outline:none; box-shadow:none; }
     .blocks-visual-list-task .blocks-list-text { grid-column:2; display:block; }
     .blocks-code-preview { margin:0; padding:.85rem; border-radius:8px; overflow:auto; background:color-mix(in srgb, var(--code-bg) 88%, #020617); border:1px solid color-mix(in srgb, var(--border) 80%, transparent); color:var(--text); }
-    .blocks-code-preview code { display:block; min-height:1.55em; outline:none; white-space:pre; font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Ubuntu Mono", monospace; font-size:.9rem; line-height:1.55; }
+    .blocks-code-preview code { display:block; outline:none; white-space:pre; font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Ubuntu Mono", monospace; font-size:.9rem; line-height:1.55; }
     .blocks-code-preview code:focus { outline:none; box-shadow:none; border-color:inherit; }
     .blocks-card-preview .link-card-wrap { margin:.1rem 0; }
     .blocks-card-preview a { cursor:pointer; }
@@ -2201,7 +2201,7 @@
     })();
   </script>
   <script type="module" src="assets/js/editor-boot.js?v=editor-i18n-20260504"></script>
-  <script type="module" src="assets/js/editor-main.js?v=editor-preview-images-20260504"></script>
+  <script type="module" src="assets/js/editor-main.js?v=editor-block-height-20260504"></script>
   <script type="module" src="assets/js/composer.js?v=editor-i18n-20260504"></script>
   <!-- Back to top button -->
   <button id="backToTop" class="back-to-top" aria-label="返回顶部" title="返回顶部" type="button" hidden>

--- a/index_editor.html
+++ b/index_editor.html
@@ -2201,7 +2201,7 @@
     })();
   </script>
   <script type="module" src="assets/js/editor-boot.js?v=editor-i18n-20260504"></script>
-  <script type="module" src="assets/js/editor-main.js?v=editor-block-height-20260504"></script>
+  <script type="module" src="assets/js/editor-main.js?v=editor-block-head-wheel-20260504"></script>
   <script type="module" src="assets/js/composer.js?v=editor-i18n-20260504"></script>
   <!-- Back to top button -->
   <button id="backToTop" class="back-to-top" aria-label="返回顶部" title="返回顶部" type="button" hidden>

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -239,6 +239,12 @@ assert.match(
 
 assert.match(
   editorBlocksSource,
+  /const findVerticalScrollParent = \(node\) => \{[\s\S]*document\.getElementById\('editorContentPane'\)[\s\S]*const forwardBlockHeadWheel = \(event\) => \{[\s\S]*absX > absY[\s\S]*scrollParent\.scrollTop = before \+ deltaY;[\s\S]*event\.preventDefault\(\);[\s\S]*head\.addEventListener\('wheel', forwardBlockHeadWheel, \{ passive: false \}\);/,
+  'active block toolbar should forward vertical wheel gestures to the editor content scroll pane'
+);
+
+assert.match(
+  editorBlocksSource,
   /item\.addEventListener\('click', \(event\) => \{[\s\S]*shouldSuppressRoutedBlockContainerClick\(\)[\s\S]*closestElement\(event\.target, '\.blocks-block-head'\)[\s\S]*setActive\(index\);[\s\S]*\}\);[\s\S]*item\.addEventListener\('focusin', \(\) => setActive\(index\)\);/,
   'block section container clicks should select the block without hijacking toolbar action clicks or routed carets'
 );

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -719,26 +719,20 @@ assert.match(
 
 assert.match(
   editorSource,
-  /\.blocks-code-preview code \{ display:block; outline:none;[\s\S]*line-height:1\.55; \}/,
-  'code blocks should size from content without a fixed minimum height'
+  /\.blocks-code-preview code \{ display:block; min-height:1\.55em; outline:none;[\s\S]*line-height:1\.55; \}/,
+  'empty code blocks should keep one editable line as a pointer target'
 );
 
-assert.doesNotMatch(
+assert.match(
   editorSource,
-  /\.blocks-code-preview code \{[^}]*min-height:/,
-  'code block content should not reserve a fixed minimum height'
+  /\.blocks-rich-editable \{ outline:none; min-height:1\.65em; line-height:1\.65;/,
+  'empty rich text blocks should keep one editable line as a pointer target'
 );
 
 assert.match(
   editorSource,
   /\.blocks-source-textarea \{ min-height:0; width:100%; resize:none; overflow:hidden; padding-block:0; \}/,
   'source markdown textareas should expand to content without fixed minimum height, internal scrolling, or vertical padding'
-);
-
-assert.doesNotMatch(
-  editorSource,
-  /\.blocks-rich-editable \{[^}]*min-height:/,
-  'rich block content should not reserve a fixed minimum height'
 );
 
 assert.doesNotMatch(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -491,8 +491,8 @@ assert.match(
 
 assert.match(
   editorBlocksSource,
-  /const autoSizeTextarea = \(area\) => \{[\s\S]*area\.style\.height = 'auto';[\s\S]*area\.style\.height = `\$\{area\.scrollHeight\}px`;[\s\S]*area\.addEventListener\('input', \(\) => \{[\s\S]*autoSizeTextarea\(area\);[\s\S]*queueMicrotask\(\(\) => autoSizeTextarea\(area\)\);/,
-  'source markdown textareas should auto-size to their content'
+  /const autoSizeTextarea = \(area\) => \{[\s\S]*area\.style\.height = 'auto';[\s\S]*area\.style\.height = `\$\{area\.scrollHeight\}px`;[\s\S]*area\.rows = 1;[\s\S]*area\.addEventListener\('input', \(\) => \{[\s\S]*autoSizeTextarea\(area\);[\s\S]*queueMicrotask\(\(\) => autoSizeTextarea\(area\)\);/,
+  'source markdown textareas should auto-size to their content from a one-row baseline'
 );
 
 assert.match(
@@ -713,14 +713,32 @@ assert.match(
 
 assert.match(
   editorSource,
-  /\.blocks-code-preview code \{ display:block; min-height:1\.55em;[\s\S]*line-height:1\.55; \}/,
-  'single-line code blocks should not inherit a tall fixed minimum height'
+  /\.blocks-code-preview code \{ display:block; outline:none;[\s\S]*line-height:1\.55; \}/,
+  'code blocks should size from content without a fixed minimum height'
+);
+
+assert.doesNotMatch(
+  editorSource,
+  /\.blocks-code-preview code \{[^}]*min-height:/,
+  'code block content should not reserve a fixed minimum height'
 );
 
 assert.match(
   editorSource,
-  /\.blocks-source-textarea \{ min-height:0; width:100%; resize:none; overflow:hidden; \}/,
-  'source markdown textareas should expand to content without a fixed minimum height or internal scrolling'
+  /\.blocks-source-textarea \{ min-height:0; width:100%; resize:none; overflow:hidden; padding-block:0; \}/,
+  'source markdown textareas should expand to content without fixed minimum height, internal scrolling, or vertical padding'
+);
+
+assert.doesNotMatch(
+  editorSource,
+  /\.blocks-rich-editable \{[^}]*min-height:/,
+  'rich block content should not reserve a fixed minimum height'
+);
+
+assert.doesNotMatch(
+  editorSource,
+  /\.blocks-textarea \{[^}]*min-height:/,
+  'block textareas should not reserve a fixed minimum height'
 );
 
 assert.match(


### PR DESCRIPTION
## Summary

Improves the Markdown block editor interaction model in two related places:

- Makes source Markdown blocks size from a one-row baseline so one-line source blocks render compactly.
- Lets the active floating block toolbar forward vertical wheel gestures to the editor content pane, so scrolling does not stop when the cursor is over the toolbar.

## Root Cause

One-line source Markdown blocks were effectively reserving extra height because source textareas inherited textarea defaults and vertical padding. Separately, the active block toolbar is a fixed-position overlay with pointer events enabled for its controls; when the pointer naturally lands over it, wheel events target the overlay instead of the editor's real scroll container.

## Changes

- Set source Markdown textareas to a one-row baseline before autosizing.
- Remove source textarea vertical padding so autosize follows text content instead of padding.
- Keep empty rich-text and code editables at a one-line minimum height so users retain a reliable caret target after clearing content.
- Add wheel forwarding from `.blocks-block-head` to `#editorContentPane`, preserving horizontal wheel gestures.
- Bump editor module query strings so browser module caches pick up the updated block editor scripts.
- Add regression assertions for one-row source textareas, empty rich/code caret targets, and toolbar wheel forwarding.

## Validation

- `node scripts/test-composer-identity-grid.js`
- `node scripts/test-editor-blocks-roundtrip.js`
- `node --check assets/js/editor-blocks.js`
- `node --check assets/js/editor-main.js`
- Browser verified: one-line source Markdown textarea renders at one line, and scrolling while the pointer is over the floating toolbar continues to move the editor content pane.