### PR TITLE
[codex] Add shared nano UI components

### DIFF
--- a/assets/js/components.js
+++ b/assets/js/components.js
@@ -1,0 +1,800 @@
+import { escapeHtml } from './utils.js';
+
+const safe = (value) => escapeHtml(String(value ?? '')) || '';
+const asBool = (value) => value === true || value === 'true' || value === '';
+
+function defineElement(name, ctor) {
+  try {
+    if (typeof customElements !== 'undefined' && !customElements.get(name)) {
+      customElements.define(name, ctor);
+    }
+  } catch (_) {}
+}
+
+function dispatchNanoEvent(element, name, detail = {}) {
+  try {
+    element.dispatchEvent(new CustomEvent(name, {
+      detail,
+      bubbles: true,
+      composed: true
+    }));
+  } catch (_) {}
+}
+
+export class NanoSearch extends HTMLElement {
+  static get observedAttributes() {
+    return ['placeholder', 'value', 'variant', 'label'];
+  }
+
+  constructor() {
+    super();
+    this._input = null;
+    this._inputHandler = (event) => this._handleKeydown(event);
+    this._toggleCleanup = null;
+  }
+
+  connectedCallback() {
+    this.render();
+  }
+
+  disconnectedCallback() {
+    this._unbindInput();
+    this._cleanupToggle();
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (!this.isConnected) return;
+    if (name === 'variant' && oldValue !== newValue) {
+      this.render();
+      return;
+    }
+    if (name === 'value') {
+      this._syncInputState();
+      return;
+    }
+    const input = this.input;
+    if (!input) return;
+    if (name === 'placeholder') {
+      if (newValue == null) input.removeAttribute('placeholder');
+      else input.setAttribute('placeholder', String(newValue));
+      return;
+    }
+    if (name === 'label') {
+      input.setAttribute('aria-label', String(newValue || 'Search'));
+    }
+  }
+
+  get input() {
+    return this.querySelector('input[type="search"]');
+  }
+
+  get value() {
+    const input = this.input;
+    return input ? input.value : (this.getAttribute('value') || '');
+  }
+
+  set value(nextValue) {
+    const value = String(nextValue || '');
+    this.setAttribute('value', value);
+    const input = this.input;
+    if (input && input.value !== value) input.value = value;
+  }
+
+  render() {
+    const previous = this.input ? this.input.value : (this.getAttribute('value') || '');
+    this._unbindInput();
+    this.innerHTML = this._markup();
+    this._input = this.input;
+    this._syncInputState(previous);
+    this._bindInput();
+  }
+
+  setPlaceholder(placeholder) {
+    this.setAttribute('placeholder', String(placeholder || ''));
+  }
+
+  focusInput(options = {}) {
+    const input = this.input;
+    if (!input) return false;
+    try {
+      input.focus(options);
+      return true;
+    } catch (_) {
+      try {
+        input.focus();
+        return true;
+      } catch (__) {
+        return false;
+      }
+    }
+  }
+
+  bindToggle(toggle, options = {}) {
+    this._cleanupToggle();
+    if (!toggle || typeof toggle.addEventListener !== 'function') return;
+    const doc = this.ownerDocument || document;
+    const toggleActiveClass = options.toggleActiveClass || 'is-active';
+    const openClass = options.openClass || 'is-open';
+    const onClick = (event) => {
+      if (event && typeof event.preventDefault === 'function') event.preventDefault();
+      this.setOpen(!this.classList.contains(openClass), { toggle, toggleActiveClass, openClass });
+    };
+    const onKeydown = (event) => {
+      if (event.key !== 'Escape') return;
+      this.setOpen(false, { toggle, toggleActiveClass, openClass });
+      try { toggle.focus({ preventScroll: true }); } catch (_) {}
+    };
+    const onFocusIn = () => this.setOpen(true, { toggle, toggleActiveClass, openClass, skipFocus: true });
+    const onDocClick = (event) => {
+      const target = event && event.target;
+      if (!this.classList.contains(openClass)) return;
+      if (target && (this.contains(target) || toggle.contains(target))) return;
+      this.setOpen(false, { toggle, toggleActiveClass, openClass });
+    };
+    toggle.addEventListener('click', onClick);
+    this.addEventListener('keydown', onKeydown);
+    this.addEventListener('focusin', onFocusIn);
+    doc.addEventListener('click', onDocClick);
+    this._toggleCleanup = () => {
+      try { toggle.removeEventListener('click', onClick); } catch (_) {}
+      try { this.removeEventListener('keydown', onKeydown); } catch (_) {}
+      try { this.removeEventListener('focusin', onFocusIn); } catch (_) {}
+      try { doc.removeEventListener('click', onDocClick); } catch (_) {}
+    };
+  }
+
+  setOpen(open, options = {}) {
+    const toggle = options.toggle || null;
+    const openClass = options.openClass || 'is-open';
+    const toggleActiveClass = options.toggleActiveClass || 'is-active';
+    const isOpen = !!open;
+    this.classList.toggle(openClass, isOpen);
+    if (toggle) {
+      toggle.classList.toggle(toggleActiveClass, isOpen);
+      toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    }
+    if (isOpen && !options.skipFocus) this.focusInput({ preventScroll: true });
+    if (!isOpen && this.ownerDocument && this.ownerDocument.activeElement && this.contains(this.ownerDocument.activeElement)) {
+      try { this.ownerDocument.activeElement.blur(); } catch (_) {}
+    }
+  }
+
+  _markup() {
+    const variant = (this.getAttribute('variant') || 'native').toLowerCase();
+    const placeholder = safe(this.getAttribute('placeholder') || '');
+    const label = safe(this.getAttribute('label') || 'Search');
+    const input = `<input id="searchInput" type="search" autocomplete="off" spellcheck="false" aria-label="${label}" placeholder="${placeholder}" />`;
+    if (variant === 'arcus') {
+      return `<label class="arcus-search" for="searchInput"><span class="arcus-search__icon" aria-hidden="true">&#128269;</span>${input}</label>`;
+    }
+    if (variant === 'solstice') {
+      return `<label class="solstice-search" for="searchInput"><span class="solstice-search__icon" aria-hidden="true">&#128269;</span>${input}</label>`;
+    }
+    return input;
+  }
+
+  _syncInputState(valueOverride) {
+    const input = this.input;
+    if (!input) return;
+    const placeholder = this.getAttribute('placeholder');
+    if (placeholder != null) input.setAttribute('placeholder', placeholder);
+    const label = this.getAttribute('label') || 'Search';
+    input.setAttribute('aria-label', label);
+    const value = valueOverride != null ? String(valueOverride) : (this.getAttribute('value') || '');
+    if (input.value !== value) input.value = value;
+  }
+
+  _bindInput() {
+    const input = this.input;
+    if (!input) return;
+    input.addEventListener('keydown', this._inputHandler);
+  }
+
+  _unbindInput() {
+    const input = this._input || this.input;
+    if (!input) return;
+    try { input.removeEventListener('keydown', this._inputHandler); } catch (_) {}
+    this._input = null;
+  }
+
+  _cleanupToggle() {
+    if (typeof this._toggleCleanup === 'function') {
+      try { this._toggleCleanup(); } catch (_) {}
+    }
+    this._toggleCleanup = null;
+  }
+
+  _handleKeydown(event) {
+    if (!event || event.key !== 'Enter') return;
+    const input = event.target && event.target.closest ? event.target.closest('input[type="search"]') : this.input;
+    const query = input ? String(input.value || '').trim() : '';
+    dispatchNanoEvent(this, 'nano:search', { query });
+  }
+}
+
+export class NanoThemeControls extends HTMLElement {
+  constructor() {
+    super();
+    this._labels = {};
+    this._themePacks = [];
+    this._languages = [];
+    this._currentPack = '';
+    this._currentLang = '';
+    this._clickHandler = (event) => this._handleClick(event);
+    this._changeHandler = (event) => this._handleChange(event);
+    this._eventsBound = false;
+  }
+
+  connectedCallback() {
+    this.render();
+    this._bindEvents();
+  }
+
+  disconnectedCallback() {
+    this._unbindEvents();
+  }
+
+  setLabels(labels = {}) {
+    this._labels = { ...this._labels, ...(labels || {}) };
+    if (this.isConnected) this.render();
+  }
+
+  setThemePacks(packs = [], current = '') {
+    this._themePacks = Array.isArray(packs) ? packs.slice() : [];
+    this._currentPack = String(current || this._currentPack || '');
+    this._populateThemePacks();
+  }
+
+  setLanguages(languages = [], current = '') {
+    this._languages = Array.isArray(languages) ? languages.slice() : [];
+    this._currentLang = String(current || this._currentLang || '');
+    this._populateLanguages();
+  }
+
+  setCurrentPack(value) {
+    this._currentPack = String(value || '');
+    const select = this.querySelector('[data-role="theme-pack"]');
+    if (select && this._currentPack) select.value = this._currentPack;
+  }
+
+  setCurrentLang(value) {
+    this._currentLang = String(value || '');
+    const select = this.querySelector('[data-role="language"]');
+    if (select && this._currentLang) select.value = this._currentLang;
+  }
+
+  render() {
+    this._syncHostClass();
+    this.innerHTML = this._markup();
+    this._populateThemePacks();
+    this._populateLanguages();
+  }
+
+  _label(key, fallback) {
+    return this._labels[key] != null ? String(this._labels[key]) : fallback;
+  }
+
+  _variant() {
+    return (this.getAttribute('variant') || 'native').toLowerCase();
+  }
+
+  _syncHostClass() {
+    const variant = this._variant();
+    if (!this.id) this.id = 'tools';
+    this.classList.remove('box', 'arcus-tools__groups', 'solstice-tools');
+    if (variant === 'arcus') {
+      this.classList.add('arcus-tools__groups');
+    } else if (variant === 'solstice') {
+      this.classList.add('solstice-tools');
+    } else {
+      this.classList.add('box');
+    }
+  }
+
+  _markup() {
+    const variant = this._variant();
+    const sectionTitle = safe(this._label('sectionTitle', 'Tools'));
+    const toggleTheme = safe(this._label('toggleTheme', 'Toggle theme'));
+    const postEditor = safe(this._label('postEditor', 'Post editor'));
+    const themePack = safe(this._label('themePack', 'Theme pack'));
+    const language = safe(this._label('language', 'Language'));
+    const resetLanguage = safe(this._label('resetLanguage', 'Reset language'));
+    if (variant === 'arcus') {
+      return `
+        <div class="arcus-tools__group" role="group" data-group="theme" aria-label="${toggleTheme} &amp; ${themePack}">
+          <button class="arcus-tool" type="button" data-role="theme-toggle" aria-label="${toggleTheme}">
+            <span class="arcus-tool__icon">&#127769;</span>
+            <span class="arcus-tool__label">${toggleTheme}</span>
+          </button>
+          <label class="arcus-tool arcus-tool--select">
+            <span class="arcus-tool__label">${themePack}</span>
+            <select data-role="theme-pack" aria-label="${themePack}"></select>
+          </label>
+        </div>
+        <div class="arcus-tools__group" role="group" data-group="language" aria-label="${language} &amp; ${resetLanguage}">
+          <label class="arcus-tool arcus-tool--select">
+            <span class="arcus-tool__label">${language}</span>
+            <select data-role="language" aria-label="${language}"></select>
+          </label>
+          <button class="arcus-tool" type="button" data-role="language-reset" aria-label="${resetLanguage}">
+            <span class="arcus-tool__icon">&#9851;</span>
+            <span class="arcus-tool__label">${resetLanguage}</span>
+          </button>
+        </div>
+        <div class="arcus-tools__group arcus-tools__group--solo" role="group" data-group="editor" aria-label="${postEditor}">
+          <button class="arcus-tool" type="button" data-role="post-editor" aria-label="${postEditor}">
+            <span class="arcus-tool__icon">&#128221;</span>
+            <span class="arcus-tool__label">${postEditor}</span>
+          </button>
+        </div>`;
+    }
+    if (variant === 'solstice') {
+      return `
+        <button class="solstice-tool" type="button" data-role="theme-toggle" aria-label="${toggleTheme}">
+          <span class="solstice-tool__icon">&#127769;</span>
+          <span class="solstice-tool__label">${toggleTheme}</span>
+        </button>
+        <button class="solstice-tool" type="button" data-role="post-editor" aria-label="${postEditor}">
+          <span class="solstice-tool__icon">&#128221;</span>
+          <span class="solstice-tool__label">${postEditor}</span>
+        </button>
+        <label class="solstice-tool solstice-tool--select">
+          <span class="solstice-tool__label">${themePack}</span>
+          <select data-role="theme-pack" aria-label="${themePack}"></select>
+        </label>
+        <label class="solstice-tool solstice-tool--select">
+          <span class="solstice-tool__label">${language}</span>
+          <select data-role="language" aria-label="${language}"></select>
+        </label>
+        <button class="solstice-tool" type="button" data-role="language-reset" aria-label="${resetLanguage}">
+          <span class="solstice-tool__icon">&#9851;</span>
+          <span class="solstice-tool__label">${resetLanguage}</span>
+        </button>`;
+    }
+    return `
+      <div class="section-title">${sectionTitle}</div>
+      <div class="tools tools-panel">
+        <div class="tool-item">
+          <button class="btn icon-btn" type="button" data-role="theme-toggle" aria-label="${toggleTheme}" title="${toggleTheme}"><span class="icon">&#127769;</span><span class="btn-text">${toggleTheme}</span></button>
+        </div>
+        <div class="tool-item">
+          <button class="btn icon-btn" type="button" data-role="post-editor" aria-label="${postEditor}" title="${postEditor}"><span class="icon">&#128221;</span><span class="btn-text">${postEditor}</span></button>
+        </div>
+        <div class="tool-item">
+          <label class="tool-label">${themePack}</label>
+          <select data-role="theme-pack" aria-label="${themePack}" title="${themePack}"></select>
+        </div>
+        <div class="tool-item">
+          <label class="tool-label">${language}</label>
+          <select data-role="language" aria-label="${language}" title="${language}"></select>
+        </div>
+        <div class="tool-item">
+          <button class="btn icon-btn" type="button" data-role="language-reset" aria-label="${resetLanguage}" title="${resetLanguage}"><span class="icon">&#9851;</span><span class="btn-text">${resetLanguage}</span></button>
+        </div>
+      </div>`;
+  }
+
+  _bindEvents() {
+    if (this._eventsBound) return;
+    this.addEventListener('click', this._clickHandler);
+    this.addEventListener('change', this._changeHandler);
+    this._eventsBound = true;
+  }
+
+  _unbindEvents() {
+    if (!this._eventsBound) return;
+    try { this.removeEventListener('click', this._clickHandler); } catch (_) {}
+    try { this.removeEventListener('change', this._changeHandler); } catch (_) {}
+    this._eventsBound = false;
+  }
+
+  _handleClick(event) {
+    const control = event.target && event.target.closest ? event.target.closest('[data-role]') : null;
+    if (!control || !this.contains(control)) return;
+    const role = control.getAttribute('data-role');
+    if (role === 'theme-toggle') dispatchNanoEvent(this, 'nano:theme-toggle');
+    else if (role === 'post-editor') dispatchNanoEvent(this, 'nano:open-editor');
+    else if (role === 'language-reset') dispatchNanoEvent(this, 'nano:language-reset');
+  }
+
+  _handleChange(event) {
+    const control = event.target && event.target.closest ? event.target.closest('[data-role]') : null;
+    if (!control || !this.contains(control)) return;
+    const role = control.getAttribute('data-role');
+    if (role === 'theme-pack') {
+      dispatchNanoEvent(this, 'nano:theme-pack-change', { value: control.value || '' });
+    } else if (role === 'language') {
+      dispatchNanoEvent(this, 'nano:language-change', { value: control.value || '' });
+    }
+  }
+
+  _populateThemePacks() {
+    const select = this.querySelector('[data-role="theme-pack"]');
+    if (!select) return;
+    const packs = this._themePacks.length ? this._themePacks : [{ value: 'native', label: 'Native' }];
+    const current = this._currentPack || (packs[0] && packs[0].value) || 'native';
+    select.textContent = '';
+    const seen = new Set();
+    packs.forEach((pack) => {
+      if (!pack) return;
+      const value = String(pack.value || pack.slug || pack.name || '').trim();
+      if (!value || seen.has(value)) return;
+      const option = (this.ownerDocument || document).createElement('option');
+      option.value = value;
+      option.textContent = String(pack.label || pack.name || value);
+      select.appendChild(option);
+      seen.add(value);
+    });
+    if (current && !seen.has(current)) {
+      const option = (this.ownerDocument || document).createElement('option');
+      option.value = current;
+      option.textContent = current;
+      select.appendChild(option);
+    }
+    select.value = current;
+  }
+
+  _populateLanguages() {
+    const select = this.querySelector('[data-role="language"]');
+    if (!select) return;
+    select.textContent = '';
+    const current = this._currentLang || (this._languages[0] && this._languages[0].value) || '';
+    this._languages.forEach((lang) => {
+      if (!lang) return;
+      const value = String(lang.value || lang.code || '').trim();
+      if (!value) return;
+      const option = (this.ownerDocument || document).createElement('option');
+      option.value = value;
+      option.textContent = String(lang.label || value);
+      select.appendChild(option);
+    });
+    if (current) select.value = current;
+  }
+}
+
+export class NanoToc extends HTMLElement {
+  constructor() {
+    super();
+    this._tocHtml = '';
+    this._articleTitle = '';
+    this._headings = [];
+    this._positions = [];
+    this._ticking = false;
+    this._onScroll = () => this._scheduleActiveUpdate();
+    this._onResize = () => {
+      this._computePositions();
+      this._updateActive();
+    };
+    this._onLoad = () => {
+      this._computePositions();
+      this._updateActive();
+    };
+    this._listenersBound = false;
+  }
+
+  disconnectedCallback() {
+    this._cleanupListeners();
+  }
+
+  renderToc(options = {}) {
+    this._cleanupListeners();
+    this._tocHtml = String(options.tocHtml || '');
+    this._articleTitle = String(options.articleTitle || '');
+    if (options.variant) this.setAttribute('variant', String(options.variant));
+    if (options.topLabel != null) this.setAttribute('top-label', String(options.topLabel));
+    if (options.topAria != null) this.setAttribute('top-aria', String(options.topAria));
+    if (options.contentSelector != null) this.setAttribute('content-selector', String(options.contentSelector));
+    if (!this._tocHtml) {
+      this.innerHTML = '';
+      return false;
+    }
+    this.innerHTML = this._markup();
+    this.enhance();
+    return true;
+  }
+
+  clear() {
+    this._cleanupListeners();
+    this._tocHtml = '';
+    this.innerHTML = '';
+  }
+
+  enhance() {
+    const list = this.querySelector('ul');
+    if (!list) return false;
+    this._enhanceRows();
+    this._bindTocClicks();
+    this._computePositions();
+    this._bindListeners();
+    const current = (location.hash || '').replace(/^#/, '');
+    if (current && this._idToLink && this._idToLink.has(current)) this._setActive(current);
+    else this._updateActive();
+    return true;
+  }
+
+  _variant() {
+    return (this.getAttribute('variant') || 'native').toLowerCase();
+  }
+
+  _markup() {
+    const variant = this._variant();
+    const title = safe(this._articleTitle || this.getAttribute('toc-title') || '');
+    if (variant === 'arcus') {
+      const heading = title || safe(this.getAttribute('fallback-title') || 'Table of contents');
+      return `<div class="arcus-toc__inner"><div class="arcus-toc__title">${heading}</div>${this._tocHtml}</div>`;
+    }
+    if (variant === 'solstice') {
+      const heading = title || safe(this.getAttribute('fallback-title') || 'Table of contents');
+      return `<div class="solstice-toc__inner"><div class="solstice-toc__title">${heading}</div>${this._tocHtml}</div>`;
+    }
+    const topLabel = safe(this.getAttribute('top-label') || 'Top');
+    const topAria = safe(this.getAttribute('top-aria') || 'Back to top');
+    const titleHtml = title ? `<span>${title}</span>` : '';
+    return `<div class="toc-header">${titleHtml}<button type="button" class="toc-top" aria-label="${topAria}">${topLabel}</button></div>${this._tocHtml}`;
+  }
+
+  _enhanceRows() {
+    this.querySelectorAll('li').forEach((li) => {
+      const sub = li.querySelector(':scope > ul');
+      const link = li.querySelector(':scope > a');
+      let row = li.querySelector(':scope > .toc-row');
+      if (!row) {
+        row = (this.ownerDocument || document).createElement('div');
+        row.className = 'toc-row';
+        if (link) li.insertBefore(row, link);
+        else if (sub) li.insertBefore(row, sub);
+        else li.appendChild(row);
+      }
+      if (link && link.parentElement !== row) row.appendChild(link);
+      if (sub && !row.querySelector(':scope > .toc-toggle')) {
+        const btn = (this.ownerDocument || document).createElement('button');
+        btn.className = 'toc-toggle';
+        btn.type = 'button';
+        btn.setAttribute('aria-label', this.getAttribute('toggle-label') || 'Toggle section');
+        btn.setAttribute('aria-expanded', 'true');
+        btn.innerHTML = '<span class="caret"></span>';
+        row.insertBefore(btn, row.firstChild || null);
+        btn.addEventListener('click', () => {
+          const collapsed = sub.classList.toggle('collapsed');
+          btn.setAttribute('aria-expanded', String(!collapsed));
+        });
+        const depth = this._getDepth(li);
+        if (depth >= 2) {
+          sub.classList.add('collapsed');
+          btn.setAttribute('aria-expanded', 'false');
+        }
+      }
+    });
+  }
+
+  _bindTocClicks() {
+    this._idToLink = new Map();
+    this.querySelectorAll('a[href^="#"]:not(.toc-anchor)').forEach((anchor) => {
+      const href = anchor.getAttribute('href') || '';
+      const id = href.replace(/^#/, '');
+      if (id && !anchor.classList.contains('toc-top')) this._idToLink.set(id, anchor);
+      if (anchor.dataset.nanoTocBound === 'true') return;
+      anchor.dataset.nanoTocBound = 'true';
+      anchor.addEventListener('click', (event) => this._handleTocLink(event, anchor));
+    });
+    const top = this.querySelector('.toc-top');
+    if (top && top.dataset.nanoTocBound !== 'true') {
+      top.dataset.nanoTocBound = 'true';
+      top.addEventListener('click', (event) => {
+        if (event && typeof event.preventDefault === 'function') event.preventDefault();
+        this._scrollToTop();
+        this.querySelectorAll('a.active').forEach((link) => link.classList.remove('active'));
+      });
+    }
+  }
+
+  _contentRoot() {
+    const selector = this.getAttribute('content-selector') || '#mainview';
+    try {
+      return (this.ownerDocument || document).querySelector(selector);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  _computePositions() {
+    const root = this._contentRoot();
+    this._headings = root ? Array.from(root.querySelectorAll('h2[id], h3[id]')) : [];
+    this._positions = this._headings.map((heading) => ({
+      id: heading.id,
+      top: heading.getBoundingClientRect().top + (window.scrollY || 0)
+    }));
+  }
+
+  _scheduleActiveUpdate() {
+    if (this._ticking) return;
+    this._ticking = true;
+    requestAnimationFrame(() => {
+      this._ticking = false;
+      this._updateActive();
+    });
+  }
+
+  _updateActive() {
+    if (!this._positions.length) return;
+    const y = (window.scrollY || 0) + 120;
+    let currentId = this._positions[0] ? this._positions[0].id : '';
+    for (let i = 0; i < this._positions.length; i += 1) {
+      if (this._positions[i].top <= y) currentId = this._positions[i].id;
+      else break;
+    }
+    if (currentId) this._setActive(currentId);
+  }
+
+  _setActive(id) {
+    this.querySelectorAll('a.active').forEach((link) => link.classList.remove('active'));
+    const link = this._idToLink && this._idToLink.get(id);
+    if (!link) return;
+    link.classList.add('active');
+    let node = link.parentElement;
+    while (node && node !== this) {
+      const sub = node.querySelector ? node.querySelector(':scope > ul') : null;
+      const btn = node.querySelector ? node.querySelector(':scope > .toc-toggle') : null;
+      if (sub && sub.classList.contains('collapsed')) {
+        sub.classList.remove('collapsed');
+        if (btn) btn.setAttribute('aria-expanded', 'true');
+      }
+      node = node.parentElement;
+    }
+    dispatchNanoEvent(this, 'nano:toc-active', { id });
+  }
+
+  _handleTocLink(event, anchor) {
+    const href = anchor.getAttribute('href') || '';
+    const id = href.replace(/^#/, '');
+    if (!id || anchor.classList.contains('toc-top')) return;
+    if (event && typeof event.preventDefault === 'function') event.preventDefault();
+    this._setActive(id);
+    const target = (this.ownerDocument || document).getElementById(id);
+    if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    try {
+      const url = new URL(window.location.href);
+      url.hash = id ? `#${id}` : '';
+      history.replaceState(null, '', url.toString());
+    } catch (_) {}
+  }
+
+  _scrollToTop() {
+    try {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    } catch (_) {
+      try { window.scrollTo(0, 0); } catch (__) {}
+    }
+  }
+
+  _bindListeners() {
+    if (this._listenersBound) return;
+    window.addEventListener('scroll', this._onScroll, { passive: true });
+    window.addEventListener('resize', this._onResize);
+    window.addEventListener('load', this._onLoad);
+    this._listenersBound = true;
+  }
+
+  _cleanupListeners() {
+    if (!this._listenersBound) return;
+    try { window.removeEventListener('scroll', this._onScroll); } catch (_) {}
+    try { window.removeEventListener('resize', this._onResize); } catch (_) {}
+    try { window.removeEventListener('load', this._onLoad); } catch (_) {}
+    this._listenersBound = false;
+  }
+
+  _getDepth(el) {
+    let depth = 0;
+    let node = el;
+    while (node && node !== this) {
+      if (node.tagName === 'UL') depth += 1;
+      node = node.parentElement;
+    }
+    return Math.max(0, depth - 1);
+  }
+}
+
+export class NanoPostCard extends HTMLElement {
+  static get observedAttributes() {
+    return ['variant', 'href', 'title', 'date', 'excerpt', 'versions-label', 'draft-label', 'data-idx'];
+  }
+
+  connectedCallback() {
+    this.style.display = 'contents';
+    this.render();
+  }
+
+  attributeChangedCallback() {
+    if (this.isConnected) this.render();
+  }
+
+  render() {
+    const coverTemplate = this.querySelector('template[data-slot="cover"]');
+    const tagsTemplate = this.querySelector('template[data-slot="tags"]');
+    if (coverTemplate) this._coverHtml = coverTemplate.innerHTML || '';
+    if (tagsTemplate) this._tagsHtml = tagsTemplate.innerHTML || '';
+    const variant = (this.getAttribute('variant') || 'native').toLowerCase();
+    if (variant === 'arcus') this.innerHTML = this._renderArcus();
+    else if (variant === 'solstice') this.innerHTML = this._renderSolstice();
+    else this.innerHTML = this._renderNative();
+  }
+
+  _renderNative() {
+    const title = safe(this.getAttribute('title') || 'Untitled');
+    const href = safe(this.getAttribute('href') || '#');
+    const dataIdx = safe(this.getAttribute('data-idx') || encodeURIComponent(this.getAttribute('title') || ''));
+    const date = safe(this.getAttribute('date') || '');
+    const versions = safe(this.getAttribute('versions-label') || '');
+    const draft = safe(this.getAttribute('draft-label') || '');
+    const parts = [];
+    if (date) parts.push(`<span class="card-date">${date}</span>`);
+    if (versions) parts.push(`<span class="card-versions">${versions}</span>`);
+    if (draft) parts.push(`<span class="card-draft">${draft}</span>`);
+    const meta = parts.join('<span class="card-sep">&bull;</span>');
+    return `<a href="${href}" data-idx="${dataIdx}">${this._coverHtml || ''}<div class="card-title">${title}</div><div class="card-excerpt"></div><div class="card-meta">${meta}</div>${this._tagsHtml || ''}</a>`;
+  }
+
+  _renderArcus() {
+    const title = safe(this.getAttribute('title') || 'Untitled');
+    const href = safe(this.getAttribute('href') || '#');
+    const date = safe(this.getAttribute('date') || '');
+    const excerpt = safe(this.getAttribute('excerpt') || '');
+    const hasCover = !!(this._coverHtml || '').trim();
+    const metaLine = (date || this._tagsHtml)
+      ? `<div class="arcus-card__meta-line">${date ? `<span class="arcus-card__meta-date">${date}</span>` : ''}${date && this._tagsHtml ? '<span class="arcus-card__meta-separator" aria-hidden="true">&bull;</span>' : ''}${this._tagsHtml ? `<div class="arcus-card__tags">${this._tagsHtml}</div>` : ''}</div>`
+      : '';
+    return `<article class="arcus-card${hasCover ? ' arcus-card--with-cover' : ''}">
+      <a class="arcus-card__link" href="${href}">
+        ${this._coverHtml || ''}
+        <div class="arcus-card__body">
+          ${metaLine}
+          <h3 class="arcus-card__title">${title}</h3>
+          ${excerpt ? `<p class="arcus-card__excerpt"><span class="arcus-card__excerpt-tilt">${excerpt}</span></p>` : ''}
+        </div>
+      </a>
+    </article>`;
+  }
+
+  _renderSolstice() {
+    const title = safe(this.getAttribute('title') || 'Untitled');
+    const href = safe(this.getAttribute('href') || '#');
+    const date = safe(this.getAttribute('date') || '');
+    const excerpt = safe(this.getAttribute('excerpt') || '');
+    const hasCover = !!(this._coverHtml || '').trim();
+    return `<article class="solstice-card${hasCover ? ' solstice-card--with-cover' : ''}">
+      <a class="solstice-card__link" href="${href}">
+        ${this._coverHtml || ''}
+        <div class="solstice-card__body">
+          <h3 class="solstice-card__title">${title}</h3>
+          ${date ? `<div class="solstice-card__meta">${date}</div>` : ''}
+          ${excerpt ? `<p class="solstice-card__excerpt">${excerpt}</p>` : ''}
+          ${this._tagsHtml ? `<div class="solstice-card__tags">${this._tagsHtml}</div>` : ''}
+        </div>
+      </a>
+    </article>`;
+  }
+}
+
+export function renderNanoPostCardHtml({
+  variant = 'native',
+  title = '',
+  href = '#',
+  dataIdx = '',
+  date = '',
+  excerpt = '',
+  versionsLabel = '',
+  draftLabel = '',
+  coverHtml = '',
+  tagsHtml = ''
+} = {}) {
+  return `<nano-post-card variant="${safe(variant)}" href="${safe(href)}" title="${safe(title)}" data-idx="${safe(dataIdx || encodeURIComponent(title || ''))}" date="${safe(date)}" excerpt="${safe(excerpt)}" versions-label="${safe(versionsLabel)}" draft-label="${safe(draftLabel)}"><template data-slot="cover">${coverHtml || ''}</template><template data-slot="tags">${tagsHtml || ''}</template></nano-post-card>`;
+}
+
+export function registerNanoComponents() {
+  defineElement('nano-search', NanoSearch);
+  defineElement('nano-theme-controls', NanoThemeControls);
+  defineElement('nano-toc', NanoToc);
+  defineElement('nano-post-card', NanoPostCard);
+}
+
+registerNanoComponents();

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -778,6 +778,11 @@ export async function loadLangJson(basePath, baseName) {
 // Update static DOM bits outside main render cycle (sidebar card, search placeholder)
 function applyStaticTranslations() {
   // Search placeholder
+  const search = document.querySelector('nano-search');
+  if (search && typeof search.setPlaceholder === 'function') {
+    search.setPlaceholder(t('sidebar.searchPlaceholder'));
+    return;
+  }
   const input = document.getElementById('searchInput');
   if (input) input.setAttribute('placeholder', t('sidebar.searchPlaceholder'));
 }

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,27 +1,43 @@
-export function setupSearch(entries){
+const LEGACY_SEARCH_BOUND = Symbol('nanoLegacySearchBound');
+let componentSearchBound = false;
+
+export function navigateSearch(query) {
+  const q = String(query || '').trim();
+  const url = new URL(window.location.href);
+  if (q) {
+    url.searchParams.set('tab', 'search');
+    url.searchParams.set('q', q);
+    url.searchParams.delete('tag');
+    url.searchParams.delete('id');
+    url.searchParams.delete('page');
+  } else {
+    url.searchParams.set('tab', 'posts');
+    url.searchParams.delete('q');
+    url.searchParams.delete('tag');
+    url.searchParams.delete('id');
+    url.searchParams.delete('page');
+  }
+  history.pushState({}, '', url.toString());
+  window.dispatchEvent(new PopStateEvent('popstate'));
+}
+
+export function bindSearchEvents(root = document) {
+  if (!componentSearchBound && root && typeof root.addEventListener === 'function') {
+    root.addEventListener('nano:search', (event) => {
+      const detail = event && event.detail ? event.detail : {};
+      navigateSearch(detail.query || '');
+    });
+    componentSearchBound = true;
+  }
+}
+
+export function setupSearch() {
+  bindSearchEvents(document);
+
   const input = document.getElementById('searchInput');
-  if (!input) return;
-  // Preserve existing value if arriving from search tab
-  // On Enter, navigate to global search view
-  input.onkeydown = (e) => {
-    if (e.key === 'Enter') {
-      const q = input.value.trim();
-      const url = new URL(window.location.href);
-      if (q) {
-        url.searchParams.set('tab', 'search');
-        url.searchParams.set('q', q);
-  url.searchParams.delete('tag');
-        url.searchParams.delete('id');
-        url.searchParams.delete('page');
-      } else {
-        url.searchParams.set('tab', 'posts');
-        url.searchParams.delete('q');
-  url.searchParams.delete('tag');
-        url.searchParams.delete('id');
-        url.searchParams.delete('page');
-      }
-      history.pushState({}, '', url.toString());
-      window.dispatchEvent(new PopStateEvent('popstate'));
-    }
-  };
+  if (!input || input.closest('nano-search') || input[LEGACY_SEARCH_BOUND]) return;
+  input[LEGACY_SEARCH_BOUND] = true;
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') navigateSearch(input.value);
+  });
 }

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,6 +1,8 @@
 import { t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=20260504saved';
+import './components.js';
 
 const PACK_LINK_ID = 'theme-pack';
+const THEME_CONTROLS_BOUND = Symbol('nanoThemeControlsBound');
 
 // Restrict theme pack names to safe slug format and default to 'native'.
 function sanitizePack(input) {
@@ -86,6 +88,7 @@ export function applyThemeConfig(siteConfig) {
 }
 
 export function bindThemeToggle() {
+  if (document.querySelector('nano-theme-controls')) return;
   const btn = document.getElementById('themeToggle');
   if (!btn) return;
   const isDark = () => document.documentElement.getAttribute('data-theme') === 'dark';
@@ -98,6 +101,7 @@ export function bindThemeToggle() {
 }
 
 export function bindPostEditor() {
+  if (document.querySelector('nano-theme-controls')) return;
   const btn = document.getElementById('postEditor');
   if (!btn) return;
   btn.addEventListener('click', () => {
@@ -118,6 +122,7 @@ export function bindPostEditor() {
 }
 
 export function bindThemePackPicker() {
+  if (document.querySelector('nano-theme-controls')) return;
   const sel = document.getElementById('themePack');
   if (!sel) return;
   // Initialize selection
@@ -132,116 +137,177 @@ export function bindThemePackPicker() {
   });
 }
 
-// Render theme tools UI (button + select) into the sidebar, before TOC.
-// Options are sourced from assets/themes/packs.json; falls back to defaults.
-export function mountThemeControls() {
-  // If already present, do nothing
-  if (document.getElementById('tools')) return;
-  const sidebar = document.querySelector('.sidebar');
-  if (!sidebar) return;
+function getThemeControlsElement(root = document) {
+  return root && root.querySelector ? root.querySelector('nano-theme-controls') : null;
+}
 
-  const wrapper = document.createElement('div');
-  wrapper.className = 'box';
-  wrapper.id = 'tools';
-  wrapper.innerHTML = `
-    <div class="section-title">${t('tools.sectionTitle')}</div>
-    <div class="tools tools-panel">
-      <div class="tool-item">
-        <button id="themeToggle" class="btn icon-btn" aria-label="Toggle light/dark" title="${t('tools.toggleTheme')}"><span class="icon">🌓</span><span class="btn-text">${t('tools.toggleTheme')}</span></button>
-      </div>
-      <div class="tool-item">
-        <button id="postEditor" class="btn icon-btn" aria-label="Open Markdown Editor" title="${t('tools.postEditor')}"><span class="icon">📝</span><span class="btn-text">${t('tools.postEditor')}</span></button>
-      </div>
-      <div class="tool-item">
-        <label for="themePack" class="tool-label">${t('tools.themePack')}</label>
-        <select id="themePack" aria-label="${t('tools.themePack')}" title="${t('tools.themePack')}"></select>
-      </div>
-      <div class="tool-item">
-        <label for="langSelect" class="tool-label">${t('tools.language')}</label>
-        <select id="langSelect" aria-label="${t('tools.language')}" title="${t('tools.language')}"></select>
-      </div>
-      <div class="tool-item">
-        <button id="langReset" class="btn icon-btn" aria-label="${t('tools.resetLanguage')}" title="${t('tools.resetLanguage')}"><span class="icon">♻️</span><span class="btn-text">${t('tools.resetLanguage')}</span></button>
-      </div>
-    </div>`;
+function getThemeControlLabels() {
+  return {
+    sectionTitle: t('tools.sectionTitle'),
+    toggleTheme: t('tools.toggleTheme'),
+    postEditor: t('tools.postEditor'),
+    themePack: t('tools.themePack'),
+    language: t('tools.language'),
+    resetLanguage: t('tools.resetLanguage')
+  };
+}
 
-  const toc = document.getElementById('tocview');
-  if (toc && toc.parentElement === sidebar) sidebar.insertBefore(wrapper, toc);
-  else sidebar.appendChild(wrapper);
-
-  // Populate theme packs
-  const sel = wrapper.querySelector('#themePack');
-  const saved = getSavedThemePack();
-  const fallback = [
-    { value: 'native', label: 'Native' }
-  ];
-
-  // Try to load from JSON; if it fails, use fallback
-  fetch('assets/themes/packs.json').then(r => r.ok ? r.json() : Promise.reject()).then(list => {
-    try {
-      sel.innerHTML = '';
-      (Array.isArray(list) ? list : []).forEach(p => {
-        const opt = document.createElement('option');
-        opt.value = sanitizePack(p.value);
-        opt.textContent = String(p.label || p.value || 'Theme');
-        sel.appendChild(opt);
-      });
-      if (!sel.options.length) throw new Error('empty options');
-    } catch (_) {
-      throw _;
-    }
-  }).catch(() => {
-    sel.innerHTML = '';
-    fallback.forEach(p => {
-      const opt = document.createElement('option');
-      opt.value = p.value;
-      opt.textContent = p.label;
-      sel.appendChild(opt);
-    });
-  }).finally(() => {
-    sel.value = saved;
+function normalizePackList(list) {
+  const out = [];
+  const seen = new Set();
+  (Array.isArray(list) ? list : []).forEach((item) => {
+    if (!item) return;
+    const value = sanitizePack(item.value || item.slug || item.name);
+    if (!value || seen.has(value)) return;
+    out.push({ value, label: String(item.label || item.name || value) });
+    seen.add(value);
   });
+  if (!out.length) out.push({ value: 'native', label: 'Native' });
+  return out;
+}
 
-  // Populate language selector
-  const langSel = wrapper.querySelector('#langSelect');
-  if (langSel) {
-    try { ensureLanguageBundle(getCurrentLang()).catch(() => {}); } catch (_) {}
-    const langs = getAvailableLangs();
-    langSel.innerHTML = '';
-    langs.forEach(code => {
-      const opt = document.createElement('option');
-      opt.value = code;
-      opt.textContent = getLanguageLabel(code);
-      langSel.appendChild(opt);
-    });
-    langSel.value = getCurrentLang();
-    langSel.addEventListener('change', async () => {
-      const val = langSel.value || 'en';
-      try {
-        await ensureLanguageBundle(val);
-      } catch (_) {}
-      switchLanguage(val);
-    });
+function getLanguageOptions() {
+  try { ensureLanguageBundle(getCurrentLang()).catch(() => {}); } catch (_) {}
+  return getAvailableLangs().map(code => ({
+    value: code,
+    label: getLanguageLabel(code)
+  }));
+}
+
+function openPostEditor() {
+  const editorUrl = 'index_editor.html';
+  let popup = null;
+  try {
+    popup = window.open(editorUrl, '_blank');
+  } catch (_) {
+    popup = null;
   }
+  if (!popup) {
+    window.location.href = editorUrl;
+    return;
+  }
+  try { popup.opener = null; } catch (_) {}
+  try { popup.focus(); } catch (_) {}
+}
 
-  // Bind language reset button
-  const resetBtn = wrapper.querySelector('#langReset');
-  if (resetBtn) {
-    resetBtn.addEventListener('click', () => {
-      // Clear saved language and drop URL param, then soft-reset without full reload
-      try { localStorage.removeItem('lang'); } catch (_) {}
-      try { const url = new URL(window.location.href); url.searchParams.delete('lang'); history.replaceState(history.state, document.title, url.toString()); } catch (_) {}
-      try { (window.__ns_softResetLang && window.__ns_softResetLang()); } catch (_) { /* fall through */ }
-      // If soft reset isn't available for some reason, fall back to reload
-      if (!window.__ns_softResetLang) {
-        try { window.location.reload(); } catch (_) {}
+function bindThemeControlsComponent(component) {
+  if (!component || component[THEME_CONTROLS_BOUND]) return;
+  component[THEME_CONTROLS_BOUND] = true;
+  component.addEventListener('nano:theme-toggle', () => {
+    const dark = document.documentElement.getAttribute('data-theme') === 'dark';
+    if (dark) document.documentElement.removeAttribute('data-theme');
+    else document.documentElement.setAttribute('data-theme', 'dark');
+    try { localStorage.setItem('theme', dark ? 'light' : 'dark'); } catch (_) {}
+  });
+  component.addEventListener('nano:open-editor', () => openPostEditor());
+  component.addEventListener('nano:theme-pack-change', (event) => {
+    const detail = event && event.detail ? event.detail : {};
+    const val = sanitizePack(detail.value) || 'native';
+    const current = getSavedThemePack();
+    if (val === current) return;
+    loadThemePack(val);
+    try { window.location.reload(); } catch (_) {}
+  });
+  component.addEventListener('nano:language-change', async (event) => {
+    const detail = event && event.detail ? event.detail : {};
+    const val = detail.value || 'en';
+    try { await ensureLanguageBundle(val); } catch (_) {}
+    switchLanguage(val);
+  });
+  component.addEventListener('nano:language-reset', () => {
+    try { localStorage.removeItem('lang'); } catch (_) {}
+    try {
+      const url = new URL(window.location.href);
+      url.searchParams.delete('lang');
+      history.replaceState(history.state, document.title, url.toString());
+    } catch (_) {}
+    try {
+      if (window.__ns_softResetLang) {
+        window.__ns_softResetLang();
+        return;
       }
-    });
+    } catch (_) {}
+    try { window.location.reload(); } catch (_) {}
+  });
+}
+
+function populateThemeControls(component) {
+  if (!component) return;
+  try { component.setLabels(getThemeControlLabels()); } catch (_) {}
+  try { component.setLanguages(getLanguageOptions(), getCurrentLang()); } catch (_) {}
+  try {
+    fetch('assets/themes/packs.json')
+      .then(r => r && r.ok ? r.json() : Promise.reject())
+      .then(list => {
+        component.setThemePacks(normalizePackList(list), getSavedThemePack());
+      })
+      .catch(() => {
+        component.setThemePacks(normalizePackList([
+          { value: 'native', label: 'Native' },
+          { value: 'arcus', label: 'Arcus' },
+          { value: 'solstice', label: 'Solstice' }
+        ]), getSavedThemePack());
+      });
+  } catch (_) {
+    component.setThemePacks(normalizePackList([{ value: 'native', label: 'Native' }]), getSavedThemePack());
   }
+}
+
+// Render theme tools UI through <nano-theme-controls>. Options are sourced from
+// assets/themes/packs.json; legacy button/select binders remain below for older
+// custom themes that have not migrated yet.
+export function mountThemeControls(options = {}) {
+  const opts = options && typeof options === 'object' ? options : {};
+  const variant = String(opts.variant || document.body.dataset.themeLayout || 'native').toLowerCase();
+  let component = null;
+  const host = opts.host || null;
+
+  if (host && host.matches && host.matches('nano-theme-controls')) {
+    component = host;
+  } else if (host && host.querySelector) {
+    component = host.querySelector('nano-theme-controls');
+    if (!component) {
+      host.textContent = '';
+      component = document.createElement('nano-theme-controls');
+      host.appendChild(component);
+    }
+  } else {
+    component = getThemeControlsElement(document);
+    if (!component) {
+      const legacyTools = document.getElementById('tools');
+      if (legacyTools && legacyTools.parentElement) {
+        component = document.createElement('nano-theme-controls');
+        legacyTools.parentElement.replaceChild(component, legacyTools);
+      }
+    }
+    if (!component) {
+      const sidebar = document.querySelector('.sidebar');
+      if (!sidebar) return null;
+      component = document.createElement('nano-theme-controls');
+      const toc = document.getElementById('tocview');
+      if (toc && toc.parentElement === sidebar) sidebar.insertBefore(component, toc);
+      else sidebar.appendChild(component);
+    }
+  }
+
+  component.setAttribute('variant', variant);
+  try { if (typeof component.render === 'function') component.render(); } catch (_) {}
+  bindThemeControlsComponent(component);
+  populateThemeControls(component);
+  return component;
 }
 
 // Rebuild language selector options based on supported UI languages
 export function refreshLanguageSelector() {
+  const component = getThemeControlsElement(document);
+  if (component && typeof component.setLanguages === 'function') {
+    try {
+      component.setLabels(getThemeControlLabels());
+      component.setLanguages(getLanguageOptions(), getCurrentLang());
+      component.setCurrentPack(getSavedThemePack());
+      return;
+    } catch (_) {}
+  }
   const sel = document.getElementById('langSelect');
   if (!sel) return;
   const current = getCurrentLang();

--- a/assets/js/toc.js
+++ b/assets/js/toc.js
@@ -34,6 +34,10 @@ export function setupAnchors() {
 export function setupTOC() {
   const tocRoot = document.getElementById('tocview');
   if (!tocRoot) return;
+  if (typeof tocRoot.enhance === 'function') {
+    try { tocRoot.enhance(); } catch (_) {}
+    return;
+  }
 
   const list = tocRoot.querySelector('ul');
   if (!list) return;

--- a/assets/main.js
+++ b/assets/main.js
@@ -1,4 +1,5 @@
 import { configureFetchCachePolicy } from './js/cache-control.js';
+import './js/components.js';
 import { mdParse } from './js/markdown.js';
 import { setupAnchors, setupTOC } from './js/toc.js';
 import { applySavedTheme, bindThemeToggle, bindThemePackPicker, mountThemeControls, refreshLanguageSelector, applyThemeConfig, bindPostEditor } from './js/theme.js';
@@ -1494,6 +1495,7 @@ callThemeHook('updateSearchPlaceholder', {
   document,
   window
 });
+try { setupSearch(); } catch (_) {}
 
 // Observe viewport changes for responsive tabs
 callThemeHook('setupResponsiveTabsObserver', {

--- a/assets/themes/arcus/modules/interactions.js
+++ b/assets/themes/arcus/modules/interactions.js
@@ -11,6 +11,7 @@ import {
   sanitizeImageUrl
 } from '../../../js/utils.js';
 import {
+  mountThemeControls,
   applySavedTheme,
   bindThemeToggle,
   bindThemePackPicker,
@@ -22,6 +23,7 @@ import { hydratePostImages, hydratePostVideos, applyLazyLoadingIn, hydrateCardCo
 import { renderPostMetaCard, renderOutdatedCard } from '../../../js/templates.js';
 import { attachHoverTooltip, renderTagSidebar as renderDefaultTags } from '../../../js/tags.js';
 import { prefersReducedMotion } from '../../../js/dom-utils.js';
+import { renderNanoPostCardHtml } from '../../../js/components.js';
 
 const defaultWindow = typeof window !== 'undefined' ? window : undefined;
 const defaultDocument = typeof document !== 'undefined' ? document : undefined;
@@ -418,32 +420,19 @@ function fadeOut(element, onDone) {
 }
 
 function buildCard({ title, meta, translate, link, siteConfig }) {
-  const safeTitle = escapeHtml(String(title || 'Untitled'));
-  const excerpt = meta && meta.excerpt ? escapeHtml(String(meta.excerpt)) : '';
+  const excerpt = meta && meta.excerpt ? String(meta.excerpt) : '';
   const date = meta && meta.date ? formatDisplayDate(meta.date) : '';
   const tags = meta ? renderTags(meta.tag) : '';
   const coverHtml = renderCardCover(meta, title, siteConfig);
-  const hasCover = Boolean(coverHtml);
-  const cardClasses = `arcus-card${hasCover ? ' arcus-card--with-cover' : ''}`;
-  const metaLine = () => {
-    if (!date && !tags) return '';
-    let html = '<div class="arcus-card__meta-line">';
-    if (date) html += `<span class="arcus-card__meta-date">${escapeHtml(date)}</span>`;
-    if (date && tags) html += '<span class="arcus-card__meta-separator" aria-hidden="true">·</span>';
-    if (tags) html += `<div class="arcus-card__tags">${tags}</div>`;
-    html += '</div>';
-    return html;
-  };
-  return `<article class="${cardClasses}">
-    <a class="arcus-card__link" href="${escapeHtml(link)}">
-      ${coverHtml}
-      <div class="arcus-card__body">
-        ${metaLine()}
-        <h3 class="arcus-card__title">${safeTitle}</h3>
-        ${excerpt ? `<p class="arcus-card__excerpt"><span class="arcus-card__excerpt-tilt">${excerpt}</span></p>` : ''}
-      </div>
-    </a>
-  </article>`;
+  return renderNanoPostCardHtml({
+    variant: 'arcus',
+    title: String(title || 'Untitled'),
+    href: link,
+    date,
+    excerpt,
+    coverHtml,
+    tagsHtml: tags
+  });
 }
 
 function ensureArcusExcerptNode(card, documentRef = defaultDocument) {
@@ -725,6 +714,11 @@ function renderLinksList(root, cfg) {
 }
 
 function updateSearchPlaceholder(documentRef = defaultDocument) {
+  const search = documentRef ? documentRef.querySelector('nano-search') : null;
+  if (search && typeof search.setPlaceholder === 'function') {
+    search.setPlaceholder(t('sidebar.searchPlaceholder'));
+    return;
+  }
   const input = documentRef ? documentRef.getElementById('searchInput') : null;
   if (!input) return;
   input.setAttribute('placeholder', t('sidebar.searchPlaceholder'));
@@ -833,74 +827,8 @@ function populateThemePackOptions(documentRef = defaultDocument, windowRef = def
 function setupToolsPanel(documentRef = defaultDocument, windowRef = defaultWindow) {
   const panel = documentRef && documentRef.getElementById('toolsPanel');
   if (!panel) return false;
-  panel.innerHTML = `
-    <div class="arcus-tools__groups" id="tools">
-      <div class="arcus-tools__group" role="group" data-group="theme" aria-label="${t('tools.toggleTheme')} & ${t('tools.themePack')}">
-        <button id="themeToggle" class="arcus-tool" type="button" aria-label="${t('tools.toggleTheme')}">
-          <span class="arcus-tool__icon">🌓</span>
-          <span class="arcus-tool__label">${t('tools.toggleTheme')}</span>
-        </button>
-        <label class="arcus-tool arcus-tool--select" for="themePack">
-          <span class="arcus-tool__label">${t('tools.themePack')}</span>
-          <select id="themePack"></select>
-        </label>
-      </div>
-      <div class="arcus-tools__group" role="group" data-group="language" aria-label="${t('tools.language')} & ${t('tools.resetLanguage')}">
-        <label class="arcus-tool arcus-tool--select" for="langSelect">
-          <span class="arcus-tool__label">${t('tools.language')}</span>
-          <select id="langSelect"></select>
-        </label>
-        <button id="langReset" class="arcus-tool" type="button" aria-label="${t('tools.resetLanguage')}">
-          <span class="arcus-tool__icon">♻️</span>
-          <span class="arcus-tool__label">${t('tools.resetLanguage')}</span>
-        </button>
-      </div>
-      <div class="arcus-tools__group arcus-tools__group--solo" role="group" data-group="editor" aria-label="${t('tools.postEditor')}">
-        <button id="postEditor" class="arcus-tool" type="button" aria-label="${t('tools.postEditor')}">
-          <span class="arcus-tool__icon">📝</span>
-          <span class="arcus-tool__label">${t('tools.postEditor')}</span>
-        </button>
-      </div>
-    </div>`;
+  try { mountThemeControls({ host: panel, variant: 'arcus' }); } catch (_) {}
   try { applySavedTheme(); } catch (_) {}
-  try { bindThemeToggle(); } catch (_) {}
-  try { bindPostEditor(); } catch (_) {}
-  try { populateThemePackOptions(documentRef, windowRef); } catch (_) {}
-  try { bindThemePackPicker(); } catch (_) {}
-  try { refreshLanguageSelector(); } catch (_) {}
-  try {
-    const langSel = documentRef.getElementById('langSelect');
-    if (langSel) {
-      langSel.addEventListener('change', () => {
-        const val = langSel.value || 'en';
-        switchLanguage(val);
-      });
-    }
-    const reset = documentRef.getElementById('langReset');
-    if (reset) {
-      reset.addEventListener('click', () => {
-        try { localStorage.removeItem('lang'); } catch (_) {}
-        try {
-          const url = new URL(windowRef ? windowRef.location.href : window.location.href);
-          url.searchParams.delete('lang');
-          if (windowRef && windowRef.history && windowRef.history.replaceState) {
-            windowRef.history.replaceState(windowRef.history.state, documentRef.title, url.toString());
-          }
-        } catch (_) {}
-        try {
-          if (windowRef && windowRef.__ns_softResetLang) {
-            windowRef.__ns_softResetLang();
-            return;
-          }
-        } catch (_) {}
-        try {
-          if (windowRef && windowRef.location) {
-            windowRef.location.reload();
-          }
-        } catch (_) {}
-      });
-    }
-  } catch (_) {}
   return true;
 }
 
@@ -1268,11 +1196,21 @@ function showToc(tocEl, tocHtml, articleTitle) {
     tocEl.__arcusTocCleanup = null;
   }
   if (!tocHtml) {
-    tocEl.innerHTML = '';
+    if (typeof tocEl.clear === 'function') tocEl.clear();
+    else tocEl.innerHTML = '';
     tocEl.hidden = true;
     return;
   }
-  tocEl.innerHTML = `<div class="arcus-toc__inner"><div class="arcus-toc__title">${escapeHtml(articleTitle || t('ui.tableOfContents'))}</div>${tocHtml}</div>`;
+  if (typeof tocEl.renderToc === 'function') {
+    tocEl.renderToc({
+      variant: 'arcus',
+      articleTitle: articleTitle || t('ui.tableOfContents'),
+      tocHtml,
+      contentSelector: '#mainview'
+    });
+  } else {
+    tocEl.innerHTML = `<div class="arcus-toc__inner"><div class="arcus-toc__title">${escapeHtml(articleTitle || t('ui.tableOfContents'))}</div>${tocHtml}</div>`;
+  }
   tocEl.hidden = false;
   fadeIn(tocEl);
   const cleanup = enhanceArcusTocDock(tocEl);
@@ -1401,8 +1339,11 @@ function mountHooks(documentRef = defaultDocument, windowRef = defaultWindow) {
       toc.hidden = true;
       toc.innerHTML = '';
     }
-    const input = documentRef.getElementById('searchInput');
-    if (input) input.value = view === 'search' ? (getQueryVariable('q') || '') : '';
+    const search = documentRef.querySelector('nano-search');
+    const value = view === 'search' ? (getQueryVariable('q') || '') : '';
+    if (search) search.value = value;
+    const input = search && search.input ? search.input : documentRef.getElementById('searchInput');
+    if (input) input.value = value;
   };
 
   hooks.renderTagSidebar = ({ postsIndex, utilities }) => {

--- a/assets/themes/arcus/modules/interactions.js
+++ b/assets/themes/arcus/modules/interactions.js
@@ -1189,6 +1189,16 @@ function enhanceArcusTocDock(tocEl) {
   };
 }
 
+function clearArcusToc(tocEl) {
+  if (!tocEl) return;
+  if (typeof tocEl.__arcusTocCleanup === 'function') {
+    try { tocEl.__arcusTocCleanup(); } catch (_) {}
+    tocEl.__arcusTocCleanup = null;
+  }
+  if (typeof tocEl.clear === 'function') tocEl.clear();
+  else tocEl.innerHTML = '';
+}
+
 function showToc(tocEl, tocHtml, articleTitle) {
   if (!tocEl) return;
   if (typeof tocEl.__arcusTocCleanup === 'function') {
@@ -1196,8 +1206,7 @@ function showToc(tocEl, tocHtml, articleTitle) {
     tocEl.__arcusTocCleanup = null;
   }
   if (!tocHtml) {
-    if (typeof tocEl.clear === 'function') tocEl.clear();
-    else tocEl.innerHTML = '';
+    clearArcusToc(tocEl);
     tocEl.hidden = true;
     return;
   }
@@ -1332,12 +1341,8 @@ function mountHooks(documentRef = defaultDocument, windowRef = defaultWindow) {
     documentRef.body.setAttribute('data-active-view', view || 'posts');
     const toc = getRoleElement('toc', documentRef);
     if (toc && view !== 'post') {
-      if (typeof toc.__arcusTocCleanup === 'function') {
-        try { toc.__arcusTocCleanup(); } catch (_) {}
-        toc.__arcusTocCleanup = null;
-      }
+      clearArcusToc(toc);
       toc.hidden = true;
-      toc.innerHTML = '';
     }
     const search = documentRef.querySelector('nano-search');
     const value = view === 'search' ? (getQueryVariable('q') || '') : '';
@@ -1562,11 +1567,7 @@ function mountHooks(documentRef = defaultDocument, windowRef = defaultWindow) {
       if (tocHtml) {
         showToc(toc, tocHtml, heading);
       } else {
-        if (typeof toc.__arcusTocCleanup === 'function') {
-          try { toc.__arcusTocCleanup(); } catch (_) {}
-          toc.__arcusTocCleanup = null;
-        }
-        toc.innerHTML = '';
+        clearArcusToc(toc);
         toc.hidden = true;
       }
     }

--- a/assets/themes/arcus/modules/layout.js
+++ b/assets/themes/arcus/modules/layout.js
@@ -158,13 +158,17 @@ export function mount(context = {}) {
   });
 
   const tocview = ensureElement(main, `#${TOCVIEW_ID}`, () => {
-    const el = doc.createElement('aside');
+    const el = doc.createElement('nano-toc');
     el.id = TOCVIEW_ID;
     el.className = 'arcus-toc';
+    el.setAttribute('variant', 'arcus');
     el.setAttribute('aria-label', 'Table of contents');
     el.hidden = true;
     return el;
   });
+  if (tocview.tagName && tocview.tagName.toLowerCase() === 'nano-toc') {
+    tocview.setAttribute('variant', 'arcus');
+  }
 
   let tagBand = rightColumn.querySelector(`#${TAGVIEW_ID}`);
   if (!tagBand) {
@@ -211,23 +215,15 @@ export function mount(context = {}) {
   });
 
   const searchSection = ensureElement(rightColumn, '.arcus-utility__search', () => {
-    const el = doc.createElement('section');
+    const el = doc.createElement('nano-search');
     el.className = 'arcus-utility__search';
     el.setAttribute('aria-label', 'Search');
-    el.innerHTML = `
-      <label class="arcus-search" for="searchInput">
-        <span class="arcus-search__icon" aria-hidden="true">🔍</span>
-        <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
-      </label>`;
+    el.setAttribute('variant', 'arcus');
     return el;
   });
 
-  if (!searchSection.querySelector('.arcus-search')) {
-    searchSection.innerHTML = `
-      <label class="arcus-search" for="searchInput">
-        <span class="arcus-search__icon" aria-hidden="true">🔍</span>
-        <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
-      </label>`;
+  if (searchSection.tagName && searchSection.tagName.toLowerCase() === 'nano-search') {
+    searchSection.setAttribute('variant', 'arcus');
   }
 
   if (searchSection.parentElement !== rightColumn) {
@@ -266,49 +262,8 @@ export function mount(context = {}) {
     main.insertBefore(searchToggleContainer, mainview);
   }
 
-  if (!searchSection.dataset.toggleBound) {
-    searchSection.dataset.toggleBound = 'true';
-
-    const getInput = () => searchSection.querySelector('input[type="search"]');
-    const setOpen = (open) => {
-      const isOpen = Boolean(open);
-      searchSection.classList.toggle('is-open', isOpen);
-      searchToggle.classList.toggle('is-active', isOpen);
-      searchToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
-      if (isOpen) {
-        const input = getInput();
-        if (input) {
-          input.focus({ preventScroll: true });
-        }
-      } else if (doc.activeElement && searchSection.contains(doc.activeElement)) {
-        doc.activeElement.blur();
-      }
-    };
-
-    searchToggle.addEventListener('click', (event) => {
-      event.preventDefault();
-      const nextState = !searchSection.classList.contains('is-open');
-      setOpen(nextState);
-    });
-
-    searchSection.addEventListener('keydown', (event) => {
-      if (event.key === 'Escape') {
-        setOpen(false);
-        searchToggle.focus({ preventScroll: true });
-      }
-    });
-
-    searchSection.addEventListener('focusin', () => {
-      setOpen(true);
-    });
-
-    doc.addEventListener('click', (event) => {
-      if (!searchSection.classList.contains('is-open')) return;
-      const target = event.target;
-      if (searchSection.contains(target)) return;
-      if (searchToggle.contains(target)) return;
-      setOpen(false);
-    });
+  if (typeof searchSection.bindToggle === 'function') {
+    searchSection.bindToggle(searchToggle);
   }
 
   const orphanCredit = utilities.querySelector('.arcus-utility__credit');

--- a/assets/themes/arcus/theme.css
+++ b/assets/themes/arcus/theme.css
@@ -2691,6 +2691,7 @@ body {
 }
 
 .arcus-toc {
+  display: block;
   position: relative;
   width: 0;
   height: 0;

--- a/assets/themes/native/base.css
+++ b/assets/themes/native/base.css
@@ -1174,6 +1174,12 @@ ul.collapsed, li > ul.collapsed { display: none; }
   min-height: 3.75rem;
 }
 
+nano-search.box,
+nano-theme-controls.box,
+nano-toc.box {
+  display: block;
+}
+
 /* Main content box special handling — class added by JavaScript */
 .box.mainview-container {
   min-height: 40rem; /* Total min-height including padding */

--- a/assets/themes/native/modules/interactions.js
+++ b/assets/themes/native/modules/interactions.js
@@ -9,6 +9,7 @@ import { renderPostNav } from '../../../js/post-nav.js';
 import { hydratePostImages, hydratePostVideos, applyLazyLoadingIn } from '../../../js/post-render.js';
 import { hydrateInternalLinkCards } from '../../../js/link-cards.js';
 import { applyLangHints } from '../../../js/typography.js';
+import { renderNanoPostCardHtml } from '../../../js/components.js';
 import { mountThemeControls, applySavedTheme, bindThemeToggle, bindThemePackPicker, bindPostEditor } from '../../../js/theme.js';
 
 const defaultWindow = typeof window !== 'undefined' ? window : undefined;
@@ -126,6 +127,11 @@ function resolveViewContainersNative(params = {}, documentRef = defaultDocument)
 
 function updateSearchPlaceholderNative(params = {}, documentRef = defaultDocument) {
   if (!documentRef) return false;
+  const search = documentRef.querySelector('nano-search');
+  if (search && typeof search.setPlaceholder === 'function') {
+    search.setPlaceholder(params && params.placeholder != null ? String(params.placeholder) : '');
+    return true;
+  }
   const input = documentRef.getElementById('searchInput');
   if (!input) return false;
   const placeholder = params && params.placeholder != null ? String(params.placeholder) : '';
@@ -490,7 +496,12 @@ function resetTOCNative(params = {}, documentRef = defaultDocument, windowRef = 
   const scope = params.containers && typeof params.containers === 'object' ? params.containers : {};
   const toc = scope.tocElement || params.tocElement || (documentRef ? documentRef.getElementById('tocview') : null);
   if (!toc) return false;
-  const clear = () => { try { toc.innerHTML = ''; } catch (_) {}; };
+  const clear = () => {
+    try {
+      if (typeof toc.clear === 'function') toc.clear();
+      else toc.innerHTML = '';
+    } catch (_) {}
+  };
   if (params.immediate) {
     clear();
     try { toc.setAttribute('aria-hidden', 'true'); } catch (_) {}
@@ -517,6 +528,18 @@ function renderPostTOCNative(params = {}, documentRef = defaultDocument, windowR
   const translate = params.translate || params.translator || t;
   const title = params.articleTitle != null ? String(params.articleTitle) : '';
   const tocHtml = params.tocHtml || '';
+  if (typeof toc.renderToc === 'function') {
+    try { toc.setAttribute('toggle-label', translate('toc.toggleAria') || 'Toggle section'); } catch (_) {}
+    toc.renderToc({
+      variant: 'native',
+      articleTitle: title,
+      tocHtml,
+      topLabel: translate('ui.top'),
+      topAria: translate('ui.backToTop') || translate('ui.top') || 'Back to top',
+      contentSelector: '#mainview'
+    });
+    return true;
+  }
   if (!tocHtml) {
     toc.innerHTML = '';
     return true;
@@ -572,9 +595,9 @@ function renderErrorStateNative(params = {}, documentRef = defaultDocument) {
 
 function handleViewChangeNative(params = {}, documentRef = defaultDocument, windowRef = defaultWindow) {
   const context = params && params.context && typeof params.context === 'object' ? params.context : {};
-  const search = context.searchElement || params.searchElement || (documentRef ? documentRef.getElementById('searchbox') : null);
+  const search = context.searchElement || params.searchElement || (documentRef ? (documentRef.querySelector('nano-search') || documentRef.getElementById('searchbox')) : null);
   const tags = context.tagElement || params.tagElement || (documentRef ? documentRef.getElementById('tagview') : null);
-  const input = context.searchInput || params.searchInput || (documentRef ? documentRef.getElementById('searchInput') : null);
+  const input = context.searchInput || params.searchInput || (search && search.input) || (documentRef ? documentRef.getElementById('searchInput') : null);
   const showSearch = context.showSearch != null ? !!context.showSearch : !!params.showSearch;
   const showTags = context.showTags != null ? !!context.showTags : !!params.showTags;
   const queryValue = context.queryValue != null ? context.queryValue : params.queryValue;
@@ -589,6 +612,10 @@ function handleViewChangeNative(params = {}, documentRef = defaultDocument, wind
   }
   if (input && typeof queryValue === 'string') {
     try { input.value = queryValue; } catch (_) {}
+    try {
+      const host = input.closest && input.closest('nano-search');
+      if (host) host.value = queryValue;
+    } catch (_) {}
   }
   return !!(search || tags || input);
 }
@@ -1099,7 +1126,10 @@ function renderStaticTabViewNative(params = {}, documentRef = defaultDocument, w
   const tocElement = documentRef.getElementById('tocview');
   if (tocElement) {
     try { hideElementNative({ element: tocElement }, windowRef); } catch (_) { try { tocElement.style.display = 'none'; } catch (_) {} }
-    try { tocElement.innerHTML = ''; } catch (_) {}
+    try {
+      if (typeof tocElement.clear === 'function') tocElement.clear();
+      else tocElement.innerHTML = '';
+    } catch (_) {}
   }
 
   const articleTitle = (() => {
@@ -1189,17 +1219,22 @@ function renderIndexViewNative(params = {}, documentRef = defaultDocument, windo
       ? `<div class="card-cover-wrap"><div class="ph-skeleton" aria-hidden="true"></div><img class="card-cover" alt="${escapeHtml(String(key || ''))}" src="${escapeHtml(cardImageSrc(coverSrc))}" loading="lazy" decoding="async" fetchpriority="low" width="1600" height="1000"></div>`
       : (useFallbackCover ? fallbackCover(key) : '');
     const hasDate = value && value.date;
-    const dateHtml = hasDate ? `<span class="card-date">${escapeHtml(formatDisplayDate(value.date))}</span>` : '';
+    const dateLabel = hasDate ? formatDisplayDate(value.date) : '';
     const verCount = (value && Array.isArray(value.versions)) ? value.versions.length : 0;
-    const versionsHtml = verCount > 1 ? `<span class="card-versions" title="${escapeHtml(translate('ui.versionLabel'))}">${escapeHtml(translate('ui.versionsCount', verCount))}</span>` : '';
-    const draftHtml = (value && value.draft) ? `<span class="card-draft">${escapeHtml(translate('ui.draftBadge'))}</span>` : '';
-    const parts = [];
-    if (dateHtml) parts.push(dateHtml);
-    if (versionsHtml) parts.push(versionsHtml);
-    if (draftHtml) parts.push(draftHtml);
-    const metaInner = parts.join('<span class="card-sep">•</span>');
+    const versionsLabel = verCount > 1 ? translate('ui.versionsCount', verCount) : '';
+    const draftLabel = (value && value.draft) ? translate('ui.draftBadge') : '';
     const href = makeLangUrl(`?id=${encodeURIComponent(value && value.location ? String(value.location) : '')}`);
-    html += `<a href="${href}" data-idx="${escapeHtml(encodeURIComponent(key))}">${cover}<div class="card-title">${escapeHtml(String(key || ''))}</div><div class="card-excerpt"></div><div class="card-meta">${metaInner}</div>${tag}</a>`;
+    html += renderNanoPostCardHtml({
+      variant: 'native',
+      title: String(key || ''),
+      href,
+      dataIdx: encodeURIComponent(key),
+      date: dateLabel,
+      versionsLabel,
+      draftLabel,
+      coverHtml: cover,
+      tagsHtml: tag
+    });
   }
   html += '</div>';
   if (totalPages > 1) {
@@ -1317,17 +1352,22 @@ function renderSearchResultsNative(params = {}, documentRef = defaultDocument, w
       ? `<div class="card-cover-wrap"><div class="ph-skeleton" aria-hidden="true"></div><img class="card-cover" alt="${escapeHtml(String(key || ''))}" src="${escapeHtml(cardImageSrc(coverSrc))}" loading="lazy" decoding="async" fetchpriority="low" width="1600" height="1000"></div>`
       : (useFallbackCover ? fallbackCover(key) : '');
     const hasDate = value && value.date;
-    const dateHtml = hasDate ? `<span class="card-date">${escapeHtml(formatDisplayDate(value.date))}</span>` : '';
+    const dateLabel = hasDate ? formatDisplayDate(value.date) : '';
     const verCount = (value && Array.isArray(value.versions)) ? value.versions.length : 0;
-    const versionsHtml = verCount > 1 ? `<span class="card-versions" title="${escapeHtml(translate('ui.versionLabel'))}">${escapeHtml(translate('ui.versionsCount', verCount))}</span>` : '';
-    const draftHtml = (value && value.draft) ? `<span class="card-draft">${escapeHtml(translate('ui.draftBadge'))}</span>` : '';
-    const parts = [];
-    if (dateHtml) parts.push(dateHtml);
-    if (versionsHtml) parts.push(versionsHtml);
-    if (draftHtml) parts.push(draftHtml);
-    const metaInner = parts.join('<span class="card-sep">•</span>');
+    const versionsLabel = verCount > 1 ? translate('ui.versionsCount', verCount) : '';
+    const draftLabel = (value && value.draft) ? translate('ui.draftBadge') : '';
     const href = makeLangUrl(`?id=${encodeURIComponent(value && value.location ? String(value.location) : '')}`);
-    html += `<a href="${href}" data-idx="${escapeHtml(encodeURIComponent(key))}">${cover}<div class="card-title">${escapeHtml(String(key || ''))}</div><div class="card-excerpt"></div><div class="card-meta">${metaInner}</div>${tag}</a>`;
+    html += renderNanoPostCardHtml({
+      variant: 'native',
+      title: String(key || ''),
+      href,
+      dataIdx: encodeURIComponent(key),
+      date: dateLabel,
+      versionsLabel,
+      draftLabel,
+      coverHtml: cover,
+      tagsHtml: tag
+    });
   }
   html += '</div>';
 

--- a/assets/themes/native/modules/search-box.js
+++ b/assets/themes/native/modules/search-box.js
@@ -6,23 +6,19 @@ export function mount(context = {}) {
 
   let searchBox = doc.getElementById('searchbox');
   if (!searchBox) {
-    searchBox = doc.createElement('div');
+    searchBox = doc.createElement('nano-search');
     searchBox.className = 'box';
     searchBox.id = 'searchbox';
+    searchBox.setAttribute('variant', 'native');
     sidebar.appendChild(searchBox);
   } else if (!searchBox.classList.contains('box')) {
     searchBox.classList.add('box');
   }
-
-  let input = doc.getElementById('searchInput');
-  if (!input) {
-    input = doc.createElement('input');
-    input.type = 'search';
-    input.id = 'searchInput';
-    searchBox.appendChild(input);
+  if (searchBox.tagName && searchBox.tagName.toLowerCase() === 'nano-search') {
+    searchBox.setAttribute('variant', 'native');
   }
 
-  const updatedRegions = { ...regions, searchBox, searchInput: input };
+  const updatedRegions = { ...regions, searchBox, searchInput: searchBox.input || searchBox.querySelector('input[type="search"]') };
   context.regions = updatedRegions;
   return { regions: updatedRegions };
 }

--- a/assets/themes/native/modules/toc.js
+++ b/assets/themes/native/modules/toc.js
@@ -6,12 +6,16 @@ export function mount(context = {}) {
 
   let toc = doc.getElementById('tocview');
   if (!toc) {
-    toc = doc.createElement('div');
+    toc = doc.createElement('nano-toc');
     toc.className = 'box';
     toc.id = 'tocview';
+    toc.setAttribute('variant', 'native');
     sidebar.appendChild(toc);
   } else if (!toc.classList.contains('box')) {
     toc.classList.add('box');
+  }
+  if (toc.tagName && toc.tagName.toLowerCase() === 'nano-toc') {
+    toc.setAttribute('variant', 'native');
   }
 
   const updatedRegions = { ...regions, tocBox: toc };

--- a/assets/themes/solstice/modules/interactions.js
+++ b/assets/themes/solstice/modules/interactions.js
@@ -633,11 +633,16 @@ function resetToolsPanel(documentRef = defaultDocument, windowRef = defaultWindo
   return setupToolsPanel(documentRef, windowRef);
 }
 
+function clearSolsticeToc(tocEl) {
+  if (!tocEl) return;
+  if (typeof tocEl.clear === 'function') tocEl.clear();
+  else tocEl.innerHTML = '';
+}
+
 function showToc(tocEl, tocHtml, articleTitle) {
   if (!tocEl) return;
   if (!tocHtml) {
-    if (typeof tocEl.clear === 'function') tocEl.clear();
-    else tocEl.innerHTML = '';
+    clearSolsticeToc(tocEl);
     tocEl.hidden = true;
     return;
   }
@@ -743,8 +748,8 @@ function mountHooks(documentRef = defaultDocument, windowRef = defaultWindow) {
     documentRef.body.setAttribute('data-active-view', view || 'posts');
     const toc = getRoleElement('toc', documentRef);
     if (toc && view !== 'post') {
+      clearSolsticeToc(toc);
       toc.hidden = true;
-      toc.innerHTML = '';
     }
     const search = documentRef.querySelector('nano-search');
     const value = view === 'search' ? (getQueryVariable('q') || '') : '';
@@ -958,7 +963,7 @@ function mountHooks(documentRef = defaultDocument, windowRef = defaultWindow) {
       if (tocHtml) {
         showToc(toc, tocHtml, heading);
       } else {
-        toc.innerHTML = '';
+        clearSolsticeToc(toc);
         toc.hidden = true;
       }
     }

--- a/assets/themes/solstice/modules/interactions.js
+++ b/assets/themes/solstice/modules/interactions.js
@@ -11,6 +11,7 @@ import {
   sanitizeImageUrl
 } from '../../../js/utils.js';
 import {
+  mountThemeControls,
   applySavedTheme,
   bindThemeToggle,
   bindThemePackPicker,
@@ -22,6 +23,7 @@ import { hydratePostImages, hydratePostVideos, applyLazyLoadingIn, hydrateCardCo
 import { renderPostMetaCard, renderOutdatedCard } from '../../../js/templates.js';
 import { attachHoverTooltip, renderTagSidebar as renderDefaultTags } from '../../../js/tags.js';
 import { prefersReducedMotion } from '../../../js/dom-utils.js';
+import { renderNanoPostCardHtml } from '../../../js/components.js';
 
 const defaultWindow = typeof window !== 'undefined' ? window : undefined;
 const defaultDocument = typeof document !== 'undefined' ? document : undefined;
@@ -292,24 +294,19 @@ function fadeOut(element, onDone) {
 }
 
 function buildCard({ title, meta, translate, link, siteConfig }) {
-  const safeTitle = escapeHtml(String(title || 'Untitled'));
-  const excerpt = meta && meta.excerpt ? escapeHtml(String(meta.excerpt)) : '';
+  const excerpt = meta && meta.excerpt ? String(meta.excerpt) : '';
   const date = meta && meta.date ? formatDisplayDate(meta.date) : '';
   const tags = meta ? renderTags(meta.tag) : '';
   const coverHtml = renderCardCover(meta, title, siteConfig);
-  const hasCover = Boolean(coverHtml);
-  const cardClasses = `solstice-card${hasCover ? ' solstice-card--with-cover' : ''}`;
-  return `<article class="${cardClasses}">
-    <a class="solstice-card__link" href="${escapeHtml(link)}">
-      ${coverHtml}
-      <div class="solstice-card__body">
-        <h3 class="solstice-card__title">${safeTitle}</h3>
-        ${date ? `<div class="solstice-card__meta">${escapeHtml(date)}</div>` : ''}
-        ${excerpt ? `<p class="solstice-card__excerpt">${excerpt}</p>` : ''}
-        ${tags ? `<div class="solstice-card__tags">${tags}</div>` : ''}
-      </div>
-    </a>
-  </article>`;
+  return renderNanoPostCardHtml({
+    variant: 'solstice',
+    title: String(title || 'Untitled'),
+    href: link,
+    date,
+    excerpt,
+    coverHtml,
+    tagsHtml: tags
+  });
 }
 
 function ensureSolsticeExcerptNode(card, documentRef = defaultDocument) {
@@ -512,6 +509,11 @@ function renderLinksList(root, cfg) {
 }
 
 function updateSearchPlaceholder(documentRef = defaultDocument) {
+  const search = documentRef ? documentRef.querySelector('nano-search') : null;
+  if (search && typeof search.setPlaceholder === 'function') {
+    search.setPlaceholder(t('sidebar.searchPlaceholder'));
+    return;
+  }
   const input = documentRef ? documentRef.getElementById('searchInput') : null;
   if (!input) return;
   input.setAttribute('placeholder', t('sidebar.searchPlaceholder'));
@@ -619,68 +621,8 @@ function populateThemePackOptions(documentRef = defaultDocument, windowRef = def
 function setupToolsPanel(documentRef = defaultDocument, windowRef = defaultWindow) {
   const panel = documentRef && documentRef.getElementById('toolsPanel');
   if (!panel) return false;
-  panel.innerHTML = `
-    <div class="solstice-tools" id="tools">
-      <button id="themeToggle" class="solstice-tool" type="button" aria-label="${t('tools.toggleTheme')}">
-        <span class="solstice-tool__icon">🌓</span>
-        <span class="solstice-tool__label">${t('tools.toggleTheme')}</span>
-      </button>
-      <button id="postEditor" class="solstice-tool" type="button" aria-label="${t('tools.postEditor')}">
-        <span class="solstice-tool__icon">📝</span>
-        <span class="solstice-tool__label">${t('tools.postEditor')}</span>
-      </button>
-      <label class="solstice-tool solstice-tool--select" for="themePack">
-        <span class="solstice-tool__label">${t('tools.themePack')}</span>
-        <select id="themePack"></select>
-      </label>
-      <label class="solstice-tool solstice-tool--select" for="langSelect">
-        <span class="solstice-tool__label">${t('tools.language')}</span>
-        <select id="langSelect"></select>
-      </label>
-      <button id="langReset" class="solstice-tool" type="button" aria-label="${t('tools.resetLanguage')}">
-        <span class="solstice-tool__icon">♻️</span>
-        <span class="solstice-tool__label">${t('tools.resetLanguage')}</span>
-      </button>
-    </div>`;
+  try { mountThemeControls({ host: panel, variant: 'solstice' }); } catch (_) {}
   try { applySavedTheme(); } catch (_) {}
-  try { bindThemeToggle(); } catch (_) {}
-  try { bindPostEditor(); } catch (_) {}
-  try { populateThemePackOptions(documentRef, windowRef); } catch (_) {}
-  try { bindThemePackPicker(); } catch (_) {}
-  try { refreshLanguageSelector(); } catch (_) {}
-  try {
-    const langSel = documentRef.getElementById('langSelect');
-    if (langSel) {
-      langSel.addEventListener('change', () => {
-        const val = langSel.value || 'en';
-        switchLanguage(val);
-      });
-    }
-    const reset = documentRef.getElementById('langReset');
-    if (reset) {
-      reset.addEventListener('click', () => {
-        try { localStorage.removeItem('lang'); } catch (_) {}
-        try {
-          const url = new URL(windowRef ? windowRef.location.href : window.location.href);
-          url.searchParams.delete('lang');
-          if (windowRef && windowRef.history && windowRef.history.replaceState) {
-            windowRef.history.replaceState(windowRef.history.state, documentRef.title, url.toString());
-          }
-        } catch (_) {}
-        try {
-          if (windowRef && windowRef.__ns_softResetLang) {
-            windowRef.__ns_softResetLang();
-            return;
-          }
-        } catch (_) {}
-        try {
-          if (windowRef && windowRef.location) {
-            windowRef.location.reload();
-          }
-        } catch (_) {}
-      });
-    }
-  } catch (_) {}
   return true;
 }
 
@@ -694,11 +636,21 @@ function resetToolsPanel(documentRef = defaultDocument, windowRef = defaultWindo
 function showToc(tocEl, tocHtml, articleTitle) {
   if (!tocEl) return;
   if (!tocHtml) {
-    tocEl.innerHTML = '';
+    if (typeof tocEl.clear === 'function') tocEl.clear();
+    else tocEl.innerHTML = '';
     tocEl.hidden = true;
     return;
   }
-  tocEl.innerHTML = `<div class="solstice-toc__inner"><div class="solstice-toc__title">${escapeHtml(articleTitle || t('ui.tableOfContents'))}</div>${tocHtml}</div>`;
+  if (typeof tocEl.renderToc === 'function') {
+    tocEl.renderToc({
+      variant: 'solstice',
+      articleTitle: articleTitle || t('ui.tableOfContents'),
+      tocHtml,
+      contentSelector: '#mainview'
+    });
+  } else {
+    tocEl.innerHTML = `<div class="solstice-toc__inner"><div class="solstice-toc__title">${escapeHtml(articleTitle || t('ui.tableOfContents'))}</div>${tocHtml}</div>`;
+  }
   tocEl.hidden = false;
   fadeIn(tocEl);
 }
@@ -794,8 +746,11 @@ function mountHooks(documentRef = defaultDocument, windowRef = defaultWindow) {
       toc.hidden = true;
       toc.innerHTML = '';
     }
-    const input = documentRef.getElementById('searchInput');
-    if (input) input.value = view === 'search' ? (getQueryVariable('q') || '') : '';
+    const search = documentRef.querySelector('nano-search');
+    const value = view === 'search' ? (getQueryVariable('q') || '') : '';
+    if (search) search.value = value;
+    const input = search && search.input ? search.input : documentRef.getElementById('searchInput');
+    if (input) input.value = value;
   };
 
   hooks.renderTagSidebar = ({ postsIndex, utilities }) => {

--- a/assets/themes/solstice/modules/layout.js
+++ b/assets/themes/solstice/modules/layout.js
@@ -55,13 +55,17 @@ export function mount(context = {}) {
   });
 
   const tocview = ensureElement(main, `#${TOCVIEW_ID}`, () => {
-    const el = doc.createElement('aside');
+    const el = doc.createElement('nano-toc');
     el.id = TOCVIEW_ID;
     el.className = 'solstice-toc';
+    el.setAttribute('variant', 'solstice');
     el.setAttribute('aria-label', 'Table of contents');
     el.hidden = true;
     return el;
   });
+  if (tocview.tagName && tocview.tagName.toLowerCase() === 'nano-toc') {
+    tocview.setAttribute('variant', 'solstice');
+  }
 
   const footer = ensureElement(container, '.solstice-footer', () => {
     const el = doc.createElement('footer');
@@ -86,12 +90,7 @@ export function mount(context = {}) {
         </div>
         <section class="solstice-footer__meta" aria-label="Site meta">
           <div class="solstice-footer__credit">NanoSite</div>
-          <section class="solstice-footer__search" aria-label="Search">
-            <label class="solstice-search" for="searchInput">
-              <span class="solstice-search__icon" aria-hidden="true">🔍</span>
-              <input id="searchInput" type="search" autocomplete="off" spellcheck="false" placeholder="Search" />
-            </label>
-          </section>
+          <nano-search class="solstice-footer__search" variant="solstice" aria-label="Search"></nano-search>
         </section>
       </div>`;
     return el;

--- a/assets/themes/solstice/theme.css
+++ b/assets/themes/solstice/theme.css
@@ -687,6 +687,7 @@ body {
 }
 
 .solstice-toc {
+  display: block;
   margin-top: 3rem;
   border-radius: var(--solstice-radius);
   border: 1px solid var(--solstice-border);

--- a/scripts/test-ui-components.js
+++ b/scripts/test-ui-components.js
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (path) => readFileSync(resolve(here, '..', path), 'utf8');
+
+const components = read('assets/js/components.js');
+const main = read('assets/main.js');
+const search = read('assets/js/search.js');
+const theme = read('assets/js/theme.js');
+const toc = read('assets/js/toc.js');
+const nativeSearch = read('assets/themes/native/modules/search-box.js');
+const nativeToc = read('assets/themes/native/modules/toc.js');
+const nativeInteractions = read('assets/themes/native/modules/interactions.js');
+const arcusLayout = read('assets/themes/arcus/modules/layout.js');
+const arcusInteractions = read('assets/themes/arcus/modules/interactions.js');
+const solsticeLayout = read('assets/themes/solstice/modules/layout.js');
+const solsticeInteractions = read('assets/themes/solstice/modules/interactions.js');
+const nativeCss = read('assets/themes/native/base.css');
+const arcusCss = read('assets/themes/arcus/theme.css');
+const solsticeCss = read('assets/themes/solstice/theme.css');
+
+function sliceBetween(source, startNeedle, endNeedle) {
+  const start = source.indexOf(startNeedle);
+  assert.notEqual(start, -1, `missing start marker: ${startNeedle}`);
+  const bodyStart = start + startNeedle.length;
+  const end = source.indexOf(endNeedle, bodyStart);
+  assert.notEqual(end, -1, `missing end marker: ${endNeedle}`);
+  return source.slice(bodyStart, end);
+}
+
+assert.match(components, /class NanoSearch extends HTMLElement[\s\S]*dispatchNanoEvent\(this, 'nano:search'/, 'nano-search should own the search input and emit nano:search');
+assert.match(components, /class NanoThemeControls extends HTMLElement[\s\S]*'nano:theme-pack-change'[\s\S]*'nano:language-change'/, 'nano-theme-controls should own tool UI events');
+assert.match(components, /class NanoToc extends HTMLElement[\s\S]*renderToc\(options = \{\}\)[\s\S]*_cleanupListeners/, 'nano-toc should render and clean up its own listeners');
+assert.match(components, /class NanoPostCard extends HTMLElement[\s\S]*_renderNative[\s\S]*_renderArcus[\s\S]*_renderSolstice/, 'nano-post-card should render all shipped card variants');
+assert.match(components, /defineElement\('nano-search'[\s\S]*defineElement\('nano-theme-controls'[\s\S]*defineElement\('nano-toc'[\s\S]*defineElement\('nano-post-card'/, 'all UI components should be registered centrally');
+
+const nanoSearchAttributeChanged = sliceBetween(
+  components,
+  '  attributeChangedCallback(name, oldValue, newValue) {',
+  '\n\n  get input()'
+);
+assert.match(nanoSearchAttributeChanged, /if \(name === 'value'\) \{[\s\S]*this\._syncInputState\(\);[\s\S]*return;/, 'nano-search should only sync input value for value attribute changes');
+const placeholderBranch = nanoSearchAttributeChanged.indexOf("if (name === 'placeholder')");
+const labelBranch = nanoSearchAttributeChanged.indexOf("if (name === 'label')");
+assert.notEqual(placeholderBranch, -1, 'nano-search should handle placeholder attribute updates separately');
+assert.notEqual(labelBranch, -1, 'nano-search should handle label attribute updates separately');
+assert.doesNotMatch(nanoSearchAttributeChanged.slice(placeholderBranch), /this\._syncInputState\(\)/, 'placeholder and label updates should not overwrite the live input value');
+
+const nanoTocBindClicks = sliceBetween(
+  components,
+  '  _bindTocClicks() {',
+  '\n    const top = this.querySelector'
+);
+const tocMapSet = nanoTocBindClicks.indexOf('this._idToLink.set(id, anchor)');
+const tocBoundGuard = nanoTocBindClicks.indexOf("anchor.dataset.nanoTocBound === 'true'");
+assert.notEqual(tocMapSet, -1, 'nano-toc should register anchors in _idToLink');
+assert.notEqual(tocBoundGuard, -1, 'nano-toc should keep a listener binding guard');
+assert.ok(tocMapSet < tocBoundGuard, 'nano-toc should rebuild _idToLink before skipping already-bound anchors');
+
+assert.match(main, /import '\.\/js\/components\.js';/, 'main should register custom elements before theme layout mounting');
+assert.match(search, /addEventListener\('nano:search'[\s\S]*navigateSearch/, 'search routing should listen for nano:search');
+assert.doesNotMatch(search, /input\.onkeydown\s*=/, 'search.js should not own the component input via onkeydown');
+
+assert.match(theme, /mountThemeControls\(options = \{\}\)[\s\S]*document\.createElement\('nano-theme-controls'\)/, 'core theme controls should mount nano-theme-controls');
+assert.match(theme, /component\.addEventListener\('nano:theme-toggle'[\s\S]*component\.addEventListener\('nano:language-reset'/, 'theme control side effects should be event-driven');
+
+assert.match(nativeSearch, /createElement\('nano-search'\)/, 'native search module should mount nano-search');
+assert.match(arcusLayout, /createElement\('nano-search'\)/, 'arcus layout should mount nano-search');
+assert.match(solsticeLayout, /<nano-search class="solstice-footer__search"/, 'solstice layout should mount nano-search');
+
+assert.match(nativeToc, /createElement\('nano-toc'\)/, 'native TOC module should mount nano-toc');
+assert.match(arcusLayout, /createElement\('nano-toc'\)/, 'arcus layout should mount nano-toc');
+assert.match(solsticeLayout, /createElement\('nano-toc'\)/, 'solstice layout should mount nano-toc');
+assert.match(toc, /typeof tocRoot\.enhance === 'function'/, 'legacy setupTOC should delegate to nano-toc when present');
+
+assert.match(nativeInteractions, /renderNanoPostCardHtml\(/, 'native cards should render through nano-post-card');
+assert.match(arcusInteractions, /renderNanoPostCardHtml\(/, 'arcus cards should render through nano-post-card');
+assert.match(solsticeInteractions, /renderNanoPostCardHtml\(/, 'solstice cards should render through nano-post-card');
+
+assert.match(nativeCss, /nano-search\.box,[\s\S]*nano-theme-controls\.box,[\s\S]*nano-toc\.box\s*\{\s*display: block;/, 'native component hosts should preserve block layout');
+assert.match(arcusCss, /\.arcus-toc\s*\{\s*display: block;/, 'arcus nano-toc host should preserve block layout');
+assert.match(solsticeCss, /\.solstice-toc\s*\{\s*display: block;/, 'solstice nano-toc host should preserve block layout');
+
+console.log('ok - ui component boundaries');

--- a/scripts/test-ui-components.js
+++ b/scripts/test-ui-components.js
@@ -79,6 +79,12 @@ assert.match(toc, /typeof tocRoot\.enhance === 'function'/, 'legacy setupTOC sho
 assert.match(nativeInteractions, /renderNanoPostCardHtml\(/, 'native cards should render through nano-post-card');
 assert.match(arcusInteractions, /renderNanoPostCardHtml\(/, 'arcus cards should render through nano-post-card');
 assert.match(solsticeInteractions, /renderNanoPostCardHtml\(/, 'solstice cards should render through nano-post-card');
+assert.doesNotMatch(arcusInteractions, /\btoc\.innerHTML\s*=\s*''/, 'arcus TOC teardown should use nano-toc.clear() when available');
+assert.doesNotMatch(solsticeInteractions, /\btoc\.innerHTML\s*=\s*''/, 'solstice TOC teardown should use nano-toc.clear() when available');
+assert.match(arcusInteractions, /function clearArcusToc\(tocEl\)[\s\S]*typeof tocEl\.clear === 'function'[\s\S]*tocEl\.clear\(\)/, 'arcus TOC teardown should call component cleanup');
+assert.match(solsticeInteractions, /function clearSolsticeToc\(tocEl\)[\s\S]*typeof tocEl\.clear === 'function'[\s\S]*tocEl\.clear\(\)/, 'solstice TOC teardown should call component cleanup');
+assert.match(arcusInteractions, /hooks\.handleViewChange[\s\S]*clearArcusToc\(toc\)/, 'arcus view transitions should use shared TOC teardown');
+assert.match(solsticeInteractions, /hooks\.handleViewChange[\s\S]*clearSolsticeToc\(toc\)/, 'solstice view transitions should use shared TOC teardown');
 
 assert.match(nativeCss, /nano-search\.box,[\s\S]*nano-theme-controls\.box,[\s\S]*nano-toc\.box\s*\{\s*display: block;/, 'native component hosts should preserve block layout');
 assert.match(arcusCss, /\.arcus-toc\s*\{\s*display: block;/, 'arcus nano-toc host should preserve block layout');


### PR DESCRIPTION
## Summary

- Introduce shared Nano UI components for search, theme controls, TOC, and post cards.
- Route native, arcus, and solstice theme surfaces through the shared components while preserving theme-specific markup and styling.
- Fix the reviewer-found state regressions: repeated `nano-toc.enhance()` rebuilds `_idToLink`, and `nano-search` placeholder/label updates preserve live input text.

## Validation

- `node scripts/test-ui-components.js`
- `node --check assets/js/components.js`
- `git diff --check`