### PR TITLE
[codex] editor mobile toolbar layout

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -8750,14 +8750,20 @@ function isEditorMobileRailLayout() {
   }
 }
 
+function getEditorRailToggles() {
+  return Array.from(document.querySelectorAll('[data-editor-rail-toggle]'));
+}
+
 function setEditorRailOpen(open) {
   const shell = document.getElementById('editorAppShell');
-  const toggle = document.getElementById('editorMobileRailToggle');
+  const toggles = getEditorRailToggles();
   const scrim = document.getElementById('editorRailScrim');
   if (!shell) return;
   const shouldOpen = !!open && isEditorMobileRailLayout();
   shell.classList.toggle('is-rail-open', shouldOpen);
-  if (toggle) toggle.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
+  toggles.forEach((toggle) => {
+    toggle.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
+  });
   if (scrim) {
     scrim.hidden = !shouldOpen;
     scrim.setAttribute('aria-hidden', shouldOpen ? 'false' : 'true');
@@ -8770,14 +8776,16 @@ function closeEditorRailDrawer() {
 
 function initMobileEditorRail() {
   if (editorMobileRailBound) return;
-  const toggle = document.getElementById('editorMobileRailToggle');
+  const toggles = getEditorRailToggles();
   const scrim = document.getElementById('editorRailScrim');
-  if (!toggle) return;
+  if (!toggles.length) return;
   editorMobileRailBound = true;
-  toggle.addEventListener('click', () => {
-    const shell = document.getElementById('editorAppShell');
-    const isOpen = !!(shell && shell.classList.contains('is-rail-open'));
-    setEditorRailOpen(!isOpen);
+  toggles.forEach((toggle) => {
+    toggle.addEventListener('click', () => {
+      const shell = document.getElementById('editorAppShell');
+      const isOpen = !!(shell && shell.classList.contains('is-rail-open'));
+      setEditorRailOpen(!isOpen);
+    });
   });
   if (scrim) scrim.addEventListener('click', closeEditorRailDrawer);
   document.addEventListener('keydown', (event) => {

--- a/index_editor.html
+++ b/index_editor.html
@@ -240,9 +240,9 @@
     .editor-structure-panel { min-width:0; border:0; border-radius:0; background:transparent; padding:0; }
     .editor-system-panel { min-width:0; border:0; border-radius:0; background:transparent; padding:0; }
     .editor-markdown-panel[hidden], .editor-structure-panel[hidden], .editor-system-panel[hidden] { display:none !important; }
-    .editor-structure-panel.is-content-entering .editor-structure-head,
+    .editor-structure-panel.is-content-entering .editor-panel-head,
     .editor-structure-panel.is-content-entering .editor-structure-body { animation:editor-structure-content-enter .2s ease-out both; }
-    .editor-system-panel.is-content-entering .editor-structure-head,
+    .editor-system-panel.is-content-entering .editor-panel-head,
     .editor-system-panel.is-content-entering .editor-system-body { animation:editor-structure-content-enter .2s ease-out both; }
     .editor-structure-panel.is-content-entering .editor-structure-body { animation-delay:.03s; }
     .editor-system-panel.is-content-entering .editor-system-body { animation-delay:.03s; }
@@ -253,13 +253,13 @@
       from { opacity:0; transform:translateY(6px); }
       to { opacity:1; transform:translateY(0); }
     }
-    .editor-structure-head { display:flex; justify-content:space-between; align-items:center; gap:1rem; margin-bottom:1rem; }
-    .editor-structure-heading { min-width:0; }
+    .editor-panel-head, .editor-structure-head { display:flex; justify-content:space-between; align-items:center; gap:1rem; margin-bottom:1rem; min-width:0; }
+    .editor-panel-heading, .editor-structure-heading { flex:1 1 auto; min-width:0; }
     .editor-structure-title-row { display:flex; align-items:baseline; gap:.65rem; min-width:0; flex-wrap:wrap; }
     .editor-structure-kicker { display:none !important; }
-    .editor-structure-head h2 { margin:0; font-size:1.25rem; line-height:1.25; color:var(--text); }
+    .editor-panel-head h2, .editor-structure-head h2 { margin:0; font-size:1.25rem; line-height:1.25; color:var(--text); }
     .editor-structure-meta { margin:0; color:var(--muted); font-size:.92rem; line-height:1.35; }
-    .editor-structure-actions { display:flex; gap:.45rem; flex-wrap:wrap; justify-content:flex-end; align-items:center; align-self:center; }
+    .editor-panel-actions, .editor-structure-actions { display:flex; gap:.45rem; flex-wrap:wrap; justify-content:flex-end; align-items:center; align-self:center; margin-left:auto; max-width:100%; }
     .editor-structure-body { display:flex; flex-direction:column; gap:.75rem; min-width:0; }
     .editor-system-body { display:flex; flex-direction:column; gap:1rem; min-width:0; }
     .editor-structure-row { display:grid; grid-template-columns:minmax(90px, 140px) minmax(0, 1fr) auto; gap:.55rem; align-items:center; min-height:2.2rem; }
@@ -1248,6 +1248,19 @@
       .editor-markdown-panel > .toolbar .current-file {
         display:none;
       }
+      .editor-panel-head {
+        flex-wrap:wrap;
+        gap:.5rem;
+      }
+      .editor-panel-head .editor-mobile-rail-toggle {
+        flex:0 0 auto;
+      }
+      .editor-panel-heading {
+        flex:1 1 10rem;
+      }
+      .editor-panel-actions {
+        justify-content:flex-end;
+      }
       .frontmatter-panel {
         border-radius:0;
       }
@@ -1994,22 +2007,28 @@
       <section class="box editor-main editor-content-shell">
         <div class="editor-detail-pane">
           <section class="editor-structure-panel" id="editorStructurePanel" aria-live="polite">
-            <div class="editor-structure-head">
-              <div class="editor-structure-heading">
+            <div class="editor-panel-head editor-structure-head">
+              <button type="button" class="editor-mobile-rail-toggle" data-editor-rail-toggle aria-controls="editorRail" aria-expanded="false" aria-label="Content files" title="Content files" data-i18n-aria-label="editor.tree.aria" data-i18n-title="editor.tree.aria">
+                <svg class="editor-mobile-rail-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                  <rect width="18" height="18" x="3" y="3" rx="2"></rect>
+                  <path d="M9 3v18"></path>
+                </svg>
+              </button>
+              <div class="editor-panel-heading editor-structure-heading">
                 <p class="editor-structure-kicker" id="editorStructureKicker" data-i18n="editor.tree.kicker">Content structure</p>
                 <div class="editor-structure-title-row">
                   <h2 id="editorStructureTitle" data-i18n="editor.tree.emptyTitle">Select a node</h2>
                   <p id="editorStructureMeta" class="editor-structure-meta" data-i18n="editor.tree.emptyMeta">Choose an item in the tree to manage its structure or edit a Markdown file.</p>
                 </div>
               </div>
-              <div class="editor-structure-actions" id="editorStructureActions"></div>
+              <div class="editor-panel-actions editor-structure-actions" id="editorStructureActions"></div>
             </div>
             <div class="editor-structure-body" id="editorStructureBody"></div>
           </section>
           <section class="editor-markdown-panel" id="editorMarkdownPanel" hidden aria-hidden="true">
             <div class="toolbar">
               <div class="left-actions">
-                <button type="button" class="editor-mobile-rail-toggle" id="editorMobileRailToggle" aria-controls="editorRail" aria-expanded="false" aria-label="Content files" title="Content files" data-i18n-aria-label="editor.tree.aria" data-i18n-title="editor.tree.aria">
+                <button type="button" class="editor-mobile-rail-toggle" data-editor-rail-toggle aria-controls="editorRail" aria-expanded="false" aria-label="Content files" title="Content files" data-i18n-aria-label="editor.tree.aria" data-i18n-title="editor.tree.aria">
                   <svg class="editor-mobile-rail-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
                     <rect width="18" height="18" x="3" y="3" rx="2"></rect>
                     <path d="M9 3v18"></path>
@@ -2101,15 +2120,21 @@
         </div>
           </section>
           <section class="editor-system-panel" id="editorSystemPanel" hidden aria-hidden="true" aria-live="polite">
-            <div class="editor-structure-head">
-              <div class="editor-structure-heading">
+            <div class="editor-panel-head editor-structure-head">
+              <button type="button" class="editor-mobile-rail-toggle" data-editor-rail-toggle aria-controls="editorRail" aria-expanded="false" aria-label="Content files" title="Content files" data-i18n-aria-label="editor.tree.aria" data-i18n-title="editor.tree.aria">
+                <svg class="editor-mobile-rail-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                  <rect width="18" height="18" x="3" y="3" rx="2"></rect>
+                  <path d="M9 3v18"></path>
+                </svg>
+              </button>
+              <div class="editor-panel-heading editor-structure-heading">
                 <p class="editor-structure-kicker" id="editorSystemKicker" data-i18n="editor.tree.system">System</p>
                 <div class="editor-structure-title-row">
                   <h2 id="editorSystemTitle" data-i18n="editor.tree.system">System</h2>
                   <p id="editorSystemMeta" class="editor-structure-meta"></p>
                 </div>
               </div>
-              <div class="editor-structure-actions" id="editorSystemActions"></div>
+              <div class="editor-panel-actions editor-structure-actions" id="editorSystemActions"></div>
             </div>
             <div class="editor-system-body" id="editorSystemBody"></div>
           </section>

--- a/index_editor.html
+++ b/index_editor.html
@@ -121,7 +121,8 @@
       min-width:0;
       min-height:0;
       max-height:100%;
-      overflow:auto;
+      overflow-x:hidden;
+      overflow-y:auto;
       padding:var(--editor-content-pane-padding);
       position:relative;
       container-type:inline-size;
@@ -140,13 +141,12 @@
       display:none;
       align-items:center;
       justify-content:center;
-      position:sticky;
-      top:0;
-      z-index:140;
-      width:max-content;
-      min-height:2.1rem;
-      margin:0 0 .75rem;
-      padding:.35rem .65rem;
+      position:relative;
+      width:2.35rem;
+      height:2.35rem;
+      min-height:2.35rem;
+      margin:0;
+      padding:0;
       border:1px solid color-mix(in srgb, var(--border) 82%, transparent);
       border-radius:8px;
       background:color-mix(in srgb, var(--card) 96%, transparent);
@@ -154,6 +154,12 @@
       box-shadow:var(--shadow);
       font:inherit;
       cursor:pointer;
+    }
+    .editor-mobile-rail-toggle svg {
+      width:1.25rem;
+      height:1.25rem;
+      display:block;
+      flex:0 0 auto;
     }
     .editor-mobile-rail-scrim {
       display:none;
@@ -1208,8 +1214,39 @@
       }
     }
     @media (max-width: 640px) {
+      .editor-content-pane {
+        --editor-content-pane-padding:0px;
+      }
       .editor-workspace {
         gap:.85rem;
+      }
+      .editor-markdown-panel > .toolbar {
+        display:grid;
+        grid-template-columns:auto minmax(0, 1fr);
+        align-items:center;
+        column-gap:.5rem;
+      }
+      .editor-markdown-panel > .toolbar .left-actions,
+      .editor-markdown-panel > .toolbar .right-actions {
+        min-width:0;
+      }
+      .editor-markdown-panel > .toolbar .left-actions {
+        grid-column:1;
+        flex:0 0 auto;
+        flex-wrap:nowrap;
+      }
+      .editor-markdown-panel > .toolbar .right-actions {
+        grid-column:2;
+        flex-wrap:wrap;
+        justify-content:flex-end;
+        justify-self:end;
+        max-width:100%;
+      }
+      .editor-markdown-panel > .toolbar .editor-mobile-rail-toggle {
+        flex:0 0 auto;
+      }
+      .editor-markdown-panel > .toolbar .current-file {
+        display:none;
       }
       .frontmatter-panel {
         border-radius:0;
@@ -1633,7 +1670,7 @@
     .syntax-language-label { position: absolute; top: .5rem; right: .75rem; background: rgba(0,0,0,.6); color: rgba(255,255,255,.9); padding: .25rem .5rem; border-radius: .25rem; font-size: .75rem; font-weight: 500; opacity: .8; border: 1px solid rgba(255,255,255,.1); cursor: pointer; user-select: none; line-height: 1; }
 
     @media (max-width: 640px) {
-      .editor-page { padding: .75rem; }
+      .editor-page { padding:0; }
     }
 
     .composer-panels { min-width: 0; display: grid; gap: 1.25rem; opacity: 1; transition: opacity 200ms ease; }
@@ -1951,7 +1988,6 @@
       <div class="editor-rail-resizer" id="editorRailResizer" role="separator" aria-orientation="vertical" aria-label="Resize file tree" tabindex="0"></div>
       <main class="editor-content-pane" id="editorContentPane">
         <div class="editor-content-frame">
-          <button type="button" class="editor-mobile-rail-toggle" id="editorMobileRailToggle" aria-controls="editorRail" aria-expanded="false" data-i18n="editor.tree.aria">Content files</button>
 
     <!-- Editor Mode -->
     <div class="editor-layout" id="mode-editor">
@@ -1973,6 +2009,12 @@
           <section class="editor-markdown-panel" id="editorMarkdownPanel" hidden aria-hidden="true">
             <div class="toolbar">
               <div class="left-actions">
+                <button type="button" class="editor-mobile-rail-toggle" id="editorMobileRailToggle" aria-controls="editorRail" aria-expanded="false" aria-label="Content files" title="Content files" data-i18n-aria-label="editor.tree.aria" data-i18n-title="editor.tree.aria">
+                  <svg class="editor-mobile-rail-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+                    <rect width="18" height="18" x="3" y="3" rx="2"></rect>
+                    <path d="M9 3v18"></path>
+                  </svg>
+                </button>
                 <span class="current-file" id="currentFile" aria-live="polite"></span>
               </div>
               <div class="right-actions">

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -1031,8 +1031,20 @@ assert.doesNotMatch(
 
 assert.match(
   editorSource,
-  /class="editor-app-shell" id="editorAppShell"[\s\S]*class="editor-rail editor-file-tree-pane" id="editorRail"[\s\S]*id="editorFileTree" role="tree"[\s\S]*class="editor-content-pane" id="editorContentPane"[\s\S]*class="editor-content-frame"[\s\S]*class="editor-mobile-rail-toggle"[\s\S]*class="editor-layout" id="mode-editor"/,
+  /class="editor-app-shell" id="editorAppShell"[\s\S]*class="editor-rail editor-file-tree-pane" id="editorRail"[\s\S]*id="editorFileTree" role="tree"[\s\S]*class="editor-content-pane" id="editorContentPane"[\s\S]*class="editor-content-frame"[\s\S]*class="editor-layout" id="mode-editor"/,
   'editor should render a fixed two-pane app shell with a left rail and a width-limited right content frame'
+);
+
+assert.match(
+  editorSource,
+  /<section class="editor-markdown-panel" id="editorMarkdownPanel"[\s\S]*<div class="toolbar">[\s\S]*<div class="left-actions">\s*<button type="button" class="editor-mobile-rail-toggle" id="editorMobileRailToggle"[\s\S]*data-i18n-aria-label="editor\.tree\.aria"[\s\S]*data-i18n-title="editor\.tree\.aria"[\s\S]*<svg class="editor-mobile-rail-icon"[\s\S]*<path d="M9 3v18"><\/path>[\s\S]*<\/button>\s*<span class="current-file" id="currentFile"/,
+  'mobile file tree toggle should sit inside the markdown toolbar as an icon-only button before the current file breadcrumb'
+);
+
+assert.doesNotMatch(
+  editorSource,
+  /id="editorMobileRailToggle"[^>]*data-i18n="editor\.tree\.aria"/,
+  'mobile file tree toggle should not translate over its SVG icon with visible text'
 );
 
 assert.doesNotMatch(
@@ -1183,8 +1195,14 @@ assert.match(
 
 assert.match(
   editorSource,
-  /\.editor-rail-tree-scroll \{[^}]*overflow:auto;[\s\S]*\.editor-content-pane \{[^}]*overflow:auto;/,
-  'editor rail tree and right content pane should scroll independently'
+  /@media \(max-width: 640px\) \{[\s\S]*\.editor-page \{ padding:0; \}/,
+  'extra narrow editor page should stay flush to the viewport edge'
+);
+
+assert.match(
+  editorSource,
+  /\.editor-rail-tree-scroll \{[^}]*overflow:auto;[\s\S]*\.editor-content-pane \{[^}]*overflow-x:hidden;[\s\S]*overflow-y:auto;/,
+  'editor rail tree and right content pane should scroll independently without page-level horizontal scrolling'
 );
 
 assert.match(
@@ -2638,6 +2656,12 @@ assert.match(
   editorSource,
   /\.editor-mobile-rail-toggle \{[\s\S]*display:none;[\s\S]*@media \(max-width: 820px\) \{[\s\S]*\.editor-mobile-rail-toggle \{\s*display:inline-flex;/,
   'mobile layout should expose a file tree drawer toggle only on small screens'
+);
+
+assert.match(
+  editorSource,
+  /@media \(max-width: 640px\) \{[\s\S]*\.editor-content-pane \{[\s\S]*--editor-content-pane-padding:0px;[\s\S]*\.editor-markdown-panel > \.toolbar \{[\s\S]*display:grid;[\s\S]*grid-template-columns:auto minmax\(0, 1fr\);[\s\S]*column-gap:\.5rem;[\s\S]*\.editor-markdown-panel > \.toolbar \.left-actions \{[\s\S]*grid-column:1;[\s\S]*flex:0 0 auto;[\s\S]*flex-wrap:nowrap;[\s\S]*\.editor-markdown-panel > \.toolbar \.right-actions \{[\s\S]*grid-column:2;[\s\S]*flex-wrap:wrap;[\s\S]*justify-content:flex-end;[\s\S]*justify-self:end;[\s\S]*max-width:100%;[\s\S]*\.editor-markdown-panel > \.toolbar \.editor-mobile-rail-toggle \{[\s\S]*flex:0 0 auto;[\s\S]*\.editor-markdown-panel > \.toolbar \.current-file \{[\s\S]*display:none;/,
+  'extra narrow markdown toolbar should hide the breadcrumb and right-align editor controls beside the drawer toggle'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -1037,14 +1037,32 @@ assert.match(
 
 assert.match(
   editorSource,
-  /<section class="editor-markdown-panel" id="editorMarkdownPanel"[\s\S]*<div class="toolbar">[\s\S]*<div class="left-actions">\s*<button type="button" class="editor-mobile-rail-toggle" id="editorMobileRailToggle"[\s\S]*data-i18n-aria-label="editor\.tree\.aria"[\s\S]*data-i18n-title="editor\.tree\.aria"[\s\S]*<svg class="editor-mobile-rail-icon"[\s\S]*<path d="M9 3v18"><\/path>[\s\S]*<\/button>\s*<span class="current-file" id="currentFile"/,
-  'mobile file tree toggle should sit inside the markdown toolbar as an icon-only button before the current file breadcrumb'
+  /<section class="editor-structure-panel" id="editorStructurePanel"[\s\S]*<div class="editor-panel-head editor-structure-head">\s*<button type="button" class="editor-mobile-rail-toggle" data-editor-rail-toggle[\s\S]*data-i18n-aria-label="editor\.tree\.aria"[\s\S]*data-i18n-title="editor\.tree\.aria"[\s\S]*<svg class="editor-mobile-rail-icon"[\s\S]*<path d="M9 3v18"><\/path>[\s\S]*<\/button>\s*<div class="editor-panel-heading editor-structure-heading">[\s\S]*<div class="editor-panel-actions editor-structure-actions" id="editorStructureActions"><\/div>/,
+  'structure panel header should expose a mobile file tree drawer toggle before the shared heading'
+);
+
+assert.match(
+  editorSource,
+  /<section class="editor-markdown-panel" id="editorMarkdownPanel"[\s\S]*<div class="toolbar">[\s\S]*<div class="left-actions">\s*<button type="button" class="editor-mobile-rail-toggle" data-editor-rail-toggle[\s\S]*data-i18n-aria-label="editor\.tree\.aria"[\s\S]*data-i18n-title="editor\.tree\.aria"[\s\S]*<svg class="editor-mobile-rail-icon"[\s\S]*<path d="M9 3v18"><\/path>[\s\S]*<\/button>\s*<span class="current-file" id="currentFile"/,
+  'markdown toolbar should keep its visual mobile file tree toggle before the current file breadcrumb'
+);
+
+assert.match(
+  editorSource,
+  /<section class="editor-system-panel" id="editorSystemPanel"[\s\S]*<div class="editor-panel-head editor-structure-head">\s*<button type="button" class="editor-mobile-rail-toggle" data-editor-rail-toggle[\s\S]*data-i18n-aria-label="editor\.tree\.aria"[\s\S]*data-i18n-title="editor\.tree\.aria"[\s\S]*<svg class="editor-mobile-rail-icon"[\s\S]*<path d="M9 3v18"><\/path>[\s\S]*<\/button>\s*<div class="editor-panel-heading editor-structure-heading">[\s\S]*<div class="editor-panel-actions editor-structure-actions" id="editorSystemActions"><\/div>/,
+  'system and publish panel header should expose the shared mobile file tree drawer toggle'
+);
+
+assert.equal(
+  (editorSource.match(/data-editor-rail-toggle/g) || []).length,
+  3,
+  'editor should render one drawer toggle entry for structure, markdown, and system surfaces'
 );
 
 assert.doesNotMatch(
   editorSource,
-  /id="editorMobileRailToggle"[^>]*data-i18n="editor\.tree\.aria"/,
-  'mobile file tree toggle should not translate over its SVG icon with visible text'
+  /id="editorMobileRailToggle"/,
+  'mobile file tree toggles should not depend on one id inside a conditionally hidden panel'
 );
 
 assert.doesNotMatch(
@@ -1892,8 +1910,8 @@ assert.match(
 
 assert.match(
   source,
-  /function initMobileEditorRail\(\) \{[\s\S]*editorMobileRailBound[\s\S]*setEditorRailOpen\(!isOpen\);/,
-  'mobile editor rail should use a drawer toggle instead of the desktop resizer'
+  /function getEditorRailToggles\(\) \{[\s\S]*document\.querySelectorAll\('\[data-editor-rail-toggle\]'\)[\s\S]*function setEditorRailOpen\(open\) \{[\s\S]*const toggles = getEditorRailToggles\(\);[\s\S]*toggles\.forEach\(\(toggle\) => \{[\s\S]*toggle\.setAttribute\('aria-expanded', shouldOpen \? 'true' : 'false'\);[\s\S]*function initMobileEditorRail\(\) \{[\s\S]*const toggles = getEditorRailToggles\(\);[\s\S]*if \(!toggles\.length\) return;[\s\S]*toggles\.forEach\(\(toggle\) => \{[\s\S]*toggle\.addEventListener\('click', \(\) => \{[\s\S]*setEditorRailOpen\(!isOpen\);/,
+  'mobile editor rail should bind every shared drawer toggle and sync expanded state'
 );
 
 assert.match(


### PR DESCRIPTION
## Summary
- Replace the mobile content tree text toggle with an icon-only toolbar button.
- Hide the current-file breadcrumb on narrow screens and right-align editor controls beside the drawer toggle.
- Remove narrow-screen outer editor padding and keep page-level horizontal scrolling suppressed.

## Validation
- `node --check scripts/test-composer-identity-grid.js`
- `node --check assets/js/editor-main.js`
- `node --check assets/js/composer.js`
- `git diff --check`
- Local browser reload of `http://localhost:8000/index_editor.html` during review.

## Known issue
- `node scripts/test-composer-identity-grid.js` still fails at the pre-existing `list blocks should render editable list item elements instead of a textarea` assertion in `scripts/test-composer-identity-grid.js:582`, unrelated to this toolbar layout change.