### PR TITLE
[codex] Migrate built-in themes to pure API

### DIFF
--- a/assets/themes/arcus/modules/interactions.js
+++ b/assets/themes/arcus/modules/interactions.js
@@ -31,9 +31,56 @@ const CLASS_HIDDEN = 'is-hidden';
 
 let themeI18n = null;
 let currentSiteConfig = null;
+let activeRegions = null;
 
 function setThemeI18n(context = {}) {
   themeI18n = context && context.i18n && typeof context.i18n === 'object' ? context.i18n : null;
+  activeRegions = context && context.regions && typeof context.regions === 'object' ? context.regions : null;
+}
+
+function getRegion(name, documentRef = defaultDocument) {
+  const key = String(name || '').trim();
+  if (!key) return null;
+  try {
+    if (activeRegions && typeof activeRegions.get === 'function') {
+      const region = activeRegions.get(key);
+      if (region) return region;
+    }
+  } catch (_) {}
+  try {
+    if (activeRegions && activeRegions[key]) return activeRegions[key];
+  } catch (_) {}
+  if (!documentRef || typeof documentRef.querySelector !== 'function') return null;
+  try {
+    return documentRef.querySelector(`[data-theme-region="${key}"]`);
+  } catch (_) {
+    return null;
+  }
+}
+
+function getMainRegion(documentRef = defaultDocument) {
+  return getRegion('main', documentRef) || (documentRef && documentRef.querySelector && documentRef.querySelector('.arcus-mainview')) || null;
+}
+
+function getTocRegion(documentRef = defaultDocument) {
+  return getRegion('toc', documentRef) || (documentRef && documentRef.querySelector && documentRef.querySelector('.arcus-toc')) || null;
+}
+
+function getNavRegion(documentRef = defaultDocument) {
+  return getRegion('nav', documentRef) || (documentRef && documentRef.querySelector && documentRef.querySelector('.arcus-nav')) || null;
+}
+
+function getTagsRegion(documentRef = defaultDocument) {
+  return getRegion('tags', documentRef) || (documentRef && documentRef.querySelector && documentRef.querySelector('.arcus-tagband')) || null;
+}
+
+function getSearchRegion(documentRef = defaultDocument) {
+  return getRegion('search', documentRef) || (documentRef && documentRef.querySelector && documentRef.querySelector('nano-search.arcus-utility__search, nano-search')) || null;
+}
+
+function getSearchInput(documentRef = defaultDocument) {
+  const search = getSearchRegion(documentRef);
+  return (search && search.input) || (search && search.querySelector && search.querySelector('input[type="search"]')) || null;
 }
 
 function getCurrentLang() {
@@ -100,7 +147,7 @@ const ARCUS_CARD_CLASSES = {
 
 function getScrollContainer(documentRef = defaultDocument) {
   if (!documentRef || typeof documentRef.querySelector !== 'function') return null;
-  return documentRef.querySelector('.arcus-rightcol');
+  return getRegion('scrollContainer', documentRef) || documentRef.querySelector('.arcus-rightcol');
 }
 
 function scrollElementToTop(element, behavior) {
@@ -444,15 +491,15 @@ function getRoleElement(role, documentRef = defaultDocument) {
   if (!documentRef) return null;
   switch (role) {
     case 'main':
-      return documentRef.getElementById('mainview');
+      return getMainRegion(documentRef);
     case 'toc':
-      return documentRef.getElementById('tocview');
+      return getTocRegion(documentRef);
     case 'sidebar':
-      return documentRef.getElementById('tagview');
+      return getTagsRegion(documentRef);
     case 'content':
-      return documentRef.querySelector('.arcus-main');
+      return getRegion('content', documentRef) || documentRef.querySelector('.arcus-main');
     case 'container':
-      return documentRef.querySelector('.arcus-shell');
+      return getRegion('container', documentRef) || documentRef.querySelector('.arcus-shell');
     default:
       return null;
   }
@@ -785,7 +832,7 @@ function updateSearchPlaceholder(documentRef = defaultDocument) {
     search.setPlaceholder(t('sidebar.searchPlaceholder'));
     return;
   }
-  const input = documentRef ? documentRef.getElementById('searchInput') : null;
+  const input = documentRef ? getSearchInput(documentRef) : null;
   if (!input) return;
   input.setAttribute('placeholder', t('sidebar.searchPlaceholder'));
 }
@@ -1281,7 +1328,7 @@ function showToc(tocEl, tocHtml, articleTitle) {
     tocEl.renderToc({
       articleTitle: articleTitle || t('ui.tableOfContents'),
       tocHtml,
-      contentSelector: '#mainview'
+      contentRoot: getMainRegion(tocEl.ownerDocument || defaultDocument)
     });
   } else {
     tocEl.innerHTML = `<div class="arcus-toc__inner"><div class="arcus-toc__title">${escapeHtml(articleTitle || t('ui.tableOfContents'))}</div>${tocHtml}</div>`;
@@ -1413,7 +1460,7 @@ function mountHooks(documentRef = defaultDocument, windowRef = defaultWindow) {
     const search = documentRef.querySelector('nano-search');
     const value = view === 'search' ? (getQueryVariable('q') || '') : '';
     if (search) search.value = value;
-    const input = search && search.input ? search.input : documentRef.getElementById('searchInput');
+    const input = search && search.input ? search.input : getSearchInput(documentRef);
     if (input) input.value = value;
   };
 
@@ -1435,7 +1482,7 @@ function mountHooks(documentRef = defaultDocument, windowRef = defaultWindow) {
   };
 
   hooks.renderTabs = ({ tabsBySlug, activeSlug, getHomeSlug, postsEnabled }) => {
-    const nav = documentRef.getElementById('tabsNav');
+    const nav = getNavRegion(documentRef);
     if (!nav) return false;
     renderNavLinks(nav, tabsBySlug, activeSlug, postsEnabled, getHomeSlug);
     return true;
@@ -1698,9 +1745,6 @@ function mountHooks(documentRef = defaultDocument, windowRef = defaultWindow) {
     return true;
   };
 
-  if (windowRef) {
-    windowRef.__ns_themeHooks = Object.assign({}, windowRef.__ns_themeHooks || {}, hooks);
-  }
   return hooks;
 }
 
@@ -1708,20 +1752,27 @@ export function mount(context = {}) {
   setThemeI18n(context);
   const doc = context.document || defaultDocument;
   const win = (context.document && context.document.defaultView) || defaultWindow;
-  const hooks = mountHooks(doc, win);
+  const effects = mountHooks(doc, win);
   updateSearchPlaceholder(doc);
   setupToolsPanel(doc, win);
   setupDynamicBackground(doc, win);
   setupBackToTop(doc, win);
+  const views = {
+    post: effects.renderPostView,
+    posts: effects.renderIndexView,
+    search: effects.renderSearchResults,
+    tab: effects.renderStaticTabView,
+    error: effects.renderErrorState,
+    loading: (params = {}) => (
+      params.view === 'tab'
+        ? effects.renderStaticTabLoadingState(params)
+        : effects.renderPostLoadingState(params)
+    )
+  };
   return {
-    hooks,
-    views: {
-      post: hooks.renderPostView,
-      posts: hooks.renderIndexView,
-      search: hooks.renderSearchResults,
-      tab: hooks.renderStaticTabView
-    },
-    effects: hooks
+    views,
+    components: {},
+    effects
   };
 }
 

--- a/assets/themes/arcus/modules/interactions.js
+++ b/assets/themes/arcus/modules/interactions.js
@@ -59,7 +59,17 @@ function getRegion(name, documentRef = defaultDocument) {
 }
 
 function getMainRegion(documentRef = defaultDocument) {
-  return getRegion('main', documentRef) || (documentRef && documentRef.querySelector && documentRef.querySelector('.arcus-mainview')) || null;
+  if (activeRegions && activeRegions.mainview && activeRegions.mainview.nodeType === 1) return activeRegions.mainview;
+  if (documentRef && documentRef.querySelector) {
+    const explicit = documentRef.querySelector('.arcus-mainview');
+    if (explicit) return explicit;
+  }
+  const region = getRegion('main', documentRef);
+  if (!region) return null;
+  try {
+    if (region.matches && region.matches('.arcus-mainview')) return region;
+  } catch (_) {}
+  return null;
 }
 
 function getTocRegion(documentRef = defaultDocument) {

--- a/assets/themes/arcus/modules/layout.js
+++ b/assets/themes/arcus/modules/layout.js
@@ -46,7 +46,7 @@ export function mount(context = {}) {
         </div>
         <div class="arcus-header__divider" aria-hidden="true"></div>
         <div class="arcus-nav__scroller" data-overflow="none">
-          <nav id="${NAV_ID}" class="arcus-nav" aria-label="Primary navigation"></nav>
+          <nav id="${NAV_ID}" class="arcus-nav" data-theme-region="nav" aria-label="Primary navigation"></nav>
         </div>
         <div class="arcus-utility__credit arcus-footer__credit arcus-header__credit" aria-label="Site credit"></div>
       </div>`;
@@ -149,22 +149,26 @@ export function mount(context = {}) {
     rightColumn.insertBefore(main, rightColumn.firstChild);
   }
 
-  const mainview = ensureElement(main, `#${MAINVIEW_ID}`, () => {
+  const mainview = ensureElement(main, '[data-theme-region="main"], .arcus-mainview', () => {
     const el = doc.createElement('section');
     el.id = MAINVIEW_ID;
     el.className = 'arcus-mainview';
+    el.setAttribute('data-theme-region', 'main');
     el.setAttribute('tabindex', '-1');
     return el;
   });
+  mainview.setAttribute('data-theme-region', 'main');
 
-  const tocview = ensureElement(main, `#${TOCVIEW_ID}`, () => {
+  const tocview = ensureElement(main, '[data-theme-region="toc"], .arcus-toc', () => {
     const el = doc.createElement('nano-toc');
     el.id = TOCVIEW_ID;
     el.className = 'arcus-toc';
+    el.setAttribute('data-theme-region', 'toc');
     el.setAttribute('aria-label', 'Table of contents');
     el.hidden = true;
     return el;
   });
+  tocview.setAttribute('data-theme-region', 'toc');
   if (tocview.tagName && tocview.tagName.toLowerCase() === 'nano-toc') {
     tocview.setAttribute('inner-class', 'arcus-toc__inner');
     tocview.setAttribute('title-class', 'arcus-toc__title');
@@ -172,15 +176,16 @@ export function mount(context = {}) {
     tocview.removeAttribute('variant');
   }
 
-  let tagBand = rightColumn.querySelector(`#${TAGVIEW_ID}`);
+  let tagBand = rightColumn.querySelector('[data-theme-region="tags"], .arcus-tagband');
   if (!tagBand) {
-    tagBand = container.querySelector(`#${TAGVIEW_ID}`) || doc.createElement('section');
+    tagBand = container.querySelector('[data-theme-region="tags"], .arcus-tagband') || doc.createElement('section');
     tagBand.id = TAGVIEW_ID;
     if (!tagBand.parentElement || tagBand.parentElement !== rightColumn) {
       rightColumn.appendChild(tagBand);
     }
   }
   tagBand.className = 'arcus-tagband';
+  tagBand.setAttribute('data-theme-region', 'tags');
   tagBand.setAttribute('aria-label', 'Tag filters');
 
   let footer = rightColumn.querySelector('.arcus-footer');
@@ -295,7 +300,7 @@ export function mount(context = {}) {
     main,
     content: main,
     mainview,
-    nav: header.querySelector(`#${NAV_ID}`),
+    nav: header.querySelector('[data-theme-region="nav"], .arcus-nav'),
     search: searchSection,
     searchInput: searchSection.input || searchSection.querySelector('input[type="search"]'),
     toc: tocview,

--- a/assets/themes/arcus/theme.json
+++ b/assets/themes/arcus/theme.json
@@ -12,58 +12,50 @@
   ],
   "views": {
     "post": {
-      "hook": "renderPostView"
+      "module": "modules/interactions.js",
+      "handler": "post"
     },
     "posts": {
-      "hook": "renderIndexView"
+      "module": "modules/interactions.js",
+      "handler": "posts"
     },
     "search": {
-      "hook": "renderSearchResults"
+      "module": "modules/interactions.js",
+      "handler": "search"
     },
     "tab": {
-      "hook": "renderStaticTabView"
+      "module": "modules/interactions.js",
+      "handler": "tab"
     },
     "error": {
-      "hook": "renderErrorState"
+      "module": "modules/interactions.js",
+      "handler": "error"
     },
     "loading": {
-      "hooks": [
-        "renderPostLoadingState",
-        "renderStaticTabLoadingState"
-      ]
+      "module": "modules/interactions.js",
+      "handler": "loading"
     }
   },
   "regions": {
     "main": {
-      "required": true,
-      "aliases": [
-        "mainview"
-      ]
+      "required": true
     },
-    "toc": {
-      "aliases": [
-        "tocview"
-      ]
-    },
-    "search": {
-      "aliases": [
-        "searchInput"
-      ]
-    },
-    "nav": {
-      "aliases": [
-        "tabsNav"
-      ]
-    },
-    "tags": {
-      "aliases": [
-        "tagBand",
-        "tagview"
-      ]
-    },
+    "toc": {},
+    "search": {},
+    "nav": {},
+    "tags": {},
     "footer": {
       "required": true
-    }
+    },
+    "container": {},
+    "content": {},
+    "footerNav": {},
+    "header": {},
+    "rightColumn": {},
+    "scrollContainer": {},
+    "tagBand": {},
+    "toolsPanel": {},
+    "utilities": {}
   },
   "components": [
     "nano-search",
@@ -87,90 +79,5 @@
       "assets",
       "links"
     ]
-  },
-  "contract": {
-    "version": 1,
-    "regions": [
-      "container",
-      "content",
-      "footer",
-      "footerNav",
-      "header",
-      "nav",
-      "search",
-      "tags",
-      "main",
-      "mainview",
-      "rightColumn",
-      "scrollContainer",
-      "tagBand",
-      "toc",
-      "toolsPanel",
-      "utilities"
-    ],
-    "domIds": [
-      "mainview",
-      "searchInput",
-      "tabsNav",
-      "tagview",
-      "tocview"
-    ],
-    "hooks": [
-      "afterIndexRender",
-      "afterSearchRender",
-      "decoratePostView",
-      "enhanceIndexLayout",
-      "getScrollState",
-      "getViewContainer",
-      "handleDocumentClick",
-      "handleRouteScroll",
-      "handleViewChange",
-      "handleWindowResize",
-      "hideElement",
-      "reflectThemeConfig",
-      "renderErrorState",
-      "renderFooterNav",
-      "renderIndexView",
-      "renderPostLoadingState",
-      "renderPostTOC",
-      "renderPostView",
-      "renderSearchResults",
-      "renderSiteIdentity",
-      "renderSiteLinks",
-      "renderStaticTabLoadingState",
-      "renderStaticTabView",
-      "renderTagSidebar",
-      "renderTabs",
-      "resetThemeControls",
-      "resolveViewContainers",
-      "restoreScrollState",
-      "scrollToHash",
-      "setupFooter",
-      "setupResponsiveTabsObserver",
-      "setupThemeControls",
-      "showElement",
-      "updateSearchPlaceholder",
-      "updateLayoutLoadingState"
-    ],
-    "views": [
-      "post",
-      "posts",
-      "search",
-      "tab"
-    ],
-    "content": {
-      "markdown": "html",
-      "toc": "html",
-      "shapes": [
-        "rawMarkdown",
-        "html",
-        "blocks",
-        "tocTree",
-        "headings",
-        "metadata",
-        "assets",
-        "links"
-      ]
-    }
   }
 }

--- a/assets/themes/native/modules/footer.js
+++ b/assets/themes/native/modules/footer.js
@@ -61,7 +61,13 @@ export function mount(context = {}) {
     right.appendChild(top);
   }
 
-  const updatedRegions = { ...regions, footer, footerNav: nav };
-  context.regions = updatedRegions;
-  return { regions: updatedRegions };
+  if (typeof regions.register === 'function') {
+    regions.register('footer', footer);
+    regions.register('footerNav', nav);
+  } else {
+    regions.footer = footer;
+    regions.footerNav = nav;
+  }
+  context.regions = regions;
+  return { regions };
 }

--- a/assets/themes/native/modules/interactions.js
+++ b/assets/themes/native/modules/interactions.js
@@ -15,9 +15,67 @@ const defaultWindow = typeof window !== 'undefined' ? window : undefined;
 const defaultDocument = typeof document !== 'undefined' ? document : undefined;
 
 let themeI18n = null;
+let activeRegions = null;
 
 function setThemeI18n(context = {}) {
   themeI18n = context && context.i18n && typeof context.i18n === 'object' ? context.i18n : null;
+  activeRegions = context && context.regions && typeof context.regions === 'object' ? context.regions : null;
+}
+
+function getRegion(name, documentRef = defaultDocument) {
+  const key = String(name || '').trim();
+  if (!key) return null;
+  try {
+    if (activeRegions && typeof activeRegions.get === 'function') {
+      const region = activeRegions.get(key);
+      if (region) return region;
+    }
+  } catch (_) {}
+  try {
+    if (activeRegions && activeRegions[key]) return activeRegions[key];
+  } catch (_) {}
+  if (!documentRef || typeof documentRef.querySelector !== 'function') return null;
+  try {
+    return documentRef.querySelector(`[data-theme-region="${key}"]`);
+  } catch (_) {
+    return null;
+  }
+}
+
+function getMainRegion(documentRef = defaultDocument) {
+  if (activeRegions && activeRegions.main && activeRegions.main.nodeType === 1) return activeRegions.main;
+  if (activeRegions && activeRegions.mainview && activeRegions.mainview.nodeType === 1) return activeRegions.mainview;
+  if (documentRef && documentRef.querySelector) {
+    const explicit = documentRef.querySelector('[data-theme-region="main"], .native-mainview');
+    if (explicit) return explicit;
+  }
+  const region = getRegion('main', documentRef);
+  if (!region) return null;
+  try {
+    if (region.matches && region.matches('[data-theme-region="main"], .native-mainview')) return region;
+  } catch (_) {}
+  return null;
+}
+
+function getTocRegion(documentRef = defaultDocument) {
+  return getRegion('toc', documentRef) || (documentRef && documentRef.querySelector && documentRef.querySelector('.native-toc')) || null;
+}
+
+function getNavRegion(documentRef = defaultDocument) {
+  return getRegion('nav', documentRef) || (documentRef && documentRef.querySelector && documentRef.querySelector('.native-tabs')) || null;
+}
+
+function getTagsRegion(documentRef = defaultDocument) {
+  return getRegion('tags', documentRef) || (documentRef && documentRef.querySelector && documentRef.querySelector('.native-tagbox')) || null;
+}
+
+function getSearchRegion(documentRef = defaultDocument) {
+  return getRegion('search', documentRef) || (documentRef && documentRef.querySelector && documentRef.querySelector('nano-search.native-searchbox, nano-search')) || null;
+}
+
+function getSearchInput(documentRef = defaultDocument) {
+  const search = getSearchRegion(documentRef);
+  return (search && search.input) || (search && search.querySelector && search.querySelector('input[type="search"]')) || null;
 }
 
 function getCurrentLang() {
@@ -113,17 +171,23 @@ function getContainerByRole(role, documentRef = defaultDocument) {
   try {
     switch (role) {
       case 'main':
-        return documentRef.getElementById('mainview');
+        return getMainRegion(documentRef);
       case 'toc':
-        return documentRef.getElementById('tocview');
+        return getTocRegion(documentRef);
       case 'sidebar':
-        return documentRef.querySelector('.sidebar');
+        return getRegion('sidebar', documentRef) || documentRef.querySelector('.sidebar');
       case 'content':
-        return documentRef.querySelector('.content');
+        return getRegion('content', documentRef) || documentRef.querySelector('.content');
       case 'container': {
         const main = getContainerByRole('main', documentRef);
         return main ? main.closest('.box') : null;
       }
+      case 'search':
+        return getSearchRegion(documentRef);
+      case 'nav':
+        return getNavRegion(documentRef);
+      case 'tags':
+        return getTagsRegion(documentRef);
       default:
         return null;
     }
@@ -201,7 +265,7 @@ function updateSearchPlaceholderNative(params = {}, documentRef = defaultDocumen
     search.setPlaceholder(params && params.placeholder != null ? String(params.placeholder) : '');
     return true;
   }
-  const input = documentRef.getElementById('searchInput');
+  const input = getSearchInput(documentRef);
   if (!input) return false;
   const placeholder = params && params.placeholder != null ? String(params.placeholder) : '';
   input.setAttribute('placeholder', placeholder);
@@ -223,7 +287,7 @@ function setupThemeControlsNative(params = {}) {
 }
 
 function handleWindowResizeNative(params = {}, documentRef = defaultDocument, windowRef = defaultWindow) {
-  const nav = documentRef ? documentRef.getElementById('tabsNav') : null;
+  const nav = documentRef ? getNavRegion(documentRef) : null;
   if (!nav) return false;
   updateMovingHighlight(nav, windowRef, documentRef);
   return true;
@@ -337,7 +401,7 @@ async function warnLargeImagesInNative(containerSelector, cfg = {}, documentRef 
 
 function bindPostVersionSelectorsNative(documentRef = defaultDocument, windowRef = defaultWindow) {
   try {
-    const root = documentRef ? documentRef.getElementById('mainview') : null;
+    const root = documentRef ? getMainRegion(documentRef) : null;
     if (!root) return;
     const selects = Array.from(root.querySelectorAll('select.post-version-select'));
     if (!selects.length) return;
@@ -544,7 +608,7 @@ function updateLayoutLoadingStateNative(params = {}, documentRef = defaultDocume
   const scope = params.containers && typeof params.containers === 'object' ? params.containers : {};
   const content = scope.contentElement || params.contentElement || (documentRef && documentRef.querySelector('.content'));
   const sidebar = scope.sidebarElement || params.sidebarElement || (documentRef && documentRef.querySelector('.sidebar'));
-  const container = scope.containerElement || params.containerElement || (documentRef && documentRef.getElementById('mainview')?.closest('.box'));
+  const container = scope.containerElement || params.containerElement || (getMainRegion(documentRef) && getMainRegion(documentRef).closest('.box'));
   const extra = Array.isArray(params.extraContentClasses) ? params.extraContentClasses : [];
   const toggle = (element, base = []) => {
     if (!element || !element.classList) return;
@@ -563,7 +627,7 @@ function updateLayoutLoadingStateNative(params = {}, documentRef = defaultDocume
 
 function resetTOCNative(params = {}, documentRef = defaultDocument, windowRef = defaultWindow) {
   const scope = params.containers && typeof params.containers === 'object' ? params.containers : {};
-  const toc = scope.tocElement || params.tocElement || (documentRef ? documentRef.getElementById('tocview') : null);
+  const toc = scope.tocElement || params.tocElement || (documentRef ? getTocRegion(documentRef) : null);
   if (!toc) return false;
   const clear = () => {
     try {
@@ -592,7 +656,7 @@ function resetTOCNative(params = {}, documentRef = defaultDocument, windowRef = 
 
 function renderPostTOCNative(params = {}, documentRef = defaultDocument, windowRef = defaultWindow) {
   const scope = params.containers && typeof params.containers === 'object' ? params.containers : {};
-  const toc = scope.tocElement || params.tocElement || (documentRef ? documentRef.getElementById('tocview') : null);
+  const toc = scope.tocElement || params.tocElement || (documentRef ? getTocRegion(documentRef) : null);
   if (!toc) return false;
   const translate = params.translate || params.translator || t;
   const title = params.articleTitle != null ? String(params.articleTitle) : '';
@@ -604,7 +668,7 @@ function renderPostTOCNative(params = {}, documentRef = defaultDocument, windowR
       tocHtml,
       topLabel: translate('ui.top'),
       topAria: translate('ui.backToTop') || translate('ui.top') || 'Back to top',
-      contentSelector: '#mainview'
+      contentRoot: scope.mainElement || getMainRegion(documentRef)
     });
     return true;
   }
@@ -632,7 +696,7 @@ function renderPostTOCNative(params = {}, documentRef = defaultDocument, windowR
 
 function renderErrorStateNative(params = {}, documentRef = defaultDocument) {
   const scope = params.containers && typeof params.containers === 'object' ? params.containers : {};
-  const target = scope.mainElement || params.targetElement || (documentRef ? documentRef.getElementById('mainview') : null);
+  const target = scope.mainElement || params.targetElement || (documentRef ? getMainRegion(documentRef) : null);
   if (!target) return false;
   const variant = String(params.variant || 'error').trim() || 'error';
   const title = params.title != null ? String(params.title) : '';
@@ -663,9 +727,9 @@ function renderErrorStateNative(params = {}, documentRef = defaultDocument) {
 
 function handleViewChangeNative(params = {}, documentRef = defaultDocument, windowRef = defaultWindow) {
   const context = params && params.context && typeof params.context === 'object' ? params.context : {};
-  const search = context.searchElement || params.searchElement || (documentRef ? (documentRef.querySelector('nano-search') || documentRef.getElementById('searchbox')) : null);
-  const tags = context.tagElement || params.tagElement || (documentRef ? documentRef.getElementById('tagview') : null);
-  const input = context.searchInput || params.searchInput || (search && search.input) || (documentRef ? documentRef.getElementById('searchInput') : null);
+  const search = context.searchElement || params.searchElement || (documentRef ? getSearchRegion(documentRef) : null);
+  const tags = context.tagElement || params.tagElement || (documentRef ? getTagsRegion(documentRef) : null);
+  const input = context.searchInput || params.searchInput || (search && search.input) || (documentRef ? getSearchInput(documentRef) : null);
   const showSearch = context.showSearch != null ? !!context.showSearch : !!params.showSearch;
   const showTags = context.showTags != null ? !!context.showTags : !!params.showTags;
   const queryValue = context.queryValue != null ? context.queryValue : params.queryValue;
@@ -705,17 +769,16 @@ function initializeSyntaxHighlightingNative(params = {}) {
 function enhanceIndexLayoutNative(params = {}, documentRef = defaultDocument, windowRef = defaultWindow) {
   const containerEl = params.containerElement || getContainerByRole('main', documentRef);
   const indexEl = params.indexElement || (containerEl ? containerEl.querySelector('.index') : null);
-  const containerSelector = params.containerSelector || (containerEl && containerEl.id ? `#${containerEl.id}` : '#mainview');
-  const indexSelector = params.indexSelector || (containerSelector ? `${containerSelector} .index` : '.index');
+  const indexSelector = params.indexSelector || '.native-mainview .index';
   if (typeof params.hydrateCardCovers === 'function') {
-    try { params.hydrateCardCovers(containerEl || containerSelector); } catch (_) {}
+    try { params.hydrateCardCovers(containerEl || documentRef); } catch (_) {}
   }
   if (typeof params.applyLazyLoadingIn === 'function') {
-    try { params.applyLazyLoadingIn(containerEl || containerSelector); } catch (_) {}
+    try { params.applyLazyLoadingIn(containerEl || documentRef); } catch (_) {}
   }
   try {
     const cfg = (params.siteConfig && params.siteConfig.assetWarnings && params.siteConfig.assetWarnings.largeImage) || {};
-    warnLargeImagesInNative(containerEl || containerSelector, cfg, documentRef, windowRef).catch(() => {});
+    warnLargeImagesInNative(containerEl || documentRef, cfg, documentRef, windowRef).catch(() => {});
   } catch (_) {}
   if (typeof params.setupSearch === 'function') {
     try { params.setupSearch(Array.isArray(params.allEntries) ? params.allEntries : []); } catch (_) {}
@@ -756,7 +819,7 @@ function enhanceIndexLayoutNative(params = {}, documentRef = defaultDocument, wi
 function decoratePostViewNative(params = {}, documentRef = defaultDocument, windowRef = defaultWindow) {
   if (!documentRef) return false;
   const scope = params.containers && typeof params.containers === 'object' ? params.containers : {};
-  const container = scope.mainElement || params.container || documentRef.getElementById('mainview');
+  const container = scope.mainElement || params.container || getMainRegion(documentRef);
   if (!container) return false;
   const translate = params.translate || params.t || t;
   const articleTitle = params.articleTitle != null ? String(params.articleTitle) : '';
@@ -977,8 +1040,8 @@ function renderFooterNavNative(params = {}, documentRef = defaultDocument, windo
 function renderPostLoadingStateNative(params = {}, documentRef = defaultDocument) {
   if (!documentRef) return false;
   const scope = params.containers && typeof params.containers === 'object' ? params.containers : {};
-  const toc = scope.tocElement || params.tocElement || documentRef.getElementById('tocview');
-  const main = scope.mainElement || params.mainElement || documentRef.getElementById('mainview');
+  const toc = scope.tocElement || params.tocElement || getTocRegion(documentRef);
+  const main = scope.mainElement || params.mainElement || getMainRegion(documentRef);
   const translate = params.translator || params.t || t;
   const renderSkeleton = typeof params.renderSkeletonArticle === 'function' ? params.renderSkeletonArticle : renderSkeletonArticle;
   const ensureAutoHeight = typeof params.ensureAutoHeight === 'function' ? params.ensureAutoHeight : (() => {});
@@ -1003,7 +1066,7 @@ function renderPostLoadingStateNative(params = {}, documentRef = defaultDocument
 function renderStaticTabLoadingStateNative(params = {}, documentRef = defaultDocument) {
   if (!documentRef) return false;
   const scope = params.containers && typeof params.containers === 'object' ? params.containers : {};
-  const main = scope.mainElement || params.mainElement || documentRef.getElementById('mainview');
+  const main = scope.mainElement || params.mainElement || getMainRegion(documentRef);
   const renderSkeleton = typeof params.renderSkeletonArticle === 'function' ? params.renderSkeletonArticle : renderSkeletonArticle;
   if (main) main.innerHTML = renderSkeleton();
   return !!main;
@@ -1012,7 +1075,7 @@ function renderStaticTabLoadingStateNative(params = {}, documentRef = defaultDoc
 function renderPostViewNative(params = {}, documentRef = defaultDocument, windowRef = defaultWindow) {
   if (!documentRef) return { handled: false, title: params && params.fallbackTitle ? String(params.fallbackTitle) : '' };
   const scope = params.containers && typeof params.containers === 'object' ? params.containers : {};
-  const container = scope.mainElement || params.container || documentRef.getElementById('mainview');
+  const container = scope.mainElement || params.container || getMainRegion(documentRef);
   if (!container) return { handled: false, title: params && params.fallbackTitle ? String(params.fallbackTitle) : '' };
 
   const markdownHtml = params.markdownHtml || '';
@@ -1047,30 +1110,30 @@ function renderPostViewNative(params = {}, documentRef = defaultDocument, window
   container.innerHTML = `${outdated}${topMeta}${markdownHtml}${bottomMeta}`;
 
   const renderNav = getUtility(params, 'renderPostNav', renderPostNav);
-  try { renderNav('#mainview', postsIndex, postId); } catch (_) {}
+  try { renderNav(container, postsIndex, postId); } catch (_) {}
 
   const hydrateImages = getUtility(params, 'hydratePostImages', (selector) => hydratePostImages(selector));
-  try { hydrateImages('#mainview'); } catch (_) {}
+  try { hydrateImages(container); } catch (_) {}
 
   const lazyLoad = getUtility(params, 'applyLazyLoadingIn', (selector) => applyLazyLoadingIn(selector));
-  try { lazyLoad('#mainview'); } catch (_) {}
+  try { lazyLoad(container); } catch (_) {}
 
   const langHints = getUtility(params, 'applyLangHints', (selector) => applyLangHints(selector));
-  try { langHints('#mainview'); } catch (_) {}
+  try { langHints(container); } catch (_) {}
 
   const hydrateVideos = getUtility(params, 'hydratePostVideos', (selector) => hydratePostVideos(selector));
-  try { hydrateVideos('#mainview'); } catch (_) {}
+  try { hydrateVideos(container); } catch (_) {}
 
   try {
     const cfg = (siteConfig && siteConfig.assetWarnings && siteConfig.assetWarnings.largeImage) || {};
-    warnLargeImagesInNative('#mainview', cfg, documentRef, windowRef).catch(() => {});
+    warnLargeImagesInNative(container, cfg, documentRef, windowRef).catch(() => {});
   } catch (_) {}
 
   const hydrateLinks = getUtility(params, 'hydrateInternalLinkCards', (selector, opts) => hydrateInternalLinkCards(selector, opts));
   const fetchMarkdown = getUtility(params, 'fetchMarkdown', () => Promise.resolve(''));
   const makeHref = getUtility(params, 'makeLangHref', (loc) => withLangParam(`?id=${encodeURIComponent(loc)}`));
   try {
-    hydrateLinks('#mainview', {
+    hydrateLinks(container, {
       allowedLocations,
       locationAliasMap,
       postsByLocationTitle,
@@ -1092,10 +1155,10 @@ function renderPostViewNative(params = {}, documentRef = defaultDocument, window
   });
 
   const tocHtml = params.tocHtml || '';
-  const tocElement = documentRef.getElementById('tocview');
+  const tocElement = getTocRegion(documentRef);
   const { headingEl: firstHeadingEl, headingText: firstHeadingText } = (() => {
     try {
-      const el = documentRef.querySelector('#mainview h1, #mainview h2, #mainview h3');
+      const el = container.querySelector('h1, h2, h3');
       if (!el) return { headingEl: null, headingText: '' };
       const clone = el.cloneNode(true);
       const anchors = clone.querySelectorAll('a.anchor');
@@ -1152,34 +1215,34 @@ function renderPostViewNative(params = {}, documentRef = defaultDocument, window
 function renderStaticTabViewNative(params = {}, documentRef = defaultDocument, windowRef = defaultWindow) {
   if (!documentRef) return { handled: false, title: params && params.tab && params.tab.title ? String(params.tab.title) : '' };
   const scope = params.containers && typeof params.containers === 'object' ? params.containers : {};
-  const container = scope.mainElement || params.container || documentRef.getElementById('mainview');
+  const container = scope.mainElement || params.container || getMainRegion(documentRef);
   if (!container) return { handled: false, title: params && params.tab && params.tab.title ? String(params.tab.title) : '' };
 
   const markdownHtml = params.markdownHtml || '';
   container.innerHTML = markdownHtml;
 
   const hydrateImages = getUtility(params, 'hydratePostImages', (selector) => hydratePostImages(selector));
-  try { hydrateImages('#mainview'); } catch (_) {}
+  try { hydrateImages(container); } catch (_) {}
 
   const lazyLoad = getUtility(params, 'applyLazyLoadingIn', (selector) => applyLazyLoadingIn(selector));
-  try { lazyLoad('#mainview'); } catch (_) {}
+  try { lazyLoad(container); } catch (_) {}
 
   const langHints = getUtility(params, 'applyLangHints', (selector) => applyLangHints(selector));
-  try { langHints('#mainview'); } catch (_) {}
+  try { langHints(container); } catch (_) {}
 
   const hydrateVideos = getUtility(params, 'hydratePostVideos', (selector) => hydratePostVideos(selector));
-  try { hydrateVideos('#mainview'); } catch (_) {}
+  try { hydrateVideos(container); } catch (_) {}
 
   try {
     const cfg = (params.siteConfig && params.siteConfig.assetWarnings && params.siteConfig.assetWarnings.largeImage) || {};
-    warnLargeImagesInNative('#mainview', cfg, documentRef, windowRef).catch(() => {});
+    warnLargeImagesInNative(container, cfg, documentRef, windowRef).catch(() => {});
   } catch (_) {}
 
   const hydrateLinks = getUtility(params, 'hydrateInternalLinkCards', (selector, opts) => hydrateInternalLinkCards(selector, opts));
   const fetchMarkdown = getUtility(params, 'fetchMarkdown', () => Promise.resolve(''));
   const makeHref = getUtility(params, 'makeLangHref', (loc) => withLangParam(`?id=${encodeURIComponent(loc)}`));
   try {
-    hydrateLinks('#mainview', {
+    hydrateLinks(container, {
       allowedLocations: params.allowedLocations || new Set(),
       locationAliasMap: params.locationAliasMap || new Map(),
       postsByLocationTitle: params.postsByLocationTitle || {},
@@ -1191,7 +1254,7 @@ function renderStaticTabViewNative(params = {}, documentRef = defaultDocument, w
     });
   } catch (_) {}
 
-  const tocElement = documentRef.getElementById('tocview');
+  const tocElement = getTocRegion(documentRef);
   if (tocElement) {
     try { hideElementNative({ element: tocElement }, windowRef); } catch (_) { try { tocElement.style.display = 'none'; } catch (_) {} }
     try {
@@ -1270,7 +1333,7 @@ function resolveCoverSource(value = {}, siteConfig = {}) {
 function renderIndexViewNative(params = {}, documentRef = defaultDocument, windowRef = defaultWindow) {
   if (!documentRef) return false;
   const scope = params.containers && typeof params.containers === 'object' ? params.containers : {};
-  const container = scope.mainElement || params.container || documentRef.getElementById('mainview');
+  const container = scope.mainElement || params.container || getMainRegion(documentRef);
   if (!container) return false;
   const pageEntries = Array.isArray(params.pageEntries) ? params.pageEntries : [];
   const totalPages = Math.max(1, parseInt(params.totalPages || 1, 10));
@@ -1391,7 +1454,7 @@ function afterIndexRenderNative(params = {}, documentRef = defaultDocument) {
 function renderSearchResultsNative(params = {}, documentRef = defaultDocument, windowRef = defaultWindow) {
   if (!documentRef) return false;
   const scope = params.containers && typeof params.containers === 'object' ? params.containers : {};
-  const container = scope.mainElement || params.container || documentRef.getElementById('mainview');
+  const container = scope.mainElement || params.container || getMainRegion(documentRef);
   if (!container) return false;
   const entries = Array.isArray(params.entries) ? params.entries : [];
   const total = parseInt(params.total || entries.length, 10);
@@ -1643,7 +1706,7 @@ function setTrackHtml(nav, markup, documentRef = defaultDocument, windowRef = de
 function renderTabsNative(params = {}) {
   const windowRef = params.window || defaultWindow;
   const documentRef = params.document || defaultDocument;
-  const nav = params.nav || (documentRef ? documentRef.getElementById('tabsNav') : null);
+  const nav = params.nav || (documentRef ? getNavRegion(documentRef) : null);
   if (!nav) return;
   const tabs = params.tabsBySlug || {};
   const activeSlug = params.activeSlug;
@@ -1827,8 +1890,8 @@ function renderTabsNative(params = {}) {
 
 function addTabClickAnimation(tab, windowRef = defaultWindow) {
   if (!tab || !tab.classList || !tab.classList.contains('tab')) return;
-  const nav = tab.closest('#tabsNav');
-  if (nav && nav.id === 'tabsNav') {
+  const nav = tab.closest('[data-theme-region="nav"], .native-tabs, .tabs');
+  if (nav) {
     const currentActive = nav.querySelector('.tab.active');
     if (currentActive && currentActive !== tab) {
       currentActive.classList.add('deactivating');
@@ -1866,7 +1929,8 @@ function setupResponsiveTabsObserverNative(params = {}) {
   const getCurrentPostTitle = () => {
     if (!documentRef) return '';
     try {
-      const el = documentRef.querySelector('#mainview .post-meta-card .post-meta-title');
+      const main = getMainRegion(documentRef);
+      const el = main && main.querySelector('.post-meta-card .post-meta-title');
       const txt = (el && el.textContent) ? el.textContent.trim() : '';
       if (txt) return txt;
     } catch (_) {}
@@ -1915,59 +1979,66 @@ export function mount(context = {}) {
   masonryHandlersBound = false;
 
   if (!lightboxInstalled) {
-    try { installLightbox({ root: '#mainview' }); lightboxInstalled = true; } catch (_) {}
+    try { installLightbox({ rootRegion: ['main'] }); lightboxInstalled = true; } catch (_) {}
   }
 
-  const hooks = (windowRef && windowRef.__ns_themeHooks) || {};
-  hooks.getViewContainer = (params = {}) => getContainerByRole(params.role, documentRef);
-  hooks.resolveViewContainers = (params = {}) => resolveViewContainersNative(params, documentRef);
-  hooks.getScrollState = () => getScrollStateNative(documentRef, windowRef);
-  hooks.restoreScrollState = (params = {}) => restoreScrollStateNative(params, documentRef, windowRef);
-  hooks.showElement = (params = {}) => showElementNative(params, windowRef);
-  hooks.hideElement = (params = {}) => hideElementNative(params, windowRef);
-  hooks.renderSiteLinks = (params = {}) => renderSiteLinksNative(params, documentRef);
-  hooks.renderSiteIdentity = (params = {}) => renderSiteIdentityNative(params, documentRef, windowRef);
-  hooks.renderFooterNav = (params = {}) => renderFooterNavNative(params, documentRef, windowRef);
-  hooks.renderTabs = (params = {}) => renderTabsNative({ ...params, window: windowRef, document: documentRef });
-  hooks.updateTabHighlight = (nav) => updateMovingHighlight(nav, windowRef, documentRef);
-  hooks.ensureTabOverlay = (nav) => ensureHighlightOverlay(nav, documentRef);
-  hooks.setupResponsiveTabsObserver = (params = {}) => setupResponsiveTabsObserverNative({ ...params, window: windowRef, document: documentRef });
-  hooks.onTabClick = (tab) => addTabClickAnimation(tab, windowRef);
-  hooks.handleWindowResize = (params = {}) => handleWindowResizeNative(params, documentRef, windowRef);
-  hooks.updateLayoutLoadingState = (params = {}) => updateLayoutLoadingStateNative(params, documentRef);
-  hooks.renderPostTOC = (params = {}) => renderPostTOCNative(params, documentRef, windowRef);
-  hooks.renderErrorState = (params = {}) => renderErrorStateNative(params, documentRef);
-  hooks.handleViewChange = (params = {}) => handleViewChangeNative(params, documentRef, windowRef);
-  hooks.renderTagSidebar = (params = {}) => renderTagSidebarNative(params, documentRef);
-  hooks.initializeSyntaxHighlighting = (params = {}) => initializeSyntaxHighlightingNative(params);
-  hooks.updateSearchPlaceholder = (params = {}) => updateSearchPlaceholderNative(params, documentRef);
-  hooks.renderPostLoadingState = (params = {}) => renderPostLoadingStateNative(params, documentRef);
-  hooks.renderPostView = (params = {}) => renderPostViewNative(params, documentRef, windowRef);
-  hooks.renderStaticTabLoadingState = (params = {}) => renderStaticTabLoadingStateNative(params, documentRef);
-  hooks.renderStaticTabView = (params = {}) => renderStaticTabViewNative(params, documentRef, windowRef);
-  hooks.renderIndexView = (params = {}) => renderIndexViewNative(params, documentRef, windowRef);
-  hooks.afterIndexRender = (params = {}) => afterIndexRenderNative(params, documentRef);
-  hooks.renderSearchResults = (params = {}) => renderSearchResultsNative(params, documentRef, windowRef);
-  hooks.afterSearchRender = (params = {}) => afterSearchRenderNative(params, documentRef);
-  hooks.enhanceIndexLayout = (params = {}) => enhanceIndexLayoutNative(params, documentRef, windowRef);
-  hooks.decoratePostView = (params = {}) => decoratePostViewNative(params, documentRef, windowRef);
-  hooks.handleDocumentClick = (params = {}) => handleDocumentClickNative(params, documentRef, windowRef);
-  hooks.resetTOC = (params = {}) => resetTOCNative(params, documentRef, windowRef);
-  hooks.setupThemeControls = (params = {}) => setupThemeControlsNative(params);
-  hooks.resetThemeControls = (params = {}) => resetThemeControlsNative(params, documentRef);
-  hooks.reflectThemeConfig = (params = {}) => reflectThemeConfigNative(params, documentRef);
-  hooks.setupFooter = (params = {}) => setupFooterNative(params, documentRef, windowRef);
-  if (windowRef) windowRef.__ns_themeHooks = hooks;
+  const effects = {};
+  effects.getViewContainer = (params = {}) => getContainerByRole(params.role, documentRef);
+  effects.resolveViewContainers = (params = {}) => resolveViewContainersNative(params, documentRef);
+  effects.getScrollState = () => getScrollStateNative(documentRef, windowRef);
+  effects.restoreScrollState = (params = {}) => restoreScrollStateNative(params, documentRef, windowRef);
+  effects.showElement = (params = {}) => showElementNative(params, windowRef);
+  effects.hideElement = (params = {}) => hideElementNative(params, windowRef);
+  effects.renderSiteLinks = (params = {}) => renderSiteLinksNative(params, documentRef);
+  effects.renderSiteIdentity = (params = {}) => renderSiteIdentityNative(params, documentRef, windowRef);
+  effects.renderFooterNav = (params = {}) => renderFooterNavNative(params, documentRef, windowRef);
+  effects.renderTabs = (params = {}) => renderTabsNative({ ...params, window: windowRef, document: documentRef });
+  effects.updateTabHighlight = (nav) => updateMovingHighlight(nav, windowRef, documentRef);
+  effects.ensureTabOverlay = (nav) => ensureHighlightOverlay(nav, documentRef);
+  effects.setupResponsiveTabsObserver = (params = {}) => setupResponsiveTabsObserverNative({ ...params, window: windowRef, document: documentRef });
+  effects.onTabClick = (tab) => addTabClickAnimation(tab, windowRef);
+  effects.handleWindowResize = (params = {}) => handleWindowResizeNative(params, documentRef, windowRef);
+  effects.updateLayoutLoadingState = (params = {}) => updateLayoutLoadingStateNative(params, documentRef);
+  effects.renderPostTOC = (params = {}) => renderPostTOCNative(params, documentRef, windowRef);
+  effects.renderErrorState = (params = {}) => renderErrorStateNative(params, documentRef);
+  effects.handleViewChange = (params = {}) => handleViewChangeNative(params, documentRef, windowRef);
+  effects.renderTagSidebar = (params = {}) => renderTagSidebarNative(params, documentRef);
+  effects.initializeSyntaxHighlighting = (params = {}) => initializeSyntaxHighlightingNative(params);
+  effects.updateSearchPlaceholder = (params = {}) => updateSearchPlaceholderNative(params, documentRef);
+  effects.renderPostLoadingState = (params = {}) => renderPostLoadingStateNative(params, documentRef);
+  effects.renderPostView = (params = {}) => renderPostViewNative(params, documentRef, windowRef);
+  effects.renderStaticTabLoadingState = (params = {}) => renderStaticTabLoadingStateNative(params, documentRef);
+  effects.renderStaticTabView = (params = {}) => renderStaticTabViewNative(params, documentRef, windowRef);
+  effects.renderIndexView = (params = {}) => renderIndexViewNative(params, documentRef);
+  effects.afterIndexRender = (params = {}) => afterIndexRenderNative(params, documentRef);
+  effects.renderSearchResults = (params = {}) => renderSearchResultsNative(params, documentRef, windowRef);
+  effects.afterSearchRender = (params = {}) => afterSearchRenderNative(params, documentRef);
+  effects.enhanceIndexLayout = (params = {}) => enhanceIndexLayoutNative(params, documentRef, windowRef);
+  effects.decoratePostView = (params = {}) => decoratePostViewNative(params, documentRef, windowRef);
+  effects.handleDocumentClick = (params = {}) => handleDocumentClickNative(params, documentRef, windowRef);
+  effects.resetTOC = (params = {}) => resetTOCNative(params, documentRef, windowRef);
+  effects.setupThemeControls = (params = {}) => setupThemeControlsNative(params);
+  effects.resetThemeControls = (params = {}) => resetThemeControlsNative(params, documentRef);
+  effects.reflectThemeConfig = (params = {}) => reflectThemeConfigNative(params, documentRef);
+  effects.setupFooter = (params = {}) => setupFooterNative(params, documentRef, windowRef);
+
+  const views = {
+    post: effects.renderPostView,
+    posts: effects.renderIndexView,
+    search: effects.renderSearchResults,
+    tab: effects.renderStaticTabView,
+    error: effects.renderErrorState,
+    loading: (params = {}) => (
+      params.view === 'tab'
+        ? effects.renderStaticTabLoadingState(params)
+        : effects.renderPostLoadingState(params)
+    )
+  };
 
   return {
-    hooks,
-    views: {
-      post: hooks.renderPostView,
-      posts: hooks.renderIndexView,
-      search: hooks.renderSearchResults,
-      tab: hooks.renderStaticTabView
-    },
-    effects: hooks
+    views,
+    components: {},
+    effects
   };
 }
 

--- a/assets/themes/native/modules/mainview.js
+++ b/assets/themes/native/modules/mainview.js
@@ -4,17 +4,26 @@ export function mount(context = {}) {
   const content = regions.content || doc.querySelector('.content');
   if (!doc || !content) return context;
 
-  let mainview = doc.getElementById('mainview');
+  let mainview = content.querySelector('[data-theme-region="main"]') || content.querySelector('.native-mainview');
   if (!mainview) {
     mainview = doc.createElement('div');
-    mainview.className = 'box';
+    mainview.className = 'box native-mainview';
     mainview.id = 'mainview';
+    mainview.setAttribute('data-theme-region', 'main');
     content.appendChild(mainview);
   } else if (!mainview.classList.contains('box')) {
     mainview.classList.add('box');
   }
+  mainview.classList.add('native-mainview');
+  mainview.setAttribute('data-theme-region', 'main');
 
-  const updatedRegions = { ...regions, main: mainview, mainview };
-  context.regions = updatedRegions;
-  return { regions: updatedRegions };
+  if (typeof regions.register === 'function') {
+    regions.register('main', mainview);
+    regions.register('mainview', mainview);
+  } else {
+    regions.main = mainview;
+    regions.mainview = mainview;
+  }
+  context.regions = regions;
+  return { regions };
 }

--- a/assets/themes/native/modules/nav-tabs.js
+++ b/assets/themes/native/modules/nav-tabs.js
@@ -4,24 +4,38 @@ export function mount(context = {}) {
   const content = regions.content || doc.querySelector('.content');
   if (!doc || !content) return context;
 
-  let navBox = doc.getElementById('mapview');
+  let navBox = content.querySelector('[data-theme-region="navBox"]') || content.querySelector('.native-navbox');
   if (!navBox) {
     navBox = doc.createElement('div');
-    navBox.className = 'box flex-split';
+    navBox.className = 'box flex-split native-navbox';
     navBox.id = 'mapview';
+    navBox.setAttribute('data-theme-region', 'navBox');
     content.appendChild(navBox);
   }
+  navBox.classList.add('native-navbox');
+  navBox.setAttribute('data-theme-region', 'navBox');
 
-  let nav = doc.getElementById('tabsNav');
+  let nav = navBox.querySelector('[data-theme-region="nav"]') || navBox.querySelector('.native-tabs');
   if (!nav) {
     nav = doc.createElement('nav');
-    nav.className = 'tabs';
+    nav.className = 'tabs native-tabs';
     nav.id = 'tabsNav';
+    nav.setAttribute('data-theme-region', 'nav');
     nav.setAttribute('aria-label', 'Sections');
     navBox.appendChild(nav);
   }
+  nav.classList.add('native-tabs');
+  nav.setAttribute('data-theme-region', 'nav');
 
-  const updatedRegions = { ...regions, nav: nav, navBox, tabsNav: nav };
-  context.regions = updatedRegions;
-  return { regions: updatedRegions };
+  if (typeof regions.register === 'function') {
+    regions.register('nav', nav);
+    regions.register('navBox', navBox);
+    regions.register('tabsNav', nav);
+  } else {
+    regions.nav = nav;
+    regions.navBox = navBox;
+    regions.tabsNav = nav;
+  }
+  context.regions = regions;
+  return { regions };
 }

--- a/assets/themes/native/modules/search-box.js
+++ b/assets/themes/native/modules/search-box.js
@@ -4,17 +4,29 @@ export function mount(context = {}) {
   const sidebar = regions.sidebar || doc.querySelector('.sidebar');
   if (!doc || !sidebar) return context;
 
-  let searchBox = doc.getElementById('searchbox');
+  let searchBox = sidebar.querySelector('[data-theme-region="search"]') || sidebar.querySelector('.native-searchbox');
   if (!searchBox) {
     searchBox = doc.createElement('nano-search');
-    searchBox.className = 'box';
+    searchBox.className = 'box native-searchbox';
     searchBox.id = 'searchbox';
+    searchBox.setAttribute('data-theme-region', 'search');
     sidebar.appendChild(searchBox);
   } else if (!searchBox.classList.contains('box')) {
     searchBox.classList.add('box');
   }
+  searchBox.classList.add('native-searchbox');
+  searchBox.setAttribute('data-theme-region', 'search');
 
-  const updatedRegions = { ...regions, search: searchBox, searchBox, searchInput: searchBox.input || searchBox.querySelector('input[type="search"]') };
-  context.regions = updatedRegions;
-  return { regions: updatedRegions };
+  const input = searchBox.input || searchBox.querySelector('input[type="search"]');
+  if (typeof regions.register === 'function') {
+    regions.register('search', searchBox);
+    regions.register('searchBox', searchBox);
+    if (input) regions.register('searchInput', input);
+  } else {
+    regions.search = searchBox;
+    regions.searchBox = searchBox;
+    if (input) regions.searchInput = input;
+  }
+  context.regions = regions;
+  return { regions };
 }

--- a/assets/themes/native/modules/site-card.js
+++ b/assets/themes/native/modules/site-card.js
@@ -51,7 +51,11 @@ export function mount(context = {}) {
     card.appendChild(list);
   }
 
-  const updatedRegions = { ...regions, siteCard: card };
-  context.regions = updatedRegions;
-  return { regions: updatedRegions };
+  if (typeof regions.register === 'function') {
+    regions.register('siteCard', card);
+  } else {
+    regions.siteCard = card;
+  }
+  context.regions = regions;
+  return { regions };
 }

--- a/assets/themes/native/modules/tag-filter.js
+++ b/assets/themes/native/modules/tag-filter.js
@@ -4,17 +4,26 @@ export function mount(context = {}) {
   const sidebar = regions.sidebar || doc.querySelector('.sidebar');
   if (!doc || !sidebar) return context;
 
-  let tagBox = doc.getElementById('tagview');
+  let tagBox = sidebar.querySelector('[data-theme-region="tags"]') || sidebar.querySelector('.native-tagbox');
   if (!tagBox) {
     tagBox = doc.createElement('div');
-    tagBox.className = 'box';
+    tagBox.className = 'box native-tagbox';
     tagBox.id = 'tagview';
+    tagBox.setAttribute('data-theme-region', 'tags');
     sidebar.appendChild(tagBox);
   } else if (!tagBox.classList.contains('box')) {
     tagBox.classList.add('box');
   }
+  tagBox.classList.add('native-tagbox');
+  tagBox.setAttribute('data-theme-region', 'tags');
 
-  const updatedRegions = { ...regions, tags: tagBox, tagBox };
-  context.regions = updatedRegions;
-  return { regions: updatedRegions };
+  if (typeof regions.register === 'function') {
+    regions.register('tags', tagBox);
+    regions.register('tagBox', tagBox);
+  } else {
+    regions.tags = tagBox;
+    regions.tagBox = tagBox;
+  }
+  context.regions = regions;
+  return { regions };
 }

--- a/assets/themes/native/modules/toc.js
+++ b/assets/themes/native/modules/toc.js
@@ -4,17 +4,26 @@ export function mount(context = {}) {
   const sidebar = regions.sidebar || doc.querySelector('.sidebar');
   if (!doc || !sidebar) return context;
 
-  let toc = doc.getElementById('tocview');
+  let toc = sidebar.querySelector('[data-theme-region="toc"]') || sidebar.querySelector('.native-toc');
   if (!toc) {
     toc = doc.createElement('nano-toc');
-    toc.className = 'box';
+    toc.className = 'box native-toc';
     toc.id = 'tocview';
+    toc.setAttribute('data-theme-region', 'toc');
     sidebar.appendChild(toc);
   } else if (!toc.classList.contains('box')) {
     toc.classList.add('box');
   }
+  toc.classList.add('native-toc');
+  toc.setAttribute('data-theme-region', 'toc');
 
-  const updatedRegions = { ...regions, toc, tocBox: toc };
-  context.regions = updatedRegions;
-  return { regions: updatedRegions };
+  if (typeof regions.register === 'function') {
+    regions.register('toc', toc);
+    regions.register('tocBox', toc);
+  } else {
+    regions.toc = toc;
+    regions.tocBox = toc;
+  }
+  context.regions = regions;
+  return { regions };
 }

--- a/assets/themes/native/theme.json
+++ b/assets/themes/native/theme.json
@@ -9,71 +9,60 @@
   "modules": [
     "modules/layout.js",
     "modules/nav-tabs.js",
-    "modules/interactions.js",
     "modules/mainview.js",
     "modules/search-box.js",
     "modules/site-card.js",
     "modules/tag-filter.js",
     "modules/toc.js",
-    "modules/footer.js"
+    "modules/footer.js",
+    "modules/interactions.js"
   ],
   "views": {
     "post": {
-      "hook": "renderPostView"
+      "module": "modules/interactions.js",
+      "handler": "post"
     },
     "posts": {
-      "hook": "renderIndexView"
+      "module": "modules/interactions.js",
+      "handler": "posts"
     },
     "search": {
-      "hook": "renderSearchResults"
+      "module": "modules/interactions.js",
+      "handler": "search"
     },
     "tab": {
-      "hook": "renderStaticTabView"
+      "module": "modules/interactions.js",
+      "handler": "tab"
     },
     "error": {
-      "hook": "renderErrorState"
+      "module": "modules/interactions.js",
+      "handler": "error"
     },
     "loading": {
-      "hooks": [
-        "renderPostLoadingState",
-        "renderStaticTabLoadingState"
-      ]
+      "module": "modules/interactions.js",
+      "handler": "loading"
     }
   },
   "regions": {
     "main": {
-      "required": true,
-      "aliases": [
-        "mainview"
-      ]
+      "required": true
     },
-    "toc": {
-      "aliases": [
-        "tocBox",
-        "tocview"
-      ]
-    },
-    "search": {
-      "aliases": [
-        "searchBox",
-        "searchInput"
-      ]
-    },
-    "nav": {
-      "aliases": [
-        "navBox",
-        "tabsNav"
-      ]
-    },
-    "tags": {
-      "aliases": [
-        "tagBox",
-        "tagview"
-      ]
-    },
+    "toc": {},
+    "search": {},
+    "nav": {},
+    "tags": {},
     "footer": {
       "required": true
-    }
+    },
+    "container": {},
+    "content": {},
+    "footerNav": {},
+    "navBox": {},
+    "searchBox": {},
+    "sidebar": {},
+    "siteCard": {},
+    "tagBox": {},
+    "tocBox": {}
   },
   "components": [
     "nano-search",
@@ -97,95 +86,5 @@
       "assets",
       "links"
     ]
-  },
-  "contract": {
-    "version": 1,
-    "regions": [
-      "main",
-      "container",
-      "content",
-      "toc",
-      "search",
-      "nav",
-      "tags",
-      "footer",
-      "footerNav",
-      "mainview",
-      "navBox",
-      "searchBox",
-      "searchInput",
-      "sidebar",
-      "siteCard",
-      "tabsNav",
-      "tagBox",
-      "tocBox"
-    ],
-    "domIds": [
-      "mainview",
-      "searchInput",
-      "tabsNav",
-      "tagview",
-      "tocview"
-    ],
-    "hooks": [
-      "afterIndexRender",
-      "afterSearchRender",
-      "decoratePostView",
-      "ensureTabOverlay",
-      "enhanceIndexLayout",
-      "getScrollState",
-      "getViewContainer",
-      "handleDocumentClick",
-      "handleViewChange",
-      "handleWindowResize",
-      "hideElement",
-      "initializeSyntaxHighlighting",
-      "onTabClick",
-      "reflectThemeConfig",
-      "renderErrorState",
-      "renderFooterNav",
-      "renderIndexView",
-      "renderPostLoadingState",
-      "renderPostTOC",
-      "renderPostView",
-      "renderSearchResults",
-      "renderSiteIdentity",
-      "renderSiteLinks",
-      "renderStaticTabLoadingState",
-      "renderStaticTabView",
-      "renderTagSidebar",
-      "renderTabs",
-      "resetThemeControls",
-      "resetTOC",
-      "resolveViewContainers",
-      "restoreScrollState",
-      "setupFooter",
-      "setupResponsiveTabsObserver",
-      "setupThemeControls",
-      "showElement",
-      "updateSearchPlaceholder",
-      "updateTabHighlight",
-      "updateLayoutLoadingState"
-    ],
-    "views": [
-      "post",
-      "posts",
-      "search",
-      "tab"
-    ],
-    "content": {
-      "markdown": "html",
-      "toc": "html",
-      "shapes": [
-        "rawMarkdown",
-        "html",
-        "blocks",
-        "tocTree",
-        "headings",
-        "metadata",
-        "assets",
-        "links"
-      ]
-    }
   }
 }

--- a/assets/themes/solstice/modules/interactions.js
+++ b/assets/themes/solstice/modules/interactions.js
@@ -59,7 +59,17 @@ function getRegion(name, documentRef = defaultDocument) {
 }
 
 function getMainRegion(documentRef = defaultDocument) {
-  return getRegion('main', documentRef) || (documentRef && documentRef.querySelector && documentRef.querySelector('.solstice-mainview')) || null;
+  if (activeRegions && activeRegions.mainview && activeRegions.mainview.nodeType === 1) return activeRegions.mainview;
+  if (documentRef && documentRef.querySelector) {
+    const explicit = documentRef.querySelector('.solstice-mainview');
+    if (explicit) return explicit;
+  }
+  const region = getRegion('main', documentRef);
+  if (!region) return null;
+  try {
+    if (region.matches && region.matches('.solstice-mainview')) return region;
+  } catch (_) {}
+  return null;
 }
 
 function getTocRegion(documentRef = defaultDocument) {

--- a/assets/themes/solstice/modules/interactions.js
+++ b/assets/themes/solstice/modules/interactions.js
@@ -31,9 +31,56 @@ const CLASS_HIDDEN = 'is-hidden';
 
 let themeI18n = null;
 let currentSiteConfig = null;
+let activeRegions = null;
 
 function setThemeI18n(context = {}) {
   themeI18n = context && context.i18n && typeof context.i18n === 'object' ? context.i18n : null;
+  activeRegions = context && context.regions && typeof context.regions === 'object' ? context.regions : null;
+}
+
+function getRegion(name, documentRef = defaultDocument) {
+  const key = String(name || '').trim();
+  if (!key) return null;
+  try {
+    if (activeRegions && typeof activeRegions.get === 'function') {
+      const region = activeRegions.get(key);
+      if (region) return region;
+    }
+  } catch (_) {}
+  try {
+    if (activeRegions && activeRegions[key]) return activeRegions[key];
+  } catch (_) {}
+  if (!documentRef || typeof documentRef.querySelector !== 'function') return null;
+  try {
+    return documentRef.querySelector(`[data-theme-region="${key}"]`);
+  } catch (_) {
+    return null;
+  }
+}
+
+function getMainRegion(documentRef = defaultDocument) {
+  return getRegion('main', documentRef) || (documentRef && documentRef.querySelector && documentRef.querySelector('.solstice-mainview')) || null;
+}
+
+function getTocRegion(documentRef = defaultDocument) {
+  return getRegion('toc', documentRef) || (documentRef && documentRef.querySelector && documentRef.querySelector('.solstice-toc')) || null;
+}
+
+function getNavRegion(documentRef = defaultDocument) {
+  return getRegion('nav', documentRef) || (documentRef && documentRef.querySelector && documentRef.querySelector('.solstice-nav')) || null;
+}
+
+function getTagsRegion(documentRef = defaultDocument) {
+  return getRegion('tags', documentRef) || (documentRef && documentRef.querySelector && documentRef.querySelector('.solstice-tagband')) || null;
+}
+
+function getSearchRegion(documentRef = defaultDocument) {
+  return getRegion('search', documentRef) || (documentRef && documentRef.querySelector && documentRef.querySelector('nano-search.solstice-footer__search, nano-search')) || null;
+}
+
+function getSearchInput(documentRef = defaultDocument) {
+  const search = getSearchRegion(documentRef);
+  return (search && search.input) || (search && search.querySelector && search.querySelector('input[type="search"]')) || null;
 }
 
 function getCurrentLang() {
@@ -316,15 +363,15 @@ function getRoleElement(role, documentRef = defaultDocument) {
   if (!documentRef) return null;
   switch (role) {
     case 'main':
-      return documentRef.getElementById('mainview');
+      return getMainRegion(documentRef);
     case 'toc':
-      return documentRef.getElementById('tocview');
+      return getTocRegion(documentRef);
     case 'sidebar':
-      return documentRef.getElementById('tagview');
+      return getTagsRegion(documentRef);
     case 'content':
-      return documentRef.querySelector('.solstice-main');
+      return getRegion('content', documentRef) || documentRef.querySelector('.solstice-main');
     case 'container':
-      return documentRef.querySelector('.solstice-shell');
+      return getRegion('container', documentRef) || documentRef.querySelector('.solstice-shell');
     default:
       return null;
   }
@@ -578,7 +625,7 @@ function updateSearchPlaceholder(documentRef = defaultDocument) {
     search.setPlaceholder(t('sidebar.searchPlaceholder'));
     return;
   }
-  const input = documentRef ? documentRef.getElementById('searchInput') : null;
+  const input = documentRef ? getSearchInput(documentRef) : null;
   if (!input) return;
   input.setAttribute('placeholder', t('sidebar.searchPlaceholder'));
 }
@@ -716,7 +763,7 @@ function showToc(tocEl, tocHtml, articleTitle) {
     tocEl.renderToc({
       articleTitle: articleTitle || t('ui.tableOfContents'),
       tocHtml,
-      contentSelector: '#mainview'
+      contentRoot: getMainRegion(tocEl.ownerDocument || defaultDocument)
     });
   } else {
     tocEl.innerHTML = `<div class="solstice-toc__inner"><div class="solstice-toc__title">${escapeHtml(articleTitle || t('ui.tableOfContents'))}</div>${tocHtml}</div>`;
@@ -819,7 +866,7 @@ function mountHooks(documentRef = defaultDocument, windowRef = defaultWindow) {
     const search = documentRef.querySelector('nano-search');
     const value = view === 'search' ? (getQueryVariable('q') || '') : '';
     if (search) search.value = value;
-    const input = search && search.input ? search.input : documentRef.getElementById('searchInput');
+    const input = search && search.input ? search.input : getSearchInput(documentRef);
     if (input) input.value = value;
   };
 
@@ -841,7 +888,7 @@ function mountHooks(documentRef = defaultDocument, windowRef = defaultWindow) {
   };
 
   hooks.renderTabs = ({ tabsBySlug, activeSlug, getHomeSlug, postsEnabled }) => {
-    const nav = documentRef.getElementById('tabsNav');
+    const nav = getNavRegion(documentRef);
     if (!nav) return false;
     renderNavLinks(nav, tabsBySlug, activeSlug, postsEnabled, getHomeSlug);
     return true;
@@ -1093,9 +1140,6 @@ function mountHooks(documentRef = defaultDocument, windowRef = defaultWindow) {
     return true;
   };
 
-  if (windowRef) {
-    windowRef.__ns_themeHooks = Object.assign({}, windowRef.__ns_themeHooks || {}, hooks);
-  }
   return hooks;
 }
 
@@ -1103,19 +1147,26 @@ export function mount(context = {}) {
   setThemeI18n(context);
   const doc = context.document || defaultDocument;
   const win = (context.document && context.document.defaultView) || defaultWindow;
-  const hooks = mountHooks(doc, win);
+  const effects = mountHooks(doc, win);
   updateSearchPlaceholder(doc);
   setupToolsPanel(doc, win);
   setupDynamicBackground(doc, win);
+  const views = {
+    post: effects.renderPostView,
+    posts: effects.renderIndexView,
+    search: effects.renderSearchResults,
+    tab: effects.renderStaticTabView,
+    error: effects.renderErrorState,
+    loading: (params = {}) => (
+      params.view === 'tab'
+        ? effects.renderStaticTabLoadingState(params)
+        : effects.renderPostLoadingState(params)
+    )
+  };
   return {
-    hooks,
-    views: {
-      post: hooks.renderPostView,
-      posts: hooks.renderIndexView,
-      search: hooks.renderSearchResults,
-      tab: hooks.renderStaticTabView
-    },
-    effects: hooks
+    views,
+    components: {},
+    effects
   };
 }
 

--- a/assets/themes/solstice/modules/layout.js
+++ b/assets/themes/solstice/modules/layout.js
@@ -34,7 +34,7 @@ export function mount(context = {}) {
           <div class="solstice-brand__title" data-site-title></div>
           <div class="solstice-brand__subtitle" data-site-subtitle></div>
         </a>
-        <nav id="${NAV_ID}" class="solstice-nav" aria-label="Primary navigation"></nav>
+        <nav id="${NAV_ID}" class="solstice-nav" data-theme-region="nav" aria-label="Primary navigation"></nav>
       </div>`;
     return el;
   });
@@ -46,22 +46,26 @@ export function mount(context = {}) {
     return el;
   });
 
-  const mainview = ensureElement(main, `#${MAINVIEW_ID}`, () => {
+  const mainview = ensureElement(main, '[data-theme-region="main"], .solstice-mainview', () => {
     const el = doc.createElement('section');
     el.id = MAINVIEW_ID;
     el.className = 'solstice-mainview';
+    el.setAttribute('data-theme-region', 'main');
     el.setAttribute('tabindex', '-1');
     return el;
   });
+  mainview.setAttribute('data-theme-region', 'main');
 
-  const tocview = ensureElement(main, `#${TOCVIEW_ID}`, () => {
+  const tocview = ensureElement(main, '[data-theme-region="toc"], .solstice-toc', () => {
     const el = doc.createElement('nano-toc');
     el.id = TOCVIEW_ID;
     el.className = 'solstice-toc';
+    el.setAttribute('data-theme-region', 'toc');
     el.setAttribute('aria-label', 'Table of contents');
     el.hidden = true;
     return el;
   });
+  tocview.setAttribute('data-theme-region', 'toc');
   if (tocview.tagName && tocview.tagName.toLowerCase() === 'nano-toc') {
     tocview.setAttribute('inner-class', 'solstice-toc__inner');
     tocview.setAttribute('title-class', 'solstice-toc__title');
@@ -104,13 +108,14 @@ export function mount(context = {}) {
     footerSearch.removeAttribute('variant');
   }
 
-  let tagBand = doc.getElementById(TAGVIEW_ID);
+  let tagBand = container.querySelector('[data-theme-region="tags"], .solstice-tagband');
   if (!tagBand) {
     tagBand = doc.createElement('section');
     tagBand.id = TAGVIEW_ID;
   }
 
   tagBand.className = 'solstice-tagband solstice-footer__tagband';
+  tagBand.setAttribute('data-theme-region', 'tags');
   tagBand.setAttribute('aria-label', 'Tag filters');
 
   if (tagBand.parentElement !== container || tagBand.nextElementSibling !== footer) {
@@ -124,7 +129,7 @@ export function mount(context = {}) {
     main,
     content: main,
     mainview,
-    nav: header.querySelector(`#${NAV_ID}`),
+    nav: header.querySelector('[data-theme-region="nav"], .solstice-nav'),
     search: footerSearch,
     searchInput: footerSearch?.input || footer.querySelector('input[type="search"]'),
     toc: tocview,

--- a/assets/themes/solstice/theme.json
+++ b/assets/themes/solstice/theme.json
@@ -12,58 +12,47 @@
   ],
   "views": {
     "post": {
-      "hook": "renderPostView"
+      "module": "modules/interactions.js",
+      "handler": "post"
     },
     "posts": {
-      "hook": "renderIndexView"
+      "module": "modules/interactions.js",
+      "handler": "posts"
     },
     "search": {
-      "hook": "renderSearchResults"
+      "module": "modules/interactions.js",
+      "handler": "search"
     },
     "tab": {
-      "hook": "renderStaticTabView"
+      "module": "modules/interactions.js",
+      "handler": "tab"
     },
     "error": {
-      "hook": "renderErrorState"
+      "module": "modules/interactions.js",
+      "handler": "error"
     },
     "loading": {
-      "hooks": [
-        "renderPostLoadingState",
-        "renderStaticTabLoadingState"
-      ]
+      "module": "modules/interactions.js",
+      "handler": "loading"
     }
   },
   "regions": {
     "main": {
-      "required": true,
-      "aliases": [
-        "mainview"
-      ]
+      "required": true
     },
-    "toc": {
-      "aliases": [
-        "tocview"
-      ]
-    },
-    "search": {
-      "aliases": [
-        "searchInput"
-      ]
-    },
-    "nav": {
-      "aliases": [
-        "tabsNav"
-      ]
-    },
-    "tags": {
-      "aliases": [
-        "tagBand",
-        "tagview"
-      ]
-    },
+    "toc": {},
+    "search": {},
+    "nav": {},
+    "tags": {},
     "footer": {
       "required": true
-    }
+    },
+    "container": {},
+    "content": {},
+    "footerNav": {},
+    "header": {},
+    "tagBand": {},
+    "toolsPanel": {}
   },
   "components": [
     "nano-search",
@@ -87,87 +76,5 @@
       "assets",
       "links"
     ]
-  },
-  "contract": {
-    "version": 1,
-    "regions": [
-      "container",
-      "content",
-      "footer",
-      "footerNav",
-      "header",
-      "nav",
-      "search",
-      "tags",
-      "main",
-      "mainview",
-      "tagBand",
-      "toc",
-      "toolsPanel"
-    ],
-    "domIds": [
-      "mainview",
-      "searchInput",
-      "tabsNav",
-      "tagview",
-      "tocview"
-    ],
-    "hooks": [
-      "afterIndexRender",
-      "afterSearchRender",
-      "decoratePostView",
-      "enhanceIndexLayout",
-      "getScrollState",
-      "getViewContainer",
-      "handleDocumentClick",
-      "handleRouteScroll",
-      "handleViewChange",
-      "handleWindowResize",
-      "hideElement",
-      "reflectThemeConfig",
-      "renderErrorState",
-      "renderFooterNav",
-      "renderIndexView",
-      "renderPostLoadingState",
-      "renderPostTOC",
-      "renderPostView",
-      "renderSearchResults",
-      "renderSiteIdentity",
-      "renderSiteLinks",
-      "renderStaticTabLoadingState",
-      "renderStaticTabView",
-      "renderTagSidebar",
-      "renderTabs",
-      "resetThemeControls",
-      "resolveViewContainers",
-      "restoreScrollState",
-      "scrollToHash",
-      "setupFooter",
-      "setupResponsiveTabsObserver",
-      "setupThemeControls",
-      "showElement",
-      "updateSearchPlaceholder",
-      "updateLayoutLoadingState"
-    ],
-    "views": [
-      "post",
-      "posts",
-      "search",
-      "tab"
-    ],
-    "content": {
-      "markdown": "html",
-      "toc": "html",
-      "shapes": [
-        "rawMarkdown",
-        "html",
-        "blocks",
-        "tocTree",
-        "headings",
-        "metadata",
-        "assets",
-        "links"
-      ]
-    }
   }
 }

--- a/docs/theme-contract.md
+++ b/docs/theme-contract.md
@@ -62,10 +62,10 @@ effects.
 - `configSchema`: JSON-schema fragment for theme-specific configuration.
 - `content.shapes`: Content model fields consumed by the theme.
 
-Compatibility themes may still include a legacy `contract` object as an adapter
-map for `window.__ns_themeHooks` and old DOM IDs. Pure contract themes should
-omit `contract`, avoid fixed legacy IDs, and target the top-level manifest fields
-plus the `ctx` object.
+Legacy third-party themes may still include a `contract` object as an adapter
+map for old hook and DOM-ID conventions. Built-in themes are pure contract
+themes: they omit `contract`, avoid fixed legacy IDs, and target the top-level
+manifest fields plus the `ctx` object.
 
 ## Theme API
 
@@ -90,9 +90,9 @@ export default {
 
 The loader merges explicit API exports first. A `mount(ctx)` function may also
 return `{ views, components, effects }` to publish handlers created from
-runtime-local state. Compatibility themes may return `hooks`; the loader exposes
-them through the adapter so existing themes keep working while new themes can
-implement `views` and `effects` directly.
+runtime-local state. Built-in themes implement `views` and `effects` directly.
+Legacy third-party themes may still return adapter hooks during the compatibility
+period, but new theme code should not depend on that path.
 
 ## Runtime Context
 
@@ -124,11 +124,9 @@ ctx.regions.register('main', mainElement);
 ctx.regions.registerMany({ toc: tocElement, search: searchElement });
 ```
 
-Compatibility themes may still expose legacy IDs such as `mainview`, `tocview`,
-`searchInput`, `tabsNav`, and `tagview`. These IDs are adapter details and are
-listed in `contract.domIds` only so the verifier and dev warnings can keep them
-visible. Pure themes should register semantic regions and communicate through
-the registry instead.
+Legacy third-party themes may still expose old DOM IDs as adapter details during
+the compatibility period. Built-in and new themes should register semantic
+regions and communicate through the registry instead.
 
 ## Content Model
 

--- a/scripts/test-theme-contracts.js
+++ b/scripts/test-theme-contracts.js
@@ -13,7 +13,7 @@ const REQUIRED_CONTENT_SHAPES = ['rawMarkdown', 'html', 'blocks', 'tocTree', 'he
 const REQUIRED_COMPONENTS = ['nano-search', 'nano-toc', 'nano-post-card'];
 const REQUIRED_STYLE_TOKENS = ['--ns-color-text', '--ns-color-surface', '--ns-font-body', '--ns-radius-card', '--ns-space-page'];
 const LEGACY_IDS = ['mainview', 'tocview', 'searchInput', 'tabsNav', 'tagview'];
-const PURE_THEME_NAMES = new Set(['cartograph']);
+const PURE_THEME_NAMES = new Set(['arcus', 'cartograph', 'native', 'solstice']);
 const CORE_RUNTIME_FILES = [
   'assets/main.js',
   'assets/js/dom-utils.js',


### PR DESCRIPTION
## Summary

- migrate the built-in Native, Arcus, and Solstice theme manifests to the pure theme API used by Cartograph
- remove built-in theme dependence on legacy `contract` declarations and `window.__ns_themeHooks`
- route built-in theme behavior through explicit `views`, `effects`, `components`, and registered theme regions
- update pure-theme validation and documentation so legacy compatibility is described as external/deprecated only

## Root Cause / Notes

Native was especially sensitive to the migration because its `interactions.js` module mounted before later DOM-region modules. That let it retain an incomplete region registry, so the posts view could resolve `.content` as the main region and wipe the top navigation. The fix keeps Native modules registering into the same region registry, mounts interactions after the DOM regions, and prevents `.content` from being accepted as the Native main region.

## Validation

- `node --experimental-default-type=module scripts/test-theme-contracts.js`
- `node scripts/test-ui-components.js`
- `node --check` on touched Native, Arcus, and Solstice theme modules
- `git diff --check --cached`
- HTTP smoke for `index.html` and all built-in `theme.json` / `theme.css` assets
- Browser Use verification across Native, Solstice, Arcus, and Cartograph, including theme switching, navigation, search, tag filters, article links, TOC/permalink anchors, and back-to-top where present
