### PR TITLE
[codex] Fix image block editing controls

### DIFF
--- a/assets/i18n/chs.js
+++ b/assets/i18n/chs.js
@@ -305,6 +305,7 @@ const translations = {
         openGithubAction: '打开 GitHub',
         markdownOpenBeforeInsert: '请先打开一个 Markdown 文件再插入图片。',
         assetAttached: ({ label }) => `已附加 ${label}`,
+        imageReplaceTargetMissing: '图片块已不存在。请选择一个图片块后重试。',
         noPendingChanges: '没有待提交的更改。',
         siteWaitStopped: '已停止等待线上站点。提交已在 GitHub 上，但显示可能还需要几分钟。',
         siteWaitTimedOut: '已将文件提交到 GitHub，但线上站点未及时更新。请手动检查部署状态。',

--- a/assets/i18n/chs.js
+++ b/assets/i18n/chs.js
@@ -347,6 +347,7 @@ const translations = {
         delete: '删除',
         imageAlt: '替代文本',
         imagePath: '图片路径',
+        replaceImage: '替换图片',
         unordered: '项目符号',
         ordered: '编号',
         task: '清单',

--- a/assets/i18n/cht-tw.js
+++ b/assets/i18n/cht-tw.js
@@ -347,6 +347,7 @@ const translations = {
         delete: '刪除',
         imageAlt: '替代文字',
         imagePath: '圖片路徑',
+        replaceImage: '替換圖片',
         unordered: '項目符號',
         ordered: '編號',
         task: '清單',

--- a/assets/i18n/cht-tw.js
+++ b/assets/i18n/cht-tw.js
@@ -305,6 +305,7 @@ const translations = {
         openGithubAction: '開啟 GitHub',
         markdownOpenBeforeInsert: '請先開啟一個 Markdown 檔案再插入圖片。',
         assetAttached: ({ label }) => `已附加 ${label}`,
+        imageReplaceTargetMissing: '圖片區塊已不存在。請選擇一個圖片區塊後重試。',
         noPendingChanges: '沒有待提交的更改。',
         siteWaitStopped: '已停止等待線上站點。提交已在 GitHub 上，但顯示可能還需要幾分鐘。',
         siteWaitTimedOut: '已將檔案提交到 GitHub，但線上站點未及時更新。請手動檢查部署狀態。',

--- a/assets/i18n/en.js
+++ b/assets/i18n/en.js
@@ -347,6 +347,7 @@ const translations = {
         delete: 'Delete',
         imageAlt: 'Alt text',
         imagePath: 'Image path',
+        replaceImage: 'Replace image',
         unordered: 'Bulleted',
         ordered: 'Numbered',
         task: 'Checklist',

--- a/assets/i18n/en.js
+++ b/assets/i18n/en.js
@@ -305,6 +305,7 @@ const translations = {
         openGithubAction: 'Open GitHub',
         markdownOpenBeforeInsert: 'Open a markdown file before inserting images.',
         assetAttached: ({ label }) => `Attached ${label}`,
+        imageReplaceTargetMissing: 'The image block no longer exists. Select an image block and try again.',
         noPendingChanges: 'No pending changes to commit.',
         siteWaitStopped: 'Stopped waiting for the live site. Your commit is already on GitHub, but it may take a few minutes to appear.',
         siteWaitTimedOut: 'Committed files to GitHub, but the live site did not update in time. Check the deploy status manually.',

--- a/assets/i18n/ja.js
+++ b/assets/i18n/ja.js
@@ -347,6 +347,7 @@ const translations = {
         delete: '削除',
         imageAlt: '代替テキスト',
         imagePath: '画像パス',
+        replaceImage: '画像を置換',
         unordered: '箇条書き',
         ordered: '番号付き',
         task: 'チェックリスト',

--- a/assets/i18n/ja.js
+++ b/assets/i18n/ja.js
@@ -305,6 +305,7 @@ const translations = {
         openGithubAction: 'GitHub を開く',
         markdownOpenBeforeInsert: '画像を挿入する前に Markdown ファイルを開いてください。',
         assetAttached: ({ label }) => `${label} を添付しました`,
+        imageReplaceTargetMissing: '画像ブロックはもう存在しません。画像ブロックを選択してからやり直してください。',
         noPendingChanges: 'コミットする変更はありません。',
         siteWaitStopped: 'ライブサイトの更新待機を停止しました。コミットは GitHub にありますが、反映まで数分かかる場合があります。',
         siteWaitTimedOut: 'GitHub にファイルをコミットしましたが、ライブサイトが時間内に更新されませんでした。デプロイ状況を手動で確認してください。',

--- a/assets/js/editor-blocks.js
+++ b/assets/js/editor-blocks.js
@@ -3205,7 +3205,7 @@ export function createMarkdownBlocksEditor(root, options = {}) {
     hydrateImages(blockEl);
   };
 
-  const createImageMetadataControls = (block) => {
+  const createImageMetadataControls = (block, index) => {
     const controls = document.createElement('div');
     controls.className = 'blocks-image-meta-controls';
     const alt = document.createElement('input');
@@ -3214,12 +3214,9 @@ export function createMarkdownBlocksEditor(root, options = {}) {
     alt.value = block.data.alt || '';
     alt.placeholder = text('imageAlt', 'Alt text');
     alt.setAttribute('aria-label', text('imageAlt', 'Alt text'));
-    const src = document.createElement('input');
-    src.type = 'text';
-    src.className = 'blocks-image-src';
-    src.value = block.data.src || '';
-    src.placeholder = text('imagePath', 'Image path');
-    src.setAttribute('aria-label', text('imagePath', 'Image path'));
+    const replace = button(text('replaceImage', 'Replace image'), 'blocks-btn blocks-image-replace');
+    replace.title = text('replaceImage', 'Replace image');
+    replace.setAttribute('aria-label', text('replaceImage', 'Replace image'));
     const title = document.createElement('input');
     title.type = 'text';
     title.className = 'blocks-image-title';
@@ -3227,13 +3224,19 @@ export function createMarkdownBlocksEditor(root, options = {}) {
     title.placeholder = text('imageTitle', 'Image title');
     title.setAttribute('aria-label', text('imageTitle', 'Image title'));
     const update = () => {
-      updateFromControl(block, { alt: inputValue(alt), src: inputValue(src), title: inputValue(title) });
+      updateFromControl(block, { alt: inputValue(alt), title: inputValue(title) });
       syncRenderedImageBlock(block);
     };
     alt.addEventListener('input', update);
-    src.addEventListener('input', update);
     title.addEventListener('input', update);
-    controls.append(alt, src, title);
+    replace.addEventListener('mousedown', (event) => event.preventDefault());
+    replace.addEventListener('click', () => {
+      setActive(index);
+      if (typeof options.requestImageUpload === 'function') {
+        options.requestImageUpload({ replaceIndex: index });
+      }
+    });
+    controls.append(alt, replace, title);
     return controls;
   };
 
@@ -3612,7 +3615,7 @@ export function createMarkdownBlocksEditor(root, options = {}) {
       head.appendChild(createCodeLanguageInput(block));
     }
     if (block.type === 'image') {
-      head.appendChild(createImageMetadataControls(block));
+      head.appendChild(createImageMetadataControls(block, index));
     }
     if (block.type === 'paragraph' || block.type === 'quote' || block.type === 'list') {
       head.appendChild(createInlineControls(index));
@@ -3682,6 +3685,15 @@ export function createMarkdownBlocksEditor(root, options = {}) {
     insertImageBlock(src, alt, index = state.activeIndex + 1) {
       const block = insertBlock('image', { src, alt: alt || '', title: '' }, index);
       return { index: state.blocks.indexOf(block) };
+    },
+    replaceImageBlock(src, index = state.activeIndex) {
+      const safeIndex = Math.max(0, Math.min(Number(index) || 0, state.blocks.length - 1));
+      const block = state.blocks[safeIndex];
+      if (!block || block.type !== 'image') return null;
+      updateFromControl(block, { src });
+      syncRenderedImageBlock(block);
+      setActive(safeIndex);
+      return { index: safeIndex };
     },
     setCardEntries(entries) {
       state.cardEntries = Array.isArray(entries) ? entries.slice() : [];

--- a/assets/js/editor-blocks.js
+++ b/assets/js/editor-blocks.js
@@ -1788,6 +1788,13 @@ export function createMarkdownBlocksEditor(root, options = {}) {
 
   const blockElements = () => Array.from(list.children).filter(el => el && el.classList && el.classList.contains('blocks-block'));
 
+  const clearNativeSelection = () => {
+    try {
+      const sel = window.getSelection && window.getSelection();
+      if (sel) sel.removeAllRanges();
+    } catch (_) {}
+  };
+
   const prefersReducedReorderMotion = () => !!(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
 
   const captureBlockRects = (indexes = null) => {
@@ -2474,6 +2481,21 @@ export function createMarkdownBlocksEditor(root, options = {}) {
     if (!event || event.defaultPrevented || event.button !== 0) return;
     if (event.isPrimary === false) return;
     if (isBlocksCaretInteractiveTarget(event.target)) return;
+    const imageBlock = closestElement(event.target, '.blocks-block-image');
+    if (imageBlock) {
+      const imageIndex = blockElements().indexOf(imageBlock);
+      if (imageIndex >= 0) {
+        event.preventDefault();
+        state.suppressNextBlockContainerClickUntil = Date.now() + 500;
+        try { imageBlock.focus({ preventScroll: true }); }
+        catch (_) {
+          try { imageBlock.focus(); } catch (__) {}
+        }
+        clearNativeSelection();
+        setActive(imageIndex);
+        return;
+      }
+    }
     const candidate = nearestEditableFromPoint(event.clientX, event.clientY);
     if (!candidate || !candidate.editable) return;
     event.preventDefault();
@@ -3165,15 +3187,76 @@ export function createMarkdownBlocksEditor(root, options = {}) {
     return select;
   };
 
+  const syncRenderedImageBlock = (block) => {
+    const blockEl = blockElements().find(el => el && el.dataset && el.dataset.blockId === block.id);
+    if (!blockEl) return;
+    const img = blockEl.querySelector('.blocks-image-preview');
+    const caption = blockEl.querySelector('.blocks-image-figure figcaption');
+    if (img) {
+      img.alt = block.data.alt || '';
+      const nextSrc = resolveAssetSrc(block.data.src || '');
+      if (nextSrc) img.src = nextSrc;
+      else img.removeAttribute('src');
+    }
+    if (caption) {
+      caption.textContent = block.data.alt || '';
+      caption.hidden = !block.data.alt;
+    }
+    hydrateImages(blockEl);
+  };
+
+  const createImageMetadataControls = (block) => {
+    const controls = document.createElement('div');
+    controls.className = 'blocks-image-meta-controls';
+    const alt = document.createElement('input');
+    alt.type = 'text';
+    alt.className = 'blocks-image-alt';
+    alt.value = block.data.alt || '';
+    alt.placeholder = text('imageAlt', 'Alt text');
+    alt.setAttribute('aria-label', text('imageAlt', 'Alt text'));
+    const src = document.createElement('input');
+    src.type = 'text';
+    src.className = 'blocks-image-src';
+    src.value = block.data.src || '';
+    src.placeholder = text('imagePath', 'Image path');
+    src.setAttribute('aria-label', text('imagePath', 'Image path'));
+    const title = document.createElement('input');
+    title.type = 'text';
+    title.className = 'blocks-image-title';
+    title.value = block.data.title || '';
+    title.placeholder = text('imageTitle', 'Image title');
+    title.setAttribute('aria-label', text('imageTitle', 'Image title'));
+    const update = () => {
+      updateFromControl(block, { alt: inputValue(alt), src: inputValue(src), title: inputValue(title) });
+      syncRenderedImageBlock(block);
+    };
+    alt.addEventListener('input', update);
+    src.addEventListener('input', update);
+    title.addEventListener('input', update);
+    controls.append(alt, src, title);
+    return controls;
+  };
+
   const renderHeadingBlock = (body, block, index) => {
     const level = Math.max(1, Math.min(6, Number(block.data.level) || 2));
     const heading = createRichEditable(`h${level}`, block, 'text', `blocks-rich-editable blocks-heading-text blocks-heading-h${level}`, index);
     body.appendChild(heading);
   };
 
-  const renderImageBlock = (body, block) => {
+  const renderImageBlock = (body, block, index) => {
     const figure = document.createElement('figure');
     figure.className = 'blocks-image-figure';
+    const selectImageBlock = (event) => {
+      if (!event || event.defaultPrevented) return;
+      if (event.type === 'pointerdown' && (event.button !== 0 || event.isPrimary === false)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      state.suppressNextBlockContainerClickUntil = Date.now() + 500;
+      clearNativeSelection();
+      setActive(index);
+    };
+    figure.addEventListener('pointerdown', selectImageBlock);
+    figure.addEventListener('click', selectImageBlock);
     const img = document.createElement('img');
     img.className = 'blocks-image-preview';
     img.alt = block.data.alt || '';
@@ -3182,36 +3265,11 @@ export function createMarkdownBlocksEditor(root, options = {}) {
     img.loading = 'lazy';
     img.decoding = 'async';
     const caption = document.createElement('figcaption');
-    caption.textContent = block.data.alt || block.data.src || text('imagePath', 'Image path');
+    caption.textContent = block.data.alt || '';
+    caption.hidden = !block.data.alt;
     figure.append(img, caption);
 
-    const controls = document.createElement('div');
-    controls.className = 'blocks-inspector blocks-image-inspector';
-    const alt = document.createElement('input');
-    alt.type = 'text';
-    alt.value = block.data.alt || '';
-    alt.placeholder = text('imageAlt', 'Alt text');
-    const src = document.createElement('input');
-    src.type = 'text';
-    src.value = block.data.src || '';
-    src.placeholder = text('imagePath', 'Image path');
-    const title = document.createElement('input');
-    title.type = 'text';
-    title.value = block.data.title || '';
-    title.placeholder = text('imageTitle', 'Image title');
-    const update = () => {
-      updateFromControl(block, { alt: inputValue(alt), src: inputValue(src), title: inputValue(title) });
-      img.alt = block.data.alt || '';
-      const nextSrc = resolveAssetSrc(block.data.src || '');
-      if (nextSrc) img.src = nextSrc;
-      caption.textContent = block.data.alt || block.data.src || text('imagePath', 'Image path');
-      hydrateImages(figure);
-    };
-    alt.addEventListener('input', update);
-    src.addEventListener('input', update);
-    title.addEventListener('input', update);
-    controls.append(alt, src, title);
-    body.append(figure, controls);
+    body.append(figure);
     hydrateImages(figure);
   };
 
@@ -3449,7 +3507,7 @@ export function createMarkdownBlocksEditor(root, options = {}) {
       quote.appendChild(createRichEditable('p', block, 'text', 'blocks-rich-editable blocks-quote-text', index));
       body.appendChild(quote);
     } else if (block.type === 'image') {
-      renderImageBlock(body, block);
+      renderImageBlock(body, block, index);
     } else if (block.type === 'list') {
       renderListBlock(body, block, index);
     } else if (block.type === 'code') {
@@ -3552,6 +3610,9 @@ export function createMarkdownBlocksEditor(root, options = {}) {
     }
     if (block.type === 'code') {
       head.appendChild(createCodeLanguageInput(block));
+    }
+    if (block.type === 'image') {
+      head.appendChild(createImageMetadataControls(block));
     }
     if (block.type === 'paragraph' || block.type === 'quote' || block.type === 'list') {
       head.appendChild(createInlineControls(index));

--- a/assets/js/editor-blocks.js
+++ b/assets/js/editor-blocks.js
@@ -3236,7 +3236,7 @@ export function createMarkdownBlocksEditor(root, options = {}) {
         options.requestImageUpload({ replaceIndex: index });
       }
     });
-    controls.append(alt, replace, title);
+    controls.append(alt, title, replace);
     return controls;
   };
 

--- a/assets/js/editor-blocks.js
+++ b/assets/js/editor-blocks.js
@@ -3249,17 +3249,6 @@ export function createMarkdownBlocksEditor(root, options = {}) {
   const renderImageBlock = (body, block, index) => {
     const figure = document.createElement('figure');
     figure.className = 'blocks-image-figure';
-    const selectImageBlock = (event) => {
-      if (!event || event.defaultPrevented) return;
-      if (event.type === 'pointerdown' && (event.button !== 0 || event.isPrimary === false)) return;
-      event.preventDefault();
-      event.stopPropagation();
-      state.suppressNextBlockContainerClickUntil = Date.now() + 500;
-      clearNativeSelection();
-      setActive(index);
-    };
-    figure.addEventListener('pointerdown', selectImageBlock);
-    figure.addEventListener('click', selectImageBlock);
     const img = document.createElement('img');
     img.className = 'blocks-image-preview';
     img.alt = block.data.alt || '';

--- a/assets/js/editor-blocks.js
+++ b/assets/js/editor-blocks.js
@@ -3233,7 +3233,7 @@ export function createMarkdownBlocksEditor(root, options = {}) {
     replace.addEventListener('click', () => {
       setActive(index);
       if (typeof options.requestImageUpload === 'function') {
-        options.requestImageUpload({ replaceIndex: index });
+        options.requestImageUpload({ replaceIndex: index, replaceBlockId: block.id });
       }
     });
     controls.append(alt, title, replace);
@@ -3675,9 +3675,23 @@ export function createMarkdownBlocksEditor(root, options = {}) {
       const block = insertBlock('image', { src, alt: alt || '', title: '' }, index);
       return { index: state.blocks.indexOf(block) };
     },
-    replaceImageBlock(src, index = state.activeIndex) {
-      const safeIndex = Math.max(0, Math.min(Number(index) || 0, state.blocks.length - 1));
-      const block = state.blocks[safeIndex];
+    replaceImageBlock(src, target = state.activeIndex) {
+      const targetIndex = target && typeof target === 'object' ? target.index : target;
+      const expectedBlockId = target && typeof target === 'object' && typeof target.blockId === 'string'
+        ? target.blockId
+        : '';
+      let safeIndex = Number.isInteger(targetIndex) ? targetIndex : state.activeIndex;
+      if (!Number.isInteger(safeIndex) || safeIndex < 0 || safeIndex >= state.blocks.length) {
+        if (!expectedBlockId) return null;
+        safeIndex = state.blocks.findIndex(item => item && item.id === expectedBlockId);
+        if (safeIndex < 0) return null;
+      }
+      let block = state.blocks[safeIndex];
+      if (expectedBlockId && (!block || block.id !== expectedBlockId)) {
+        safeIndex = state.blocks.findIndex(item => item && item.id === expectedBlockId);
+        if (safeIndex < 0) return null;
+        block = state.blocks[safeIndex];
+      }
       if (!block || block.type !== 'image') return null;
       updateFromControl(block, { src });
       syncRenderedImageBlock(block);

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -1,5 +1,5 @@
 import { configureFetchCachePolicy } from './cache-control.js';
-import { createMarkdownBlocksEditor } from './editor-blocks.js?v=editor-image-replace-20260504';
+import { createMarkdownBlocksEditor } from './editor-blocks.js?v=editor-image-controls-order-20260504';
 import { createHiEditor } from './hieditor.js';
 import { mdParse } from './markdown.js';
 import { insertImageMarkdownAtSelection, normalizeDateInputValue } from './editor-markdown-ops.js';

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -1,5 +1,5 @@
 import { configureFetchCachePolicy } from './cache-control.js';
-import { createMarkdownBlocksEditor } from './editor-blocks.js?v=editor-block-head-wheel-20260504';
+import { createMarkdownBlocksEditor } from './editor-blocks.js?v=editor-image-toolbar-v4-20260504';
 import { createHiEditor } from './hieditor.js';
 import { mdParse } from './markdown.js';
 import { insertImageMarkdownAtSelection, normalizeDateInputValue } from './editor-markdown-ops.js';

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -404,9 +404,11 @@ const applyPreviewAssetOverrides = (container, markdownPath) => {
 };
 
 const refreshPreviewAssetOverrides = () => {
-  const target = document.getElementById('mainview');
-  if (!target) return;
-  applyPreviewAssetOverrides(target, previewAssetCurrentPath);
+  ['mainview', 'blocks-wrap'].forEach((id) => {
+    const target = document.getElementById(id);
+    if (!target) return;
+    applyPreviewAssetOverrides(target, previewAssetCurrentPath);
+  });
 };
 
 const fetchMarkdownForLinkCard = (loc) => {
@@ -2476,7 +2478,7 @@ document.addEventListener('DOMContentLoaded', () => {
         console.error('Failed to dispatch asset-added event', err);
       }
 
-      emitEditorToast('success', `Inserted ${paths.relativePath}`);
+      emitEditorToast('success', t('editor.toasts.assetAttached', { label: paths.relativePath }));
     }
   };
 

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -1642,10 +1642,11 @@ document.addEventListener('DOMContentLoaded', () => {
           applyPreviewAssetOverrides(node, getCurrentMarkdownPath());
         } catch (_) {}
       },
-      requestImageUpload: ({ index, replaceIndex } = {}) => {
+      requestImageUpload: ({ index, replaceIndex, replaceBlockId } = {}) => {
         pendingBlocksImageInsert = {
           index: Number.isFinite(index) ? index : null,
-          replaceIndex: Number.isFinite(replaceIndex) ? replaceIndex : null
+          replaceIndex: Number.isFinite(replaceIndex) ? replaceIndex : null,
+          replaceBlockId: typeof replaceBlockId === 'string' && replaceBlockId ? replaceBlockId : null
         };
         if (!getCurrentMarkdownPath()) {
           emitEditorToast('warn', t('editor.toasts.markdownOpenBeforeInsert'));
@@ -2843,14 +2844,17 @@ document.addEventListener('DOMContentLoaded', () => {
         const replaceIndex = blockInsert && Number.isFinite(blockInsert.replaceIndex)
           ? blockInsert.replaceIndex
           : null;
+        const replaceBlockId = blockInsert && typeof blockInsert.replaceBlockId === 'string'
+          ? blockInsert.replaceBlockId
+          : null;
         let insertIndex = blockInsert && Number.isFinite(blockInsert.index)
           ? blockInsert.index
           : null;
-        const replaceMarkdown = replaceIndex != null
+        const replaceMarkdown = (replaceIndex != null || replaceBlockId)
           && markdownBlocksEditor
           && typeof markdownBlocksEditor.replaceImageBlock === 'function'
           ? (relativePath) => {
-            markdownBlocksEditor.replaceImageBlock(relativePath, replaceIndex);
+            markdownBlocksEditor.replaceImageBlock(relativePath, { index: replaceIndex, blockId: replaceBlockId });
             return {};
           }
           : null;

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -1610,6 +1610,36 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
   let pendingBlocksImageInsert = null;
+  let pendingImagePickerToken = 0;
+  const armImagePickerCancelReset = (token) => {
+    const clearIfPickerStillPending = () => {
+      window.setTimeout(() => {
+        if (token !== pendingImagePickerToken) return;
+        const hasFiles = imageInput && imageInput.files && imageInput.files.length;
+        if (!hasFiles) pendingBlocksImageInsert = null;
+      }, 250);
+    };
+    window.addEventListener('focus', clearIfPickerStillPending, { once: true });
+    if (imageInput) {
+      imageInput.addEventListener('cancel', clearIfPickerStillPending, { once: true });
+      imageInput.addEventListener('blur', clearIfPickerStillPending, { once: true });
+    }
+  };
+  const openImageInputPicker = () => {
+    if (!imageInput) {
+      pendingBlocksImageInsert = null;
+      return;
+    }
+    pendingImagePickerToken += 1;
+    const pickerToken = pendingImagePickerToken;
+    try { imageInput.value = ''; } catch (_) {}
+    armImagePickerCancelReset(pickerToken);
+    try { imageInput.click(); }
+    catch (_) {
+      try { imageInput.dispatchEvent(new MouseEvent('click', { bubbles: true })); }
+      catch (__) {}
+    }
+  };
   const setEditorBodyFromBlocks = (body) => {
     const text = body == null ? '' : String(body);
     if (editor) editor.setValue(text);
@@ -1653,13 +1683,7 @@ document.addEventListener('DOMContentLoaded', () => {
           pendingBlocksImageInsert = null;
           return;
         }
-        if (imageInput) {
-          try { imageInput.click(); }
-          catch (_) {
-            try { imageInput.dispatchEvent(new MouseEvent('click', { bubbles: true })); }
-            catch (__) {}
-          }
-        }
+        openImageInputPicker();
       }
     });
     syncMarkdownBlocksFromSource = () => {
@@ -2825,22 +2849,17 @@ document.addEventListener('DOMContentLoaded', () => {
         emitEditorToast('warn', 'Open a markdown file before inserting images.');
         return;
       }
-      if (imageInput) {
-        try { imageInput.click(); }
-        catch (_) {
-          try { imageInput.dispatchEvent(new MouseEvent('click', { bubbles: true })); }
-          catch (__) {}
-        }
-      }
+      openImageInputPicker();
     });
   }
 
   if (imageInput) {
     imageInput.addEventListener('change', () => {
       const files = imageInput.files;
+      const blockInsert = pendingBlocksImageInsert;
+      pendingBlocksImageInsert = null;
+      pendingImagePickerToken += 1;
       if (files && files.length) {
-        const blockInsert = pendingBlocksImageInsert;
-        pendingBlocksImageInsert = null;
         const replaceIndex = blockInsert && Number.isFinite(blockInsert.replaceIndex)
           ? blockInsert.replaceIndex
           : null;

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -1,5 +1,5 @@
 import { configureFetchCachePolicy } from './cache-control.js';
-import { createMarkdownBlocksEditor } from './editor-blocks.js?v=editor-image-toolbar-v4-20260504';
+import { createMarkdownBlocksEditor } from './editor-blocks.js?v=editor-image-replace-20260504';
 import { createHiEditor } from './hieditor.js';
 import { mdParse } from './markdown.js';
 import { insertImageMarkdownAtSelection, normalizeDateInputValue } from './editor-markdown-ops.js';
@@ -1563,6 +1563,7 @@ document.addEventListener('DOMContentLoaded', () => {
     delete: 'Delete',
     imageAlt: 'Alt text',
     imagePath: 'Image path',
+    replaceImage: 'Replace image',
     unordered: 'Bulleted',
     ordered: 'Numbered',
     task: 'Checklist',
@@ -1639,8 +1640,11 @@ document.addEventListener('DOMContentLoaded', () => {
           applyPreviewAssetOverrides(node, getCurrentMarkdownPath());
         } catch (_) {}
       },
-      requestImageUpload: ({ index } = {}) => {
-        pendingBlocksImageInsert = { index: Number.isFinite(index) ? index : null };
+      requestImageUpload: ({ index, replaceIndex } = {}) => {
+        pendingBlocksImageInsert = {
+          index: Number.isFinite(index) ? index : null,
+          replaceIndex: Number.isFinite(replaceIndex) ? replaceIndex : null
+        };
         if (!getCurrentMarkdownPath()) {
           emitEditorToast('warn', t('editor.toasts.markdownOpenBeforeInsert'));
           pendingBlocksImageInsert = null;
@@ -2417,6 +2421,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (fileList && fileList.length) emitEditorToast('warn', 'Only image files can be inserted.');
       return;
     }
+    if (options.singleImage && files.length > 1) files.splice(1);
 
     const textarea = getEditorTextarea();
     const customInsertMarkdown = typeof options.insertMarkdown === 'function' ? options.insertMarkdown : null;
@@ -2833,17 +2838,31 @@ document.addEventListener('DOMContentLoaded', () => {
       if (files && files.length) {
         const blockInsert = pendingBlocksImageInsert;
         pendingBlocksImageInsert = null;
+        const replaceIndex = blockInsert && Number.isFinite(blockInsert.replaceIndex)
+          ? blockInsert.replaceIndex
+          : null;
         let insertIndex = blockInsert && Number.isFinite(blockInsert.index)
           ? blockInsert.index
           : null;
-        const insertMarkdown = blockInsert && markdownBlocksEditor && typeof markdownBlocksEditor.insertImageBlock === 'function'
+        const replaceMarkdown = replaceIndex != null
+          && markdownBlocksEditor
+          && typeof markdownBlocksEditor.replaceImageBlock === 'function'
+          ? (relativePath) => {
+            markdownBlocksEditor.replaceImageBlock(relativePath, replaceIndex);
+            return {};
+          }
+          : null;
+        const insertMarkdown = !replaceMarkdown && blockInsert && markdownBlocksEditor && typeof markdownBlocksEditor.insertImageBlock === 'function'
           ? (relativePath, altText) => {
             const result = markdownBlocksEditor.insertImageBlock(relativePath, altText, insertIndex);
             if (result && Number.isFinite(result.index)) insertIndex = result.index + 1;
             return {};
           }
           : null;
-        handleImageFiles(files, insertMarkdown ? { source: 'picker', insertMarkdown } : { source: 'picker' }).catch((err) => {
+        const markdownHandler = replaceMarkdown || insertMarkdown;
+        handleImageFiles(files, markdownHandler
+          ? { source: 'picker', insertMarkdown: markdownHandler, singleImage: !!replaceMarkdown }
+          : { source: 'picker' }).catch((err) => {
           console.error('Image insertion failed', err);
         });
       }

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -2471,9 +2471,17 @@ document.addEventListener('DOMContentLoaded', () => {
 
       const meta = buildAssetFileMeta(file);
       const paths = computeAssetPaths(markdownPath, meta.fileName);
-      const selection = customInsertMarkdown
-        ? (customInsertMarkdown(paths.relativePath, meta.altText) || {})
-        : insertImageMarkdown(paths.relativePath, meta.altText);
+      let selection;
+      if (customInsertMarkdown) {
+        selection = customInsertMarkdown(paths.relativePath, meta.altText);
+        if (selection === false) {
+          if (options.insertAbortToast) emitEditorToast('warn', options.insertAbortToast);
+          continue;
+        }
+        selection = selection || {};
+      } else {
+        selection = insertImageMarkdown(paths.relativePath, meta.altText);
+      }
       lastSelection = selection;
 
       if (!customInsertMarkdown && textarea) {
@@ -2873,7 +2881,8 @@ document.addEventListener('DOMContentLoaded', () => {
           && markdownBlocksEditor
           && typeof markdownBlocksEditor.replaceImageBlock === 'function'
           ? (relativePath) => {
-            markdownBlocksEditor.replaceImageBlock(relativePath, { index: replaceIndex, blockId: replaceBlockId });
+            const result = markdownBlocksEditor.replaceImageBlock(relativePath, { index: replaceIndex, blockId: replaceBlockId });
+            if (!result) return false;
             return {};
           }
           : null;
@@ -2885,9 +2894,11 @@ document.addEventListener('DOMContentLoaded', () => {
           }
           : null;
         const markdownHandler = replaceMarkdown || insertMarkdown;
-        handleImageFiles(files, markdownHandler
+        const imageFileOptions = markdownHandler
           ? { source: 'picker', insertMarkdown: markdownHandler, singleImage: !!replaceMarkdown }
-          : { source: 'picker' }).catch((err) => {
+          : { source: 'picker' };
+        if (replaceMarkdown) imageFileOptions.insertAbortToast = t('editor.toasts.imageReplaceTargetMissing');
+        handleImageFiles(files, imageFileOptions).catch((err) => {
           console.error('Image insertion failed', err);
         });
       }

--- a/index_editor.html
+++ b/index_editor.html
@@ -1309,12 +1309,12 @@
     .blocks-action-menu-item:disabled { opacity:.45; cursor:not-allowed; }
     .blocks-action-menu-delete { color:color-mix(in srgb, #dc2626 82%, var(--text)); }
     .blocks-action-menu-delete:hover:not(:disabled), .blocks-action-menu-delete:focus-visible:not(:disabled) { background:color-mix(in srgb, #dc2626 12%, transparent); border-color:transparent; color:#b91c1c; }
-    .blocks-block-head .blocks-heading-level, .blocks-block-head .blocks-list-type-select, .blocks-block-head .blocks-code-language, .blocks-block-head .blocks-image-meta-controls input { min-height:1.65rem; border:1px solid color-mix(in srgb, var(--border) 82%, transparent); border-radius:999px; background:color-mix(in srgb, var(--card) 96%, transparent); color:var(--text); font:inherit; font-size:.8rem; line-height:1.2; padding:.12rem .55rem; }
+    .blocks-block-head .blocks-heading-level, .blocks-block-head .blocks-list-type-select, .blocks-block-head .blocks-code-language, .blocks-block-head .blocks-image-meta-controls input, .blocks-block-head .blocks-image-replace { min-height:1.65rem; border:1px solid color-mix(in srgb, var(--border) 82%, transparent); border-radius:999px; background:color-mix(in srgb, var(--card) 96%, transparent); color:var(--text); font:inherit; font-size:.8rem; line-height:1.2; padding:.12rem .55rem; }
     .blocks-block-head .blocks-heading-level, .blocks-block-head .blocks-list-type-select { padding-right:1.45rem; }
     .blocks-block-head .blocks-code-language { width:8.5rem; max-width:26vw; }
     .blocks-image-meta-controls { display:flex; align-items:center; gap:.24rem; margin-left:.16rem; padding-left:.34rem; border-left:1px solid color-mix(in srgb, var(--border) 82%, transparent); }
     .blocks-block-head .blocks-image-meta-controls input { width:clamp(6.5rem, 12vw, 10rem); max-width:18vw; }
-    .blocks-block-head .blocks-image-meta-controls .blocks-image-src { width:clamp(8rem, 16vw, 13rem); max-width:24vw; }
+    .blocks-block-head .blocks-image-replace { white-space:nowrap; cursor:pointer; }
     .blocks-block-body { display:flex; flex-direction:column; gap:.7rem; padding:0; }
     .blocks-heading-controls, .blocks-inspector { display:flex; align-items:center; gap:.45rem; flex-wrap:wrap; }
     .blocks-inspector input, .blocks-inspector select, .blocks-heading-level, .blocks-textarea, .blocks-block input, .blocks-block select, .blocks-card-search { box-sizing:border-box; border:1px solid color-mix(in srgb, var(--border) 82%, transparent); border-radius:7px; background:color-mix(in srgb, var(--card) 96%, transparent); color:var(--text); font:inherit; line-height:1.45; padding:.5rem .6rem; }

--- a/index_editor.html
+++ b/index_editor.html
@@ -1262,7 +1262,7 @@
     .markdown-blocks-shell, .blocks-list, .blocks-block, .blocks-block-body { cursor:text; }
     .markdown-blocks-shell[hidden] { display:none !important; }
     .blocks-toolbar { display:flex; align-items:center; gap:.35rem; flex-wrap:wrap; padding:.2rem .2rem .7rem; border-bottom:1px solid color-mix(in srgb, var(--border) 72%, transparent); }
-    .blocks-toolbar, .blocks-block-head, .blocks-link-editor, .blocks-inspector, .blocks-card-picker, .blocks-action-menu, .blocks-inline-more-menu { cursor:default; }
+    .blocks-toolbar, .blocks-block-head, .blocks-link-editor, .blocks-image-meta-controls, .blocks-inspector, .blocks-card-picker, .blocks-action-menu, .blocks-inline-more-menu { cursor:default; }
     .blocks-btn, .blocks-icon-btn, .blocks-inline-btn, .blocks-card-result, .blocks-action-menu-item, .blocks-inline-menu-item { border:1px solid color-mix(in srgb, var(--border) 82%, transparent); background:color-mix(in srgb, var(--card) 96%, transparent); color:var(--text); border-radius:7px; font:inherit; font-size:.86rem; line-height:1.1; padding:.42rem .58rem; cursor:pointer; transition:background .16s ease, border-color .16s ease, color .16s ease; }
     .blocks-btn:hover, .blocks-btn:focus-visible, .blocks-icon-btn:hover:not(:disabled), .blocks-icon-btn:focus-visible:not(:disabled), .blocks-inline-btn:hover, .blocks-inline-btn:focus-visible, .blocks-card-result:hover, .blocks-card-result:focus-visible, .blocks-action-menu-item:hover:not(:disabled), .blocks-action-menu-item:focus-visible:not(:disabled), .blocks-inline-menu-item:hover:not(:disabled), .blocks-inline-menu-item:focus-visible:not(:disabled) { background:color-mix(in srgb, var(--primary) 10%, var(--card)); border-color:color-mix(in srgb, var(--primary) 45%, var(--border)); color:color-mix(in srgb, var(--primary) 92%, var(--text)); outline:none; }
     .blocks-inline-btn { min-width:2rem; min-height:1.85rem; padding:.25rem .45rem; font-weight:700; }
@@ -1309,9 +1309,12 @@
     .blocks-action-menu-item:disabled { opacity:.45; cursor:not-allowed; }
     .blocks-action-menu-delete { color:color-mix(in srgb, #dc2626 82%, var(--text)); }
     .blocks-action-menu-delete:hover:not(:disabled), .blocks-action-menu-delete:focus-visible:not(:disabled) { background:color-mix(in srgb, #dc2626 12%, transparent); border-color:transparent; color:#b91c1c; }
-    .blocks-block-head .blocks-heading-level, .blocks-block-head .blocks-list-type-select, .blocks-block-head .blocks-code-language { min-height:1.65rem; border:1px solid color-mix(in srgb, var(--border) 82%, transparent); border-radius:999px; background:color-mix(in srgb, var(--card) 96%, transparent); color:var(--text); font:inherit; font-size:.8rem; line-height:1.2; padding:.12rem .55rem; }
+    .blocks-block-head .blocks-heading-level, .blocks-block-head .blocks-list-type-select, .blocks-block-head .blocks-code-language, .blocks-block-head .blocks-image-meta-controls input { min-height:1.65rem; border:1px solid color-mix(in srgb, var(--border) 82%, transparent); border-radius:999px; background:color-mix(in srgb, var(--card) 96%, transparent); color:var(--text); font:inherit; font-size:.8rem; line-height:1.2; padding:.12rem .55rem; }
     .blocks-block-head .blocks-heading-level, .blocks-block-head .blocks-list-type-select { padding-right:1.45rem; }
     .blocks-block-head .blocks-code-language { width:8.5rem; max-width:26vw; }
+    .blocks-image-meta-controls { display:flex; align-items:center; gap:.24rem; margin-left:.16rem; padding-left:.34rem; border-left:1px solid color-mix(in srgb, var(--border) 82%, transparent); }
+    .blocks-block-head .blocks-image-meta-controls input { width:clamp(6.5rem, 12vw, 10rem); max-width:18vw; }
+    .blocks-block-head .blocks-image-meta-controls .blocks-image-src { width:clamp(8rem, 16vw, 13rem); max-width:24vw; }
     .blocks-block-body { display:flex; flex-direction:column; gap:.7rem; padding:0; }
     .blocks-heading-controls, .blocks-inspector { display:flex; align-items:center; gap:.45rem; flex-wrap:wrap; }
     .blocks-inspector input, .blocks-inspector select, .blocks-heading-level, .blocks-textarea, .blocks-block input, .blocks-block select, .blocks-card-search { box-sizing:border-box; border:1px solid color-mix(in srgb, var(--border) 82%, transparent); border-radius:7px; background:color-mix(in srgb, var(--card) 96%, transparent); color:var(--text); font:inherit; line-height:1.45; padding:.5rem .6rem; }
@@ -1338,9 +1341,10 @@
     .blocks-textarea { resize:vertical; font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Ubuntu Mono", monospace; font-size:.9rem; }
     .blocks-source-textarea { min-height:0; width:100%; resize:none; overflow:hidden; padding-block:0; }
     .blocks-source-textarea:focus { outline:none; box-shadow:none; border-color:color-mix(in srgb, var(--border) 82%, transparent); }
-    .blocks-image-figure { margin:0; display:flex; flex-direction:column; gap:.45rem; align-items:flex-start; }
-    .blocks-image-preview { display:block; max-width:100%; max-height:28rem; height:auto; border-radius:8px; border:1px solid color-mix(in srgb, var(--border) 72%, transparent); background:color-mix(in srgb, var(--text) 3%, transparent); box-shadow:0 1px 2px rgba(15,23,42,.08); object-fit:contain; }
-    .blocks-image-figure figcaption { color:var(--muted); font-size:.86rem; word-break:break-word; }
+    .blocks-image-figure { margin:0; display:block; width:100%; }
+    .blocks-image-preview { display:block; width:100%; height:auto; border-radius:.5rem; background:color-mix(in srgb, var(--text) 3%, transparent); box-shadow:var(--shadow, 0 1px 2px rgba(15,23,42,.08)); object-fit:contain; }
+    .blocks-image-figure figcaption { margin-top:.5em; color:var(--muted); font-family:var(--serif, var(--article-serif-stack, Georgia, "Times New Roman", Times, serif)); font-size:.9em; text-align:center; word-break:break-word; }
+    .blocks-image-figure figcaption[hidden] { display:none !important; }
     .blocks-visual-list { margin:.1rem 0 .2rem; padding-left:1.65rem; line-height:1.6; }
     .blocks-visual-list-task { list-style:none; padding-left:0; }
     .blocks-list-item { padding:.28rem 0; }

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -509,6 +509,18 @@ assert.match(
 
 assert.match(
   editorMainSource,
+  /let pendingBlocksImageInsert = null;[\s\S]*let pendingImagePickerToken = 0;[\s\S]*const armImagePickerCancelReset = \(token\) => \{[\s\S]*if \(token !== pendingImagePickerToken\) return;[\s\S]*if \(!hasFiles\) pendingBlocksImageInsert = null;[\s\S]*imageInput\.addEventListener\('cancel', clearIfPickerStillPending, \{ once: true \}\);[\s\S]*imageInput\.addEventListener\('blur', clearIfPickerStillPending, \{ once: true \}\);[\s\S]*const openImageInputPicker = \(\) => \{[\s\S]*pendingImagePickerToken \+= 1;[\s\S]*imageInput\.value = '';[\s\S]*armImagePickerCancelReset\(pickerToken\);[\s\S]*imageInput\.click\(\);/,
+  'image picker cancellation should clear stale pending replacement targets'
+);
+
+assert.match(
+  editorMainSource,
+  /imageInput\.addEventListener\('change', \(\) => \{[\s\S]*const blockInsert = pendingBlocksImageInsert;[\s\S]*pendingBlocksImageInsert = null;[\s\S]*pendingImagePickerToken \+= 1;[\s\S]*if \(files && files\.length\) \{/,
+  'image picker changes should consume the pending replacement target before handling files'
+);
+
+assert.match(
+  editorMainSource,
   /const refreshPreviewAssetOverrides = \(\) => \{[\s\S]*\['mainview', 'blocks-wrap'\]\.forEach\(\(id\) => \{[\s\S]*document\.getElementById\(id\)[\s\S]*applyPreviewAssetOverrides\(target, previewAssetCurrentPath\);[\s\S]*\}\);[\s\S]*\};/,
   'asset preview refresh should update both rendered preview and WYSIWYG block images'
 );

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -471,10 +471,10 @@ assert.match(
   'image blocks should render a real image element instead of a path-only placeholder'
 );
 
-assert.match(
+assert.doesNotMatch(
   editorBlocksSource,
-  /const renderImageBlock = \(body, block, index\) => \{[\s\S]*const selectImageBlock = \(event\) => \{[\s\S]*event\.preventDefault\(\);[\s\S]*event\.stopPropagation\(\);[\s\S]*clearNativeSelection\(\);[\s\S]*setActive\(index\);[\s\S]*figure\.addEventListener\('pointerdown', selectImageBlock\);[\s\S]*figure\.addEventListener\('click', selectImageBlock\);/,
-  'image figure pointer and click events should select the image block directly'
+  /const selectImageBlock = \(event\) => \{[\s\S]*figure\.addEventListener\('pointerdown', selectImageBlock\);[\s\S]*figure\.addEventListener\('click', selectImageBlock\);/,
+  'image figures should rely on delegated block pointer routing, not stopped local click handlers'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -501,6 +501,12 @@ assert.match(
   'image upload picker should support replacing one existing image block through the existing asset pipeline'
 );
 
+assert.match(
+  editorMainSource,
+  /const refreshPreviewAssetOverrides = \(\) => \{[\s\S]*\['mainview', 'blocks-wrap'\]\.forEach\(\(id\) => \{[\s\S]*document\.getElementById\(id\)[\s\S]*applyPreviewAssetOverrides\(target, previewAssetCurrentPath\);[\s\S]*\}\);[\s\S]*\};/,
+  'asset preview refresh should update both rendered preview and WYSIWYG block images'
+);
+
 assert.doesNotMatch(
   editorBlocksSource,
   /blocks-image-inspector/,

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -479,7 +479,7 @@ assert.doesNotMatch(
 
 assert.match(
   editorBlocksSource,
-  /const createImageMetadataControls = \(block, index\) => \{[\s\S]*controls\.className = 'blocks-image-meta-controls';[\s\S]*alt\.className = 'blocks-image-alt';[\s\S]*const replace = button\(text\('replaceImage', 'Replace image'\), 'blocks-btn blocks-image-replace'\);[\s\S]*title\.className = 'blocks-image-title';[\s\S]*updateFromControl\(block, \{ alt: inputValue\(alt\), title: inputValue\(title\) \}\);[\s\S]*options\.requestImageUpload\(\{ replaceIndex: index \}\);[\s\S]*controls\.append\(alt, title, replace\);/,
+  /const createImageMetadataControls = \(block, index\) => \{[\s\S]*controls\.className = 'blocks-image-meta-controls';[\s\S]*alt\.className = 'blocks-image-alt';[\s\S]*const replace = button\(text\('replaceImage', 'Replace image'\), 'blocks-btn blocks-image-replace'\);[\s\S]*title\.className = 'blocks-image-title';[\s\S]*updateFromControl\(block, \{ alt: inputValue\(alt\), title: inputValue\(title\) \}\);[\s\S]*options\.requestImageUpload\(\{ replaceIndex: index, replaceBlockId: block\.id \}\);[\s\S]*controls\.append\(alt, title, replace\);/,
   'image metadata controls should place replace-image after text fields'
 );
 
@@ -491,14 +491,20 @@ assert.match(
 
 assert.match(
   editorBlocksSource,
-  /replaceImageBlock\(src, index = state\.activeIndex\) \{[\s\S]*block\.type !== 'image'[\s\S]*updateFromControl\(block, \{ src \}\);[\s\S]*syncRenderedImageBlock\(block\);[\s\S]*setActive\(safeIndex\);[\s\S]*return \{ index: safeIndex \};/,
-  'image replacement should update the existing image block src without inserting another block'
+  /replaceImageBlock\(src, target = state\.activeIndex\) \{[\s\S]*const expectedBlockId = target && typeof target === 'object' && typeof target\.blockId === 'string'[\s\S]*if \(!Number\.isInteger\(safeIndex\) \|\| safeIndex < 0 \|\| safeIndex >= state\.blocks\.length\) \{[\s\S]*if \(!expectedBlockId\) return null;[\s\S]*state\.blocks\.findIndex\(item => item && item\.id === expectedBlockId\)[\s\S]*if \(expectedBlockId && \(!block \|\| block\.id !== expectedBlockId\)\) \{[\s\S]*block\.type !== 'image'[\s\S]*updateFromControl\(block, \{ src \}\);[\s\S]*syncRenderedImageBlock\(block\);[\s\S]*setActive\(safeIndex\);[\s\S]*return \{ index: safeIndex \};/,
+  'image replacement should validate the target image identity before updating an existing block'
+);
+
+assert.doesNotMatch(
+  editorBlocksSource,
+  /replaceImageBlock\(src, index = state\.activeIndex\) \{[\s\S]*Math\.max\(0, Math\.min/,
+  'image replacement should not clamp stale out-of-range indexes onto another block'
 );
 
 assert.match(
   editorMainSource,
-  /requestImageUpload: \(\{ index, replaceIndex \} = \{\}\) => \{[\s\S]*replaceIndex: Number\.isFinite\(replaceIndex\) \? replaceIndex : null[\s\S]*const replaceIndex = blockInsert && Number\.isFinite\(blockInsert\.replaceIndex\)[\s\S]*const replaceMarkdown = replaceIndex != null[\s\S]*markdownBlocksEditor\.replaceImageBlock\(relativePath, replaceIndex\);[\s\S]*singleImage: !!replaceMarkdown/,
-  'image upload picker should support replacing one existing image block through the existing asset pipeline'
+  /requestImageUpload: \(\{ index, replaceIndex, replaceBlockId \} = \{\}\) => \{[\s\S]*replaceIndex: Number\.isFinite\(replaceIndex\) \? replaceIndex : null,[\s\S]*replaceBlockId: typeof replaceBlockId === 'string' && replaceBlockId \? replaceBlockId : null[\s\S]*const replaceIndex = blockInsert && Number\.isFinite\(blockInsert\.replaceIndex\)[\s\S]*const replaceBlockId = blockInsert && typeof blockInsert\.replaceBlockId === 'string'[\s\S]*const replaceMarkdown = \(replaceIndex != null \|\| replaceBlockId\)[\s\S]*markdownBlocksEditor\.replaceImageBlock\(relativePath, \{ index: replaceIndex, blockId: replaceBlockId \}\);[\s\S]*singleImage: !!replaceMarkdown/,
+  'image upload picker should support replacing one existing image block through an identity-checked target'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -335,6 +335,18 @@ assert.match(
 
 assert.match(
   editorBlocksSource,
+  /const clearNativeSelection = \(\) => \{[\s\S]*sel\.removeAllRanges\(\);[\s\S]*\};/,
+  'non-text block selection should be able to clear stale browser text selections'
+);
+
+assert.match(
+  editorBlocksSource,
+  /const routeBlocksCaretFromPointer = \(event\) => \{[\s\S]*isBlocksCaretInteractiveTarget\(event\.target\)[\s\S]*const imageBlock = closestElement\(event\.target, '\.blocks-block-image'\);[\s\S]*event\.preventDefault\(\);[\s\S]*clearNativeSelection\(\);[\s\S]*setActive\(imageIndex\);[\s\S]*return;[\s\S]*const candidate = nearestEditableFromPoint\(event\.clientX, event\.clientY\);/,
+  'image block pointerdowns should clear stale text selections and select the image block before routing a caret to nearby text'
+);
+
+assert.match(
+  editorBlocksSource,
   /const editableCaretCandidates = \(\) => \{[\s\S]*querySelectorAll\('\.blocks-list-item \.blocks-list-text'\)[\s\S]*hitTarget: closestElement\(editable, '\.blocks-list-item'\) \|\| editable[\s\S]*querySelectorAll\('\.blocks-rich-editable:not\(\.blocks-list-text\), \.blocks-code-preview code\[contenteditable="true"\], \.blocks-source-textarea'\)[\s\S]*sync: editableSyncMap\.get\(editable\) \|\| null/,
   'routed caret candidates should include whole-row list item hit targets, rich text, code editors, and source markdown textareas with sync callbacks'
 );
@@ -451,6 +463,30 @@ assert.match(
   editorBlocksSource,
   /const img = document\.createElement\('img'\);[\s\S]*img\.className = 'blocks-image-preview'[\s\S]*img\.src = resolved/,
   'image blocks should render a real image element instead of a path-only placeholder'
+);
+
+assert.match(
+  editorBlocksSource,
+  /const renderImageBlock = \(body, block, index\) => \{[\s\S]*const selectImageBlock = \(event\) => \{[\s\S]*event\.preventDefault\(\);[\s\S]*event\.stopPropagation\(\);[\s\S]*clearNativeSelection\(\);[\s\S]*setActive\(index\);[\s\S]*figure\.addEventListener\('pointerdown', selectImageBlock\);[\s\S]*figure\.addEventListener\('click', selectImageBlock\);/,
+  'image figure pointer and click events should select the image block directly'
+);
+
+assert.match(
+  editorBlocksSource,
+  /const createImageMetadataControls = \(block\) => \{[\s\S]*controls\.className = 'blocks-image-meta-controls';[\s\S]*alt\.className = 'blocks-image-alt';[\s\S]*src\.className = 'blocks-image-src';[\s\S]*title\.className = 'blocks-image-title';[\s\S]*updateFromControl\(block, \{ alt: inputValue\(alt\), src: inputValue\(src\), title: inputValue\(title\) \}\);[\s\S]*syncRenderedImageBlock\(block\);/,
+  'image metadata controls should live in the active block toolbar and update the rendered preview'
+);
+
+assert.match(
+  editorBlocksSource,
+  /if \(block\.type === 'image'\) \{[\s\S]*head\.appendChild\(createImageMetadataControls\(block\)\);[\s\S]*\}/,
+  'image block controls should be appended to the floating block toolbar'
+);
+
+assert.doesNotMatch(
+  editorBlocksSource,
+  /blocks-image-inspector/,
+  'image metadata controls should not render as an inspector inside the block body'
 );
 
 assert.match(
@@ -575,7 +611,7 @@ assert.match(
 
 assert.match(
   editorSource,
-  /\.blocks-toolbar, \.blocks-block-head, \.blocks-link-editor, \.blocks-inspector, \.blocks-card-picker, \.blocks-action-menu, \.blocks-inline-more-menu \{ cursor:default; \}/,
+  /\.blocks-toolbar, \.blocks-block-head, \.blocks-link-editor, \.blocks-image-meta-controls, \.blocks-inspector, \.blocks-card-picker, \.blocks-action-menu, \.blocks-inline-more-menu \{ cursor:default; \}/,
   'blocks controls and floating panels should not inherit the canvas text cursor'
 );
 
@@ -709,6 +745,18 @@ assert.match(
   editorSource,
   /\.blocks-block-head \.blocks-heading-level, \.blocks-block-head \.blocks-list-type-select, \.blocks-block-head \.blocks-code-language[\s\S]*\.blocks-block-head \.blocks-code-language \{ width:8\.5rem; max-width:26vw; \}/,
   'code block language input should use compact floating-toolbar styling'
+);
+
+assert.match(
+  editorSource,
+  /\.blocks-block-head \.blocks-heading-level, \.blocks-block-head \.blocks-list-type-select, \.blocks-block-head \.blocks-code-language, \.blocks-block-head \.blocks-image-meta-controls input[\s\S]*\.blocks-image-meta-controls \{ display:flex; align-items:center; gap:\.24rem;[\s\S]*\.blocks-block-head \.blocks-image-meta-controls \.blocks-image-src \{ width:clamp\(8rem, 16vw, 13rem\); max-width:24vw; \}/,
+  'image metadata fields should use compact floating-toolbar input styling'
+);
+
+assert.match(
+  editorSource,
+  /\.blocks-image-figure \{ margin:0; display:block; width:100%; \}[\s\S]*\.blocks-image-preview \{ display:block; width:100%; height:auto; border-radius:\.5rem;[\s\S]*box-shadow:var\(--shadow,[\s\S]*\.blocks-image-figure figcaption \{ margin-top:\.5em; color:var\(--muted\); font-family:var\(--serif,[\s\S]*font-size:\.9em; text-align:center;[\s\S]*\.blocks-image-figure figcaption\[hidden\] \{ display:none !important; \}/,
+  'image block visual styling should mirror native article image and centered figcaption styling'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -114,6 +114,12 @@ assert.match(
   'block link title field should have a local fallback label'
 );
 
+assert.match(
+  editorMainSource,
+  /replaceImage: 'Replace image'/,
+  'block replace image button should have a local fallback label'
+);
+
 [
   [enI18nSource, /linkTitle: 'Link title'/],
   [chsI18nSource, /linkTitle: '链接标题'/],
@@ -473,20 +479,38 @@ assert.match(
 
 assert.match(
   editorBlocksSource,
-  /const createImageMetadataControls = \(block\) => \{[\s\S]*controls\.className = 'blocks-image-meta-controls';[\s\S]*alt\.className = 'blocks-image-alt';[\s\S]*src\.className = 'blocks-image-src';[\s\S]*title\.className = 'blocks-image-title';[\s\S]*updateFromControl\(block, \{ alt: inputValue\(alt\), src: inputValue\(src\), title: inputValue\(title\) \}\);[\s\S]*syncRenderedImageBlock\(block\);/,
-  'image metadata controls should live in the active block toolbar and update the rendered preview'
+  /const createImageMetadataControls = \(block, index\) => \{[\s\S]*controls\.className = 'blocks-image-meta-controls';[\s\S]*alt\.className = 'blocks-image-alt';[\s\S]*const replace = button\(text\('replaceImage', 'Replace image'\), 'blocks-btn blocks-image-replace'\);[\s\S]*title\.className = 'blocks-image-title';[\s\S]*updateFromControl\(block, \{ alt: inputValue\(alt\), title: inputValue\(title\) \}\);[\s\S]*options\.requestImageUpload\(\{ replaceIndex: index \}\);[\s\S]*controls\.append\(alt, replace, title\);/,
+  'image metadata controls should replace the path input with a replace-image upload button'
 );
 
 assert.match(
   editorBlocksSource,
-  /if \(block\.type === 'image'\) \{[\s\S]*head\.appendChild\(createImageMetadataControls\(block\)\);[\s\S]*\}/,
+  /if \(block\.type === 'image'\) \{[\s\S]*head\.appendChild\(createImageMetadataControls\(block, index\)\);[\s\S]*\}/,
   'image block controls should be appended to the floating block toolbar'
+);
+
+assert.match(
+  editorBlocksSource,
+  /replaceImageBlock\(src, index = state\.activeIndex\) \{[\s\S]*block\.type !== 'image'[\s\S]*updateFromControl\(block, \{ src \}\);[\s\S]*syncRenderedImageBlock\(block\);[\s\S]*setActive\(safeIndex\);[\s\S]*return \{ index: safeIndex \};/,
+  'image replacement should update the existing image block src without inserting another block'
+);
+
+assert.match(
+  editorMainSource,
+  /requestImageUpload: \(\{ index, replaceIndex \} = \{\}\) => \{[\s\S]*replaceIndex: Number\.isFinite\(replaceIndex\) \? replaceIndex : null[\s\S]*const replaceIndex = blockInsert && Number\.isFinite\(blockInsert\.replaceIndex\)[\s\S]*const replaceMarkdown = replaceIndex != null[\s\S]*markdownBlocksEditor\.replaceImageBlock\(relativePath, replaceIndex\);[\s\S]*singleImage: !!replaceMarkdown/,
+  'image upload picker should support replacing one existing image block through the existing asset pipeline'
 );
 
 assert.doesNotMatch(
   editorBlocksSource,
   /blocks-image-inspector/,
   'image metadata controls should not render as an inspector inside the block body'
+);
+
+assert.doesNotMatch(
+  editorBlocksSource,
+  /blocks-image-src/,
+  'image metadata controls should not expose a direct image path input'
 );
 
 assert.match(
@@ -749,8 +773,8 @@ assert.match(
 
 assert.match(
   editorSource,
-  /\.blocks-block-head \.blocks-heading-level, \.blocks-block-head \.blocks-list-type-select, \.blocks-block-head \.blocks-code-language, \.blocks-block-head \.blocks-image-meta-controls input[\s\S]*\.blocks-image-meta-controls \{ display:flex; align-items:center; gap:\.24rem;[\s\S]*\.blocks-block-head \.blocks-image-meta-controls \.blocks-image-src \{ width:clamp\(8rem, 16vw, 13rem\); max-width:24vw; \}/,
-  'image metadata fields should use compact floating-toolbar input styling'
+  /\.blocks-block-head \.blocks-heading-level, \.blocks-block-head \.blocks-list-type-select, \.blocks-block-head \.blocks-code-language, \.blocks-block-head \.blocks-image-meta-controls input, \.blocks-block-head \.blocks-image-replace[\s\S]*\.blocks-image-meta-controls \{ display:flex; align-items:center; gap:\.24rem;[\s\S]*\.blocks-block-head \.blocks-image-replace \{ white-space:nowrap; cursor:pointer; \}/,
+  'image metadata fields and replace button should use compact floating-toolbar styling'
 );
 
 assert.match(
@@ -1547,6 +1571,14 @@ assert.match(
     i18nText,
     /status:\s*\{[\s\S]*added:[\s\S]*modified:[\s\S]*deleted:[\s\S]*checking:[\s\S]*changedCount:[\s\S]*changedSummary:[\s\S]*orderChanged:[\s\S]*deletedSummary:/,
     `locale ${index} should expose editor tree status badge text`
+  );
+});
+
+[enI18nSource, chsI18nSource, chtTwI18nSource, jaI18nSource].forEach((i18nText, index) => {
+  assert.match(
+    i18nText,
+    /replaceImage:/,
+    `locale ${index} should expose image replacement toolbar text`
   );
 });
 

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -479,8 +479,8 @@ assert.match(
 
 assert.match(
   editorBlocksSource,
-  /const createImageMetadataControls = \(block, index\) => \{[\s\S]*controls\.className = 'blocks-image-meta-controls';[\s\S]*alt\.className = 'blocks-image-alt';[\s\S]*const replace = button\(text\('replaceImage', 'Replace image'\), 'blocks-btn blocks-image-replace'\);[\s\S]*title\.className = 'blocks-image-title';[\s\S]*updateFromControl\(block, \{ alt: inputValue\(alt\), title: inputValue\(title\) \}\);[\s\S]*options\.requestImageUpload\(\{ replaceIndex: index \}\);[\s\S]*controls\.append\(alt, replace, title\);/,
-  'image metadata controls should replace the path input with a replace-image upload button'
+  /const createImageMetadataControls = \(block, index\) => \{[\s\S]*controls\.className = 'blocks-image-meta-controls';[\s\S]*alt\.className = 'blocks-image-alt';[\s\S]*const replace = button\(text\('replaceImage', 'Replace image'\), 'blocks-btn blocks-image-replace'\);[\s\S]*title\.className = 'blocks-image-title';[\s\S]*updateFromControl\(block, \{ alt: inputValue\(alt\), title: inputValue\(title\) \}\);[\s\S]*options\.requestImageUpload\(\{ replaceIndex: index \}\);[\s\S]*controls\.append\(alt, title, replace\);/,
+  'image metadata controls should place replace-image after text fields'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -503,8 +503,14 @@ assert.doesNotMatch(
 
 assert.match(
   editorMainSource,
-  /requestImageUpload: \(\{ index, replaceIndex, replaceBlockId \} = \{\}\) => \{[\s\S]*replaceIndex: Number\.isFinite\(replaceIndex\) \? replaceIndex : null,[\s\S]*replaceBlockId: typeof replaceBlockId === 'string' && replaceBlockId \? replaceBlockId : null[\s\S]*const replaceIndex = blockInsert && Number\.isFinite\(blockInsert\.replaceIndex\)[\s\S]*const replaceBlockId = blockInsert && typeof blockInsert\.replaceBlockId === 'string'[\s\S]*const replaceMarkdown = \(replaceIndex != null \|\| replaceBlockId\)[\s\S]*markdownBlocksEditor\.replaceImageBlock\(relativePath, \{ index: replaceIndex, blockId: replaceBlockId \}\);[\s\S]*singleImage: !!replaceMarkdown/,
+  /requestImageUpload: \(\{ index, replaceIndex, replaceBlockId \} = \{\}\) => \{[\s\S]*replaceIndex: Number\.isFinite\(replaceIndex\) \? replaceIndex : null,[\s\S]*replaceBlockId: typeof replaceBlockId === 'string' && replaceBlockId \? replaceBlockId : null[\s\S]*const replaceIndex = blockInsert && Number\.isFinite\(blockInsert\.replaceIndex\)[\s\S]*const replaceBlockId = blockInsert && typeof blockInsert\.replaceBlockId === 'string'[\s\S]*const replaceMarkdown = \(replaceIndex != null \|\| replaceBlockId\)[\s\S]*const result = markdownBlocksEditor\.replaceImageBlock\(relativePath, \{ index: replaceIndex, blockId: replaceBlockId \}\);[\s\S]*if \(!result\) return false;[\s\S]*singleImage: !!replaceMarkdown[\s\S]*if \(replaceMarkdown\) imageFileOptions\.insertAbortToast = t\('editor\.toasts\.imageReplaceTargetMissing'\);/,
   'image upload picker should support replacing one existing image block through an identity-checked target'
+);
+
+assert.match(
+  editorMainSource,
+  /let selection;[\s\S]*if \(customInsertMarkdown\) \{[\s\S]*selection = customInsertMarkdown\(paths\.relativePath, meta\.altText\);[\s\S]*if \(selection === false\) \{[\s\S]*if \(options\.insertAbortToast\) emitEditorToast\('warn', options\.insertAbortToast\);[\s\S]*continue;[\s\S]*window\.dispatchEvent\(new CustomEvent\('ns-editor-asset-added'/,
+  'image uploads should skip asset-added events and success toasts when replacement aborts'
 );
 
 assert.match(


### PR DESCRIPTION
## Summary

This PR fixes image blocks in the WYSIWYG editor so they behave like selectable visual blocks and exposes image metadata through the active block toolbar.

## Changes

- Make image visual surfaces selectable without routing the caret into nearby text blocks.
- Match image preview styling more closely to the native article output, including centered captions and no path fallback caption.
- Move image metadata editing into the floating toolbar.
- Replace the visible image path field with a `Replace image` upload action that preserves alt/title and updates the current block.
- Refresh local uploaded image previews in both the rendered preview and WYSIWYG blocks view.
- Move the `Replace image` action after the text fields in the image toolbar.

## Validation

- `node --check assets/js/editor-main.js && node --check assets/js/editor-blocks.js`
- `node scripts/test-composer-identity-grid.js`
- `node scripts/test-editor-blocks-roundtrip.js`
- Browser smoke on `http://localhost:8000/index_editor.html` for image selection, toolbar controls, and control ordering.