### PR TITLE
[codex] Make image captions directly editable

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -4679,15 +4679,6 @@ function openGithubCommitFilePreview(file, triggerEl) {
   previewDialog.appendChild(head);
   previewDialog.setAttribute('aria-labelledby', previewTitleId);
 
-  const body = document.createElement('div');
-  body.className = 'github-preview-body';
-  const pathLine = document.createElement('p');
-  pathLine.className = 'github-preview-path';
-  pathLine.textContent = file.path || file.label || '';
-  body.appendChild(pathLine);
-
-  const contentWrap = document.createElement('div');
-  contentWrap.className = 'github-preview-content';
   if (file.kind === 'asset') {
     if (file.base64) {
       const mime = file.mime || 'application/octet-stream';
@@ -4695,34 +4686,32 @@ function openGithubCommitFilePreview(file, triggerEl) {
       img.className = 'github-preview-image';
       img.alt = file.label || file.path || '';
       img.src = `data:${mime};base64,${file.base64}`;
-      contentWrap.appendChild(img);
+      previewDialog.appendChild(img);
       if (Number.isFinite(file.size)) {
         const meta = document.createElement('p');
         meta.className = 'github-preview-meta';
         const sizeKb = file.size > 0 ? (file.size / 1024).toFixed(1) : '0';
         meta.textContent = `${mime} · ${sizeKb} KB`;
-        body.appendChild(meta);
+        previewDialog.appendChild(meta);
       }
     } else {
       const notice = document.createElement('p');
       notice.className = 'github-preview-empty';
       notice.textContent = t('editor.composer.github.preview.unavailable');
-      contentWrap.appendChild(notice);
+      previewDialog.appendChild(notice);
     }
   } else if (typeof file.content === 'string') {
     const pre = document.createElement('pre');
     pre.className = 'github-preview-code';
     pre.textContent = file.content;
-    contentWrap.appendChild(pre);
+    previewDialog.appendChild(pre);
   } else {
     const notice = document.createElement('p');
     notice.className = 'github-preview-empty';
     notice.textContent = t('editor.composer.github.preview.unavailable');
-    contentWrap.appendChild(notice);
+    previewDialog.appendChild(notice);
   }
 
-  body.appendChild(contentWrap);
-  previewDialog.appendChild(body);
   previewModal.appendChild(previewDialog);
   document.body.appendChild(previewModal);
 

--- a/assets/js/editor-blocks.js
+++ b/assets/js/editor-blocks.js
@@ -1278,6 +1278,33 @@ function inputValue(input) {
   return input ? String(input.value || '') : '';
 }
 
+function plainEditableValue(editable) {
+  return String(editable && editable.textContent != null ? editable.textContent : '')
+    .replace(/\u00a0/g, ' ')
+    .replace(/[\r\n]+/g, ' ');
+}
+
+function insertPlainTextIntoEditable(editable, text) {
+  if (!editable) return false;
+  const value = String(text == null ? '' : text);
+  try {
+    const sel = window.getSelection && window.getSelection();
+    if (!sel || !sel.rangeCount) return false;
+    const range = sel.getRangeAt(0);
+    if (!nodeContains(editable, range.startContainer) || !nodeContains(editable, range.endContainer)) return false;
+    range.deleteContents();
+    const node = document.createTextNode(value);
+    range.insertNode(node);
+    range.setStartAfter(node);
+    range.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(range);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
 function resolveCodeHighlightLanguage(language, codeText) {
   const raw = String(language || '').trim();
   const normalized = raw.toLowerCase();
@@ -2543,7 +2570,7 @@ export function createMarkdownBlocksEditor(root, options = {}) {
       if (!blockEl) return;
       const index = nodes.indexOf(blockEl);
       const body = blockEl.querySelector('.blocks-block-body');
-      const editable = body ? body.querySelector('.blocks-rich-editable, .blocks-code-preview code[contenteditable="true"], .blocks-source-textarea') : null;
+      const editable = body ? body.querySelector('.blocks-rich-editable, .blocks-code-preview code[contenteditable="true"], .blocks-image-caption, .blocks-source-textarea') : null;
       if (!editable) {
         try { blockEl.focus({ preventScroll: true }); }
         catch (_) {
@@ -3347,6 +3374,7 @@ export function createMarkdownBlocksEditor(root, options = {}) {
       'textarea',
       'label',
       'a[href]',
+      '.blocks-image-caption',
       '[contenteditable="true"]'
     ].join(','));
   };
@@ -3387,7 +3415,7 @@ export function createMarkdownBlocksEditor(root, options = {}) {
           sync: editableSyncMap.get(editable) || null
         });
       });
-      const editables = blockEl.querySelectorAll('.blocks-rich-editable:not(.blocks-list-text), .blocks-code-preview code[contenteditable="true"], .blocks-source-textarea');
+      const editables = blockEl.querySelectorAll('.blocks-rich-editable:not(.blocks-list-text), .blocks-code-preview code[contenteditable="true"], .blocks-image-caption, .blocks-source-textarea');
       editables.forEach(editable => {
         candidates.push({
           editable,
@@ -3421,7 +3449,7 @@ export function createMarkdownBlocksEditor(root, options = {}) {
     const listTexts = Array.from(blockEl.querySelectorAll('.blocks-list-item .blocks-list-text'));
     const listTarget = listTexts.length ? (edge === 'last' ? listTexts[listTexts.length - 1] : listTexts[0]) : null;
     const editable = listTarget
-      || blockEl.querySelector('.blocks-rich-editable:not(.blocks-list-text), .blocks-code-preview code[contenteditable="true"], .blocks-source-textarea');
+      || blockEl.querySelector('.blocks-rich-editable:not(.blocks-list-text), .blocks-code-preview code[contenteditable="true"], .blocks-image-caption, .blocks-source-textarea');
     if (editable) {
       return {
         blockEl,
@@ -4399,9 +4427,18 @@ export function createMarkdownBlocksEditor(root, options = {}) {
     }
     if (caption) {
       caption.textContent = block.data.alt || '';
-      caption.hidden = !block.data.alt;
+      caption.classList.toggle('is-empty', !block.data.alt);
     }
     hydrateImages(blockEl);
+  };
+
+  const syncImageAltFromCaption = (block, caption) => {
+    const blockEl = blockElements().find(el => el && el.dataset && el.dataset.blockId === block.id);
+    const img = blockEl && blockEl.querySelector('.blocks-image-preview');
+    const alt = plainEditableValue(caption);
+    if (img) img.alt = alt;
+    if (caption) caption.classList.toggle('is-empty', !alt);
+    updateFromControl(block, { alt });
   };
 
   const setImagePlaceholderVisible = (figure, visible) => {
@@ -4434,12 +4471,6 @@ export function createMarkdownBlocksEditor(root, options = {}) {
   const createImageMetadataControls = (block, index) => {
     const controls = document.createElement('div');
     controls.className = 'blocks-image-meta-controls';
-    const alt = document.createElement('input');
-    alt.type = 'text';
-    alt.className = 'blocks-image-alt';
-    alt.value = block.data.alt || '';
-    alt.placeholder = text('imageAlt', 'Alt text');
-    alt.setAttribute('aria-label', text('imageAlt', 'Alt text'));
     const replace = button(text('replaceImage', 'Replace image'), 'blocks-btn blocks-image-replace');
     replace.title = text('replaceImage', 'Replace image');
     replace.setAttribute('aria-label', text('replaceImage', 'Replace image'));
@@ -4450,10 +4481,8 @@ export function createMarkdownBlocksEditor(root, options = {}) {
     title.placeholder = text('imageTitle', 'Image title');
     title.setAttribute('aria-label', text('imageTitle', 'Image title'));
     const update = () => {
-      updateFromControl(block, { alt: inputValue(alt), title: inputValue(title) });
-      syncRenderedImageBlock(block);
+      updateFromControl(block, { title: inputValue(title) });
     };
-    alt.addEventListener('input', update);
     title.addEventListener('input', update);
     replace.addEventListener('mousedown', (event) => event.preventDefault());
     replace.addEventListener('click', () => {
@@ -4462,7 +4491,7 @@ export function createMarkdownBlocksEditor(root, options = {}) {
         options.requestImageUpload({ replaceIndex: index, replaceBlockId: block.id });
       }
     });
-    controls.append(alt, title, replace);
+    controls.append(title, replace);
     return controls;
   };
 
@@ -4490,8 +4519,34 @@ export function createMarkdownBlocksEditor(root, options = {}) {
     const resolved = resolveAssetSrc(block.data.src || '');
     configureImagePreview(figure, img, resolved);
     const caption = document.createElement('figcaption');
+    caption.className = 'blocks-image-caption';
+    caption.contentEditable = 'true';
+    caption.spellcheck = true;
+    caption.dataset.placeholder = text('imageAlt', 'Alt text');
+    caption.setAttribute('aria-label', text('imageAlt', 'Alt text'));
     caption.textContent = block.data.alt || '';
-    caption.hidden = !block.data.alt;
+    caption.classList.toggle('is-empty', !block.data.alt);
+    const syncCaption = () => syncImageAltFromCaption(block, caption);
+    editableSyncMap.set(caption, syncCaption);
+    caption.addEventListener('input', syncCaption);
+    caption.addEventListener('paste', (event) => {
+      const pasted = event.clipboardData && event.clipboardData.getData('text/plain');
+      if (pasted == null) return;
+      event.preventDefault();
+      if (insertPlainTextIntoEditable(caption, pasted.replace(/[\r\n]+/g, ' '))) syncCaption();
+    });
+    caption.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' && !event.isComposing) {
+        event.preventDefault();
+        return;
+      }
+      if (removeEmptyBlockWithBackspace(event, block, index, caption, syncCaption)) return;
+      handleCrossBlockArrowNavigation(event, index, caption);
+    });
+    caption.addEventListener('focus', () => {
+      setActive(index, caption, syncCaption);
+      updateInlineToolbarState();
+    });
     figure.append(img, placeholder, caption);
 
     body.append(figure);
@@ -5257,7 +5312,7 @@ export function createMarkdownBlocksEditor(root, options = {}) {
       if (state.cardPickerOpen) renderCardPicker();
     },
     focus() {
-      const active = list.querySelector('.blocks-block.is-active [contenteditable="true"], .blocks-block.is-active input, .blocks-block.is-active textarea');
+      const active = list.querySelector('.blocks-block.is-active [contenteditable="true"], .blocks-block.is-active .blocks-image-caption, .blocks-block.is-active input, .blocks-block.is-active textarea');
       try { if (active) active.focus(); } catch (_) {}
     },
     requestLayout() {

--- a/assets/themes/native/base.css
+++ b/assets/themes/native/base.css
@@ -1618,26 +1618,6 @@ nano-toc.box {
 .gh-sync-file-entry:active { transform: translateY(1px); }
 
 .github-preview-dialog { max-width: min(90vw, 860px); }
-.github-preview-body {
-  padding: 0.25rem 0 0.5rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.65rem;
-}
-.github-preview-path {
-  margin: 0;
-  font-size: 0.85rem;
-  color: var(--muted);
-  overflow-wrap: anywhere;
-}
-.github-preview-content {
-  border: 1px solid var(--border);
-  border-radius: 0.75rem;
-  background: color-mix(in srgb, var(--surface, var(--card)) 90%, transparent);
-  padding: 0.75rem;
-  max-height: 60vh;
-  overflow: auto;
-}
 .github-preview-code {
   margin: 0;
   white-space: pre-wrap;

--- a/index_editor.html
+++ b/index_editor.html
@@ -1455,8 +1455,9 @@
     .blocks-image-placeholder::after { content:""; position:absolute; inset:0; background:linear-gradient(to top right, transparent calc(50% - .75px), color-mix(in srgb, var(--muted) 45%, transparent) 50%, transparent calc(50% + .75px)); }
     .blocks-image-figure.is-image-placeholder .blocks-image-placeholder { display:flex; }
     .blocks-image-placeholder-label { position:relative; z-index:1; max-width:min(22rem, 80%); font-family:var(--sans, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif); font-size:.88rem; line-height:1.25; }
-    .blocks-image-figure figcaption { margin-top:.5em; color:var(--muted); font-family:var(--serif, var(--article-serif-stack, Georgia, "Times New Roman", Times, serif)); font-size:.9em; text-align:center; word-break:break-word; }
-    .blocks-image-figure figcaption[hidden] { display:none !important; }
+    .blocks-image-figure figcaption { margin-top:.5em; min-height:1.45em; color:var(--muted); font-family:var(--serif, var(--article-serif-stack, Georgia, "Times New Roman", Times, serif)); font-size:.9em; text-align:center; word-break:break-word; outline:none; border-radius:6px; cursor:text; }
+    .blocks-image-figure figcaption:focus { outline:none; box-shadow:none; }
+    .blocks-image-figure figcaption.is-empty::before { content:attr(data-placeholder); color:color-mix(in srgb, var(--muted) 58%, transparent); pointer-events:none; }
     .blocks-visual-list { margin:0 0 0 1.25rem; padding-left:0; font-family:var(--serif, var(--article-serif-stack, Georgia, "Times New Roman", Times, serif)); font-size:1.04rem; line-height:1.75; letter-spacing:.005em; }
     .blocks-visual-list-standard { margin-left:0; padding-left:0; }
     .blocks-visual-list-task { list-style:none; margin-left:0; padding-left:0; }

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -10,6 +10,7 @@ const editorMainPath = resolve(here, '../assets/js/editor-main.js');
 const editorBlocksPath = resolve(here, '../assets/js/editor-blocks.js');
 const syntaxHighlightPath = resolve(here, '../assets/js/syntax-highlight.js');
 const editorPath = resolve(here, '../index_editor.html');
+const nativeBasePath = resolve(here, '../assets/themes/native/base.css');
 const nativeThemePath = resolve(here, '../assets/themes/native/theme.css');
 const enI18nPath = resolve(here, '../assets/i18n/en.js');
 const chsI18nPath = resolve(here, '../assets/i18n/chs.js');
@@ -24,6 +25,7 @@ const editorMainSource = readFileSync(editorMainPath, 'utf8');
 const editorBlocksSource = readFileSync(editorBlocksPath, 'utf8');
 const syntaxHighlightSource = readFileSync(syntaxHighlightPath, 'utf8');
 const editorSource = readFileSync(editorPath, 'utf8');
+const nativeBaseSource = readFileSync(nativeBasePath, 'utf8');
 const nativeThemeSource = readFileSync(nativeThemePath, 'utf8');
 const i18nSource = readFileSync(i18nPath, 'utf8');
 const enI18nSource = readFileSync(enI18nPath, 'utf8');
@@ -60,6 +62,30 @@ assert.doesNotMatch(
   editorSource,
   /\.view-toggle \.vt-btn\.has-draft::before/,
   'composer file switch dirty indicators should not render as inline orange dots'
+);
+
+assert.match(
+  source,
+  /function openGithubCommitFilePreview\(file, triggerEl\) \{[\s\S]*previewDialog\.appendChild\(head\);[\s\S]*pre\.className = 'github-preview-code';[\s\S]*previewDialog\.appendChild\(pre\);[\s\S]*previewModal\.appendChild\(previewDialog\);/,
+  'GitHub pending-file preview should append code directly to the dialog without extra content wrappers'
+);
+
+assert.doesNotMatch(
+  source,
+  /github-preview-body|github-preview-content|github-preview-path/,
+  'GitHub pending-file preview should not render the removed body, content, or repeated path wrappers'
+);
+
+assert.match(
+  nativeBaseSource,
+  /\.github-preview-code \{[\s\S]*margin: 0;[\s\S]*white-space: pre-wrap;[\s\S]*word-break: break-word;/,
+  'GitHub pending-file preview code block should render directly without owning a nested scroll area'
+);
+
+assert.doesNotMatch(
+  nativeBaseSource,
+  /\.github-preview-code \{[^}]*\b(?:max-height|overflow):/,
+  'GitHub pending-file preview should rely on the modal dialog scroll container'
 );
 
 assert.match(

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -457,8 +457,8 @@ assert.match(
 
 assert.match(
   editorBlocksSource,
-  /const isBlocksCaretInteractiveTarget = \(target\) => \{[\s\S]*closestElement\(target, \[[\s\S]*'\.blocks-block-head'[\s\S]*'\.blocks-command-menu'[\s\S]*'\.blocks-link-editor'[\s\S]*'\.blocks-card-preview'[\s\S]*'\.blocks-inspector'[\s\S]*'button'[\s\S]*'input'[\s\S]*'select'[\s\S]*'textarea'[\s\S]*'a\[href\]'[\s\S]*'\[contenteditable="true"\]'[\s\S]*\]\.join/,
-  'blocks caret routing should exclude command menus, link editors, article cards, controls, links, and native editable targets'
+  /const isBlocksCaretInteractiveTarget = \(target\) => \{[\s\S]*closestElement\(target, \[[\s\S]*'\.blocks-block-head'[\s\S]*'\.blocks-command-menu'[\s\S]*'\.blocks-link-editor'[\s\S]*'\.blocks-card-preview'[\s\S]*'\.blocks-inspector'[\s\S]*'button'[\s\S]*'input'[\s\S]*'select'[\s\S]*'textarea'[\s\S]*'a\[href\]'[\s\S]*'\.blocks-image-caption'[\s\S]*'\[contenteditable="true"\]'[\s\S]*\]\.join/,
+  'blocks caret routing should exclude command menus, link editors, article cards, controls, links, image captions, and native editable targets'
 );
 
 assert.match(
@@ -475,8 +475,8 @@ assert.match(
 
 assert.match(
   editorBlocksSource,
-  /const editableCaretCandidates = \(\) => \{[\s\S]*querySelectorAll\('\.blocks-list-item \.blocks-list-text'\)[\s\S]*hitTarget: closestElement\(editable, '\.blocks-list-item'\) \|\| editable[\s\S]*querySelectorAll\('\.blocks-rich-editable:not\(\.blocks-list-text\), \.blocks-code-preview code\[contenteditable="true"\], \.blocks-source-textarea'\)[\s\S]*sync: editableSyncMap\.get\(editable\) \|\| null/,
-  'routed caret candidates should include whole-row list item hit targets, rich text, code editors, and source markdown textareas with sync callbacks'
+  /const editableCaretCandidates = \(\) => \{[\s\S]*querySelectorAll\('\.blocks-list-item \.blocks-list-text'\)[\s\S]*hitTarget: closestElement\(editable, '\.blocks-list-item'\) \|\| editable[\s\S]*querySelectorAll\('\.blocks-rich-editable:not\(\.blocks-list-text\), \.blocks-code-preview code\[contenteditable="true"\], \.blocks-image-caption, \.blocks-source-textarea'\)[\s\S]*sync: editableSyncMap\.get\(editable\) \|\| null/,
+  'routed caret candidates should include whole-row list item hit targets, rich text, code editors, image captions, and source markdown textareas with sync callbacks'
 );
 
 assert.match(
@@ -601,8 +601,8 @@ assert.match(
 
 assert.match(
   editorBlocksSource,
-  /const img = document\.createElement\('img'\);[\s\S]*img\.className = 'blocks-image-preview'[\s\S]*const placeholder = document\.createElement\('div'\);[\s\S]*placeholder\.className = 'blocks-image-placeholder'[\s\S]*figure\.append\(img, placeholder, caption\);/,
-  'image blocks should render a real image element with an editor-only empty-image placeholder'
+  /const img = document\.createElement\('img'\);[\s\S]*img\.className = 'blocks-image-preview'[\s\S]*const placeholder = document\.createElement\('div'\);[\s\S]*placeholder\.className = 'blocks-image-placeholder'[\s\S]*const caption = document\.createElement\('figcaption'\);[\s\S]*caption\.className = 'blocks-image-caption';[\s\S]*caption\.contentEditable = 'true';[\s\S]*caption\.dataset\.placeholder = text\('imageAlt', 'Alt text'\);[\s\S]*figure\.append\(img, placeholder, caption\);/,
+  'image blocks should render a real image element with an editor-only empty-image placeholder and directly editable caption'
 );
 
 assert.match(
@@ -625,8 +625,20 @@ assert.doesNotMatch(
 
 assert.match(
   editorBlocksSource,
-  /const createImageMetadataControls = \(block, index\) => \{[\s\S]*controls\.className = 'blocks-image-meta-controls';[\s\S]*alt\.className = 'blocks-image-alt';[\s\S]*const replace = button\(text\('replaceImage', 'Replace image'\), 'blocks-btn blocks-image-replace'\);[\s\S]*title\.className = 'blocks-image-title';[\s\S]*updateFromControl\(block, \{ alt: inputValue\(alt\), title: inputValue\(title\) \}\);[\s\S]*options\.requestImageUpload\(\{ replaceIndex: index, replaceBlockId: block\.id \}\);[\s\S]*controls\.append\(alt, title, replace\);/,
-  'image metadata controls should place replace-image after text fields'
+  /const createImageMetadataControls = \(block, index\) => \{[\s\S]*controls\.className = 'blocks-image-meta-controls';[\s\S]*const replace = button\(text\('replaceImage', 'Replace image'\), 'blocks-btn blocks-image-replace'\);[\s\S]*title\.className = 'blocks-image-title';[\s\S]*updateFromControl\(block, \{ title: inputValue\(title\) \}\);[\s\S]*options\.requestImageUpload\(\{ replaceIndex: index, replaceBlockId: block\.id \}\);[\s\S]*controls\.append\(title, replace\);/,
+  'image metadata controls should keep title and replace-image controls after moving alt editing into the caption'
+);
+
+assert.doesNotMatch(
+  editorBlocksSource,
+  /blocks-image-alt|controls\.append\(alt, title, replace\)|alt: inputValue\(alt\)/,
+  'image metadata controls should not keep the old toolbar alt-text input'
+);
+
+assert.match(
+  editorBlocksSource,
+  /const syncImageAltFromCaption = \(block, caption\) => \{[\s\S]*const img = blockEl && blockEl\.querySelector\('\.blocks-image-preview'\);[\s\S]*const alt = plainEditableValue\(caption\);[\s\S]*if \(img\) img\.alt = alt;[\s\S]*caption\.classList\.toggle\('is-empty', !alt\);[\s\S]*updateFromControl\(block, \{ alt \}\);[\s\S]*caption\.addEventListener\('input', syncCaption\);/,
+  'editable image captions should update block alt text and keep the rendered img alt synchronized'
 );
 
 assert.match(
@@ -1135,8 +1147,8 @@ assert.match(
 
 assert.match(
   editorSource,
-  /\.blocks-image-figure \{ position:relative; margin:0; display:block; width:100%; \}[\s\S]*\.blocks-image-preview \{ display:block; width:100%; height:auto; border-radius:\.5rem;[\s\S]*\.blocks-image-figure\.is-image-placeholder \{ aspect-ratio:5 \/ 1; min-height:5rem;[\s\S]*\.blocks-image-placeholder::after \{ content:""; position:absolute; inset:0; background:linear-gradient\(to top right,[\s\S]*\.blocks-image-figure\.is-image-placeholder \.blocks-image-placeholder \{ display:flex; \}[\s\S]*\.blocks-image-figure figcaption \{ margin-top:\.5em; color:var\(--muted\); font-family:var\(--serif,[\s\S]*font-size:\.9em; text-align:center;[\s\S]*\.blocks-image-figure figcaption\[hidden\] \{ display:none !important; \}/,
-  'image block visual styling should mirror native article images and reserve a diagonal empty-image placeholder'
+  /\.blocks-image-figure \{ position:relative; margin:0; display:block; width:100%; \}[\s\S]*\.blocks-image-preview \{ display:block; width:100%; height:auto; border-radius:\.5rem;[\s\S]*\.blocks-image-figure\.is-image-placeholder \{ aspect-ratio:5 \/ 1; min-height:5rem;[\s\S]*\.blocks-image-placeholder::after \{ content:""; position:absolute; inset:0; background:linear-gradient\(to top right,[\s\S]*\.blocks-image-figure\.is-image-placeholder \.blocks-image-placeholder \{ display:flex; \}[\s\S]*\.blocks-image-figure figcaption \{ margin-top:\.5em; min-height:1\.45em; color:var\(--muted\); font-family:var\(--serif,[\s\S]*font-size:\.9em; text-align:center;[\s\S]*\.blocks-image-figure figcaption\.is-empty::before \{ content:attr\(data-placeholder\);/,
+  'image block visual styling should mirror native article images and expose a subtle editable empty-caption placeholder'
 );
 
 assert.match(

--- a/scripts/test-editor-blocks-roundtrip.js
+++ b/scripts/test-editor-blocks-roundtrip.js
@@ -667,8 +667,8 @@ run('blank blocks use existing removable and cross-block navigation paths', () =
   );
   assert.match(
     editorBlocksSource,
-    /blockEl\.querySelector\('\.blocks-rich-editable:not\(\.blocks-list-text\), \.blocks-code-preview code\[contenteditable="true"\], \.blocks-source-textarea'\)/,
-    'cross-block target discovery should include blank rich editables'
+    /blockEl\.querySelector\('\.blocks-rich-editable:not\(\.blocks-list-text\), \.blocks-code-preview code\[contenteditable="true"\], \.blocks-image-caption, \.blocks-source-textarea'\)/,
+    'cross-block target discovery should include blank rich editables and image captions'
   );
   assert.match(
     editorBlocksSource,


### PR DESCRIPTION
## Summary

- Move image alt-text editing from the image block toolbar into the visible caption.
- Keep image title and replace-image controls in the toolbar.
- Simplify the GitHub pending-file preview modal by removing redundant wrapper/path elements and relying on the modal dialog for scrolling.

## Validation

- node scripts/test-composer-identity-grid.js
- node scripts/test-editor-blocks-roundtrip.js
- node --check assets/js/composer.js
- node --check assets/js/editor-blocks.js
- git diff --check
