### PR TITLE
Infer starter repository from Pages URL

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -312,6 +312,90 @@ function applyComposerEffectiveSiteConfig(siteConfig) {
   return effective;
 }
 
+function inferRepoConfigFromGitHubPagesUrl(locationLike) {
+  let protocol = '';
+  let hostname = '';
+  let pathname = '';
+
+  try {
+    if (typeof locationLike === 'string') {
+      const url = new URL(locationLike);
+      protocol = url.protocol;
+      hostname = url.hostname;
+      pathname = url.pathname;
+    } else if (locationLike && typeof locationLike === 'object') {
+      if (locationLike.href) {
+        const url = new URL(String(locationLike.href));
+        protocol = url.protocol;
+        hostname = url.hostname;
+        pathname = url.pathname;
+      } else {
+        protocol = String(locationLike.protocol || '');
+        hostname = String(locationLike.hostname || '');
+        pathname = String(locationLike.pathname || '');
+      }
+    }
+  } catch (_) {
+    return null;
+  }
+
+  if (protocol !== 'https:') return null;
+  const host = String(hostname || '').trim().toLowerCase();
+  const suffix = '.github.io';
+  if (!host.endsWith(suffix)) return null;
+  const owner = host.slice(0, -suffix.length);
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/.test(owner)) return null;
+
+  const rawSegments = String(pathname || '').split('/').filter(Boolean);
+  const firstSegment = rawSegments[0] || '';
+  let name = '';
+  if (!firstSegment || firstSegment === 'index.html' || firstSegment === 'index_editor.html') {
+    name = `${owner}.github.io`;
+  } else {
+    try {
+      name = decodeURIComponent(firstSegment);
+    } catch (_) {
+      return null;
+    }
+  }
+  if (!/^[A-Za-z0-9_.-]+$/.test(name)) return null;
+
+  return { owner, name, branch: 'main' };
+}
+
+function isPlaceholderRepoConfig(repo) {
+  const source = repo && typeof repo === 'object' ? repo : {};
+  const owner = String(source.owner || '').trim();
+  const name = String(source.name || '').trim();
+  const ownerIsPlaceholder = owner === '' || owner === 'OWNER';
+  const nameIsPlaceholder = name === '' || name === 'REPOSITORY';
+  return ownerIsPlaceholder && nameIsPlaceholder;
+}
+
+function applyInferredRepoConfig(site, inferred) {
+  if (!site || typeof site !== 'object') return false;
+  if (!inferred || typeof inferred !== 'object') return false;
+  const owner = String(inferred.owner || '').trim();
+  const name = String(inferred.name || '').trim();
+  const branch = String(inferred.branch || 'main').trim() || 'main';
+  if (!owner || !name) return false;
+
+  const repo = site.repo && typeof site.repo === 'object' ? site.repo : {};
+  if (!isPlaceholderRepoConfig(repo)) return false;
+
+  const previousOwner = String(repo.owner || '').trim();
+  const previousName = String(repo.name || '').trim();
+  const previousBranch = String(repo.branch || '').trim();
+  site.repo = repo;
+  repo.owner = owner;
+  repo.name = name;
+  if (!previousBranch) repo.branch = branch;
+
+  return previousOwner !== String(repo.owner || '').trim()
+    || previousName !== String(repo.name || '').trim()
+    || previousBranch !== String(repo.branch || '').trim();
+}
+
 async function fetchComposerTrackedSiteConfig() {
   const tracked = await fetchTrackedSiteConfig();
   composerSiteLocalOverride = await fetchSiteLocalOverride();
@@ -13619,6 +13703,15 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   activeComposerState = state;
   const restoredDrafts = loadDraftSnapshotsIntoState(state);
+  let inferredSiteRepoApplied = false;
+  try {
+    inferredSiteRepoApplied = applyInferredRepoConfig(
+      state.site,
+      inferRepoConfigFromGitHubPagesUrl(window.location)
+    );
+  } catch (_) {
+    inferredSiteRepoApplied = false;
+  }
   applyComposerEffectiveSiteConfig(state.site);
   updateMarkdownPushButton(getActiveDynamicTab());
 
@@ -13637,7 +13730,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   notifyComposerChange('index', { skipAutoSave: true });
   notifyComposerChange('tabs', { skipAutoSave: true });
-  notifyComposerChange('site', { skipAutoSave: true });
+  notifyComposerChange('site', inferredSiteRepoApplied ? {} : { skipAutoSave: true });
 
   refreshEditorContentTree();
   const restoredEditorState = restoreDynamicEditorState();

--- a/index_editor.html
+++ b/index_editor.html
@@ -2408,7 +2408,7 @@
   </script>
   <script type="module" src="assets/js/editor-boot.js?v=theme-manager-20260507"></script>
   <script type="module" src="assets/js/editor-main.js?v=theme-manager-20260507"></script>
-  <script type="module" src="assets/js/composer.js?v=theme-manager-20260507"></script>
+  <script type="module" src="assets/js/composer.js?v=repo-autofill-20260507"></script>
   <!-- Back to top button -->
   <button id="backToTop" class="back-to-top" aria-label="返回顶部" title="返回顶部" type="button" hidden>
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -52,6 +52,34 @@ function extractFunctionBody(text, name) {
   assert.fail(`${name} body should be balanced`);
 }
 
+function extractFunctionDeclaration(text, name) {
+  const start = text.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `${name} should exist`);
+  const open = text.indexOf('{', start);
+  assert.notEqual(open, -1, `${name} should have a body`);
+  let depth = 0;
+  for (let index = open; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === '{') depth += 1;
+    if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return text.slice(start, index + 1);
+    }
+  }
+  assert.fail(`${name} declaration should be balanced`);
+}
+
+function loadRepoInferenceHelpers() {
+  const helpers = [
+    extractFunctionDeclaration(source, 'inferRepoConfigFromGitHubPagesUrl'),
+    extractFunctionDeclaration(source, 'isPlaceholderRepoConfig'),
+    extractFunctionDeclaration(source, 'applyInferredRepoConfig')
+  ].join('\n');
+  return Function(`${helpers}\nreturn { inferRepoConfigFromGitHubPagesUrl, isPlaceholderRepoConfig, applyInferredRepoConfig };`)();
+}
+
+const repoInference = loadRepoInferenceHelpers();
+
 assert.match(
   editorSource,
   /\.view-toggle \.vt-btn \.vt-dirty-badge\{position:absolute;top:-\.45rem;right:0;min-width:1\.15rem;height:1\.15rem[\s\S]*transform:translateX\(50%\) scale\(\.72\)/,
@@ -62,6 +90,84 @@ assert.doesNotMatch(
   editorSource,
   /\.view-toggle \.vt-btn\.has-draft::before/,
   'composer file switch dirty indicators should not render as inline orange dots'
+);
+
+assert.match(
+  editorSource,
+  /assets\/js\/composer\.js\?v=repo-autofill-20260507/,
+  'editor HTML should cache-bust composer.js when repository autofill changes'
+);
+
+assert.deepEqual(
+  repoInference.inferRepoConfigFromGitHubPagesUrl('https://deemoe404.github.io/test1/index_editor.html'),
+  { owner: 'deemoe404', name: 'test1', branch: 'main' },
+  'GitHub project Pages editor URLs should infer owner and repository'
+);
+
+assert.deepEqual(
+  repoInference.inferRepoConfigFromGitHubPagesUrl('https://deemoe404.github.io/test1/'),
+  { owner: 'deemoe404', name: 'test1', branch: 'main' },
+  'GitHub project Pages root URLs should infer owner and repository'
+);
+
+assert.deepEqual(
+  repoInference.inferRepoConfigFromGitHubPagesUrl('https://deemoe404.github.io/index_editor.html'),
+  { owner: 'deemoe404', name: 'deemoe404.github.io', branch: 'main' },
+  'GitHub user Pages editor URLs should infer the owner.github.io repository'
+);
+
+assert.equal(
+  repoInference.inferRepoConfigFromGitHubPagesUrl('http://localhost:8000/index_editor.html'),
+  null,
+  'localhost editor URLs should not infer a repository'
+);
+
+assert.equal(
+  repoInference.inferRepoConfigFromGitHubPagesUrl('https://example.com/index_editor.html'),
+  null,
+  'custom-domain editor URLs should not infer a repository'
+);
+
+{
+  const site = { repo: { owner: 'OWNER', name: 'REPOSITORY', branch: '' } };
+  assert.equal(
+    repoInference.applyInferredRepoConfig(site, { owner: 'deemoe404', name: 'test1', branch: 'main' }),
+    true,
+    'placeholder starter repositories should accept inferred repo config'
+  );
+  assert.deepEqual(site.repo, { owner: 'deemoe404', name: 'test1', branch: 'main' });
+}
+
+{
+  const site = { repo: { owner: '', name: '', branch: 'docs' } };
+  assert.equal(
+    repoInference.applyInferredRepoConfig(site, { owner: 'deemoe404', name: 'test1', branch: 'main' }),
+    true,
+    'empty starter repositories should accept inferred owner and name'
+  );
+  assert.deepEqual(site.repo, { owner: 'deemoe404', name: 'test1', branch: 'docs' });
+}
+
+{
+  const site = { repo: { owner: 'EkilyHQ', name: 'Press', branch: 'main' } };
+  assert.equal(
+    repoInference.applyInferredRepoConfig(site, { owner: 'deemoe404', name: 'test1', branch: 'main' }),
+    false,
+    'real configured repositories should not be overwritten'
+  );
+  assert.deepEqual(site.repo, { owner: 'EkilyHQ', name: 'Press', branch: 'main' });
+}
+
+assert.match(
+  source,
+  /const restoredDrafts = loadDraftSnapshotsIntoState\(state\);[\s\S]*applyInferredRepoConfig\([\s\S]*inferRepoConfigFromGitHubPagesUrl\(window\.location\)[\s\S]*applyComposerEffectiveSiteConfig\(state\.site\);[\s\S]*buildSiteUI\(\$\(\'#composerSite\'\), state\);/,
+  'composer should infer starter repository config before rendering Site Settings'
+);
+
+assert.match(
+  source,
+  /notifyComposerChange\('site', inferredSiteRepoApplied \? \{\} : \{ skipAutoSave: true \}\);/,
+  'composer should mark inferred site repo changes dirty while preserving normal initialization behavior'
 );
 
 assert.match(


### PR DESCRIPTION
## Summary
- infer placeholder Starter repo settings from standard GitHub Pages URLs in the editor
- apply the inferred repo before Site Settings render, marking `site.yaml` dirty for the first publish
- bump the editor composer cache key and cover the inference cases in composer tests

## Validation
- `node scripts/test-composer-identity-grid.js`
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-system-release-workflow.sh`
- `git diff --check`

## Follow-up Verification After Merge
- confirm the Press system release workflow publishes a new `press-system-vX.Y.Z.zip`
- confirm `EkilyHQ/Press-Starter` receives the repository dispatch and opens a sync PR
