### PR TITLE
[codex] Support IPv6 preview port probes

### DIFF
--- a/scripts/preview-local.sh
+++ b/scripts/preview-local.sh
@@ -63,6 +63,15 @@ require_valid_port() {
   fi
 }
 
+preview_url_host() {
+  local value="$1"
+  if [[ "$value" == *:* && "$value" != \[*\] ]]; then
+    printf '[%s]\n' "$value"
+  else
+    printf '%s\n' "$value"
+  fi
+}
+
 port_is_free() {
   local port="$1"
   python3 - "$host" "$port" <<'PY'
@@ -72,10 +81,18 @@ import sys
 host = sys.argv[1]
 port = int(sys.argv[2])
 
-with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+infos = socket.getaddrinfo(
+    host,
+    port,
+    type=socket.SOCK_STREAM,
+    flags=socket.AI_PASSIVE,
+)
+family, _, _, _, sockaddr = next(iter(infos))
+
+with socket.socket(family, socket.SOCK_STREAM) as sock:
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     try:
-        sock.bind((host, port))
+        sock.bind(sockaddr)
     except OSError:
         sys.exit(1)
 PY
@@ -132,7 +149,7 @@ mkdir -p "$(dirname "$port_file")"
 printf '%s\n' "$selected_port" > "$port_file"
 
 printf 'Serving %s\n' "$repo_root"
-printf 'Preview URL: http://%s:%s/\n' "$host" "$selected_port"
+printf 'Preview URL: http://%s:%s/\n' "$(preview_url_host "$host")" "$selected_port"
 printf 'Port saved to %s\n' "$port_file"
 
 exec python3 -m http.server "$selected_port" --bind "$host"


### PR DESCRIPTION
## Summary

Addresses the review finding from PR #328 about IPv6 host overrides in `scripts/preview-local.sh`.

- Updates the free-port probe to use `socket.getaddrinfo(..., AI_PASSIVE)` so it binds with the same address family selected by `python3 -m http.server`.
- Formats preview URLs with brackets for IPv6 hosts, for example `http://[::1]:8000/`.

## Why

The script documents `NANOSITE_PREVIEW_HOST` / `PREVIEW_HOST`, but the probe previously hardcoded `socket.AF_INET`. That made IPv6 hosts such as `::1` fail before the server could start.

## Validation

- `bash -n scripts/preview-local.sh`
- IPv4 collision test: occupied one `127.0.0.1` port, verified the script skipped to the next port and served the homepage over HTTP 200.
- IPv6 collision test: occupied one `::1` port, verified the script skipped to the next port, printed a bracketed IPv6 URL, and served the homepage over HTTP 200.