### PR TITLE
Handle index-named Pages repositories

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -346,10 +346,14 @@ function inferRepoConfigFromGitHubPagesUrl(locationLike) {
   const owner = host.slice(0, -suffix.length);
   if (!/^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/.test(owner)) return null;
 
-  const rawSegments = String(pathname || '').split('/').filter(Boolean);
+  const path = String(pathname || '');
+  const rawSegments = path.split('/').filter(Boolean);
   const firstSegment = rawSegments[0] || '';
+  const isRootIndexFile = rawSegments.length === 1
+    && (firstSegment === 'index.html' || firstSegment === 'index_editor.html')
+    && !path.endsWith('/');
   let name = '';
-  if (!firstSegment || firstSegment === 'index.html' || firstSegment === 'index_editor.html') {
+  if (!firstSegment || isRootIndexFile) {
     name = `${owner}.github.io`;
   } else {
     try {

--- a/index_editor.html
+++ b/index_editor.html
@@ -2408,7 +2408,7 @@
   </script>
   <script type="module" src="assets/js/editor-boot.js?v=theme-manager-20260507"></script>
   <script type="module" src="assets/js/editor-main.js?v=theme-manager-20260507"></script>
-  <script type="module" src="assets/js/composer.js?v=repo-autofill-20260507"></script>
+  <script type="module" src="assets/js/composer.js?v=repo-autofill-root-20260507"></script>
   <!-- Back to top button -->
   <button id="backToTop" class="back-to-top" aria-label="返回顶部" title="返回顶部" type="button" hidden>
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -94,7 +94,7 @@ assert.doesNotMatch(
 
 assert.match(
   editorSource,
-  /assets\/js\/composer\.js\?v=repo-autofill-20260507/,
+  /assets\/js\/composer\.js\?v=repo-autofill-root-20260507/,
   'editor HTML should cache-bust composer.js when repository autofill changes'
 );
 
@@ -114,6 +114,24 @@ assert.deepEqual(
   repoInference.inferRepoConfigFromGitHubPagesUrl('https://deemoe404.github.io/index_editor.html'),
   { owner: 'deemoe404', name: 'deemoe404.github.io', branch: 'main' },
   'GitHub user Pages editor URLs should infer the owner.github.io repository'
+);
+
+assert.deepEqual(
+  repoInference.inferRepoConfigFromGitHubPagesUrl('https://deemoe404.github.io/index.html'),
+  { owner: 'deemoe404', name: 'deemoe404.github.io', branch: 'main' },
+  'GitHub user Pages root index URLs should infer the owner.github.io repository'
+);
+
+assert.deepEqual(
+  repoInference.inferRepoConfigFromGitHubPagesUrl('https://deemoe404.github.io/index.html/'),
+  { owner: 'deemoe404', name: 'index.html', branch: 'main' },
+  'GitHub project Pages repos named index.html should not be treated as user Pages root files'
+);
+
+assert.deepEqual(
+  repoInference.inferRepoConfigFromGitHubPagesUrl('https://deemoe404.github.io/index_editor.html/index_editor.html'),
+  { owner: 'deemoe404', name: 'index_editor.html', branch: 'main' },
+  'GitHub project Pages repos named index_editor.html should not be treated as user Pages root files'
 );
 
 assert.equal(


### PR DESCRIPTION
## Summary
- distinguish root index files from project Pages repositories named `index.html` or `index_editor.html`
- keep user-site root inference for `/index.html` and `/index_editor.html`
- bump the editor composer cache key and add regression coverage for index-named repositories

## Validation
- `node scripts/test-composer-identity-grid.js`
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-system-release-workflow.sh`
- `git diff --check`
