### PR TITLE
[codex] Update YAP release dispatch target

### DIFF
--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -258,12 +258,12 @@ jobs:
           PY
           gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${{ steps.create.outputs.release_id }}" --input dist/publish-release.json >/dev/null
 
-      - name: Notify starter template
+      - name: Notify YAP template
         if: steps.plan.outputs.should_release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           STARTER_SYNC_TOKEN: ${{ secrets.STARTER_SYNC_TOKEN }}
-          STARTER_REPOSITORY: ${{ vars.STARTER_REPOSITORY || 'EkilyHQ/Press-Starter' }}
+          STARTER_REPOSITORY: ${{ vars.STARTER_REPOSITORY || 'EkilyHQ/YAP' }}
           NEXT_TAG: ${{ steps.plan.outputs.next_tag }}
           ASSET_NAME: ${{ steps.plan.outputs.asset_name }}
           ASSET_SIZE: ${{ steps.package.outputs.archive_size }}
@@ -272,12 +272,12 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -z "${STARTER_SYNC_TOKEN}" ]]; then
-            echo "STARTER_SYNC_TOKEN is not configured; skipping Press-Starter sync dispatch."
+            echo "STARTER_SYNC_TOKEN is not configured; skipping YAP sync dispatch."
             exit 0
           fi
 
           if ! gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" > dist/starter-release.json; then
-            echo "::warning title=Press-Starter sync skipped::Unable to read the published release for Starter dispatch."
+            echo "::warning title=YAP sync skipped::Unable to read the published release for YAP dispatch."
             exit 0
           fi
           node <<'NODE' > dist/starter-dispatch.json
@@ -301,7 +301,7 @@ jobs:
             --method POST \
             "repos/${STARTER_REPOSITORY}/dispatches" \
             --input dist/starter-dispatch.json; then
-            echo "::warning title=Press-Starter sync dispatch failed::Release ${NEXT_TAG} was published, but the optional dispatch to ${STARTER_REPOSITORY} failed."
+            echo "::warning title=YAP sync dispatch failed::Release ${NEXT_TAG} was published, but the optional dispatch to ${STARTER_REPOSITORY} failed."
             exit 0
           fi
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ The `wwwroot/` folder is intentionally not minimal. It hosts the official Press 
 
 ## For New Sites
 
-The clean starter template lives in [EkilyHQ/Press-Starter](https://github.com/EkilyHQ/Press-Starter).
+The clean starter template lives in [EkilyHQ/YAP](https://github.com/EkilyHQ/YAP).
 
 Use that starter repository when you want to create your own site. This repository is useful when you want to develop Press itself, inspect the official documentation source, or test behavior against the full documentation corpus.
 
 The theme starter template lives in [EkilyHQ/Press-Theme-Starter](https://github.com/EkilyHQ/Press-Theme-Starter). Use it when you want to create a new Press theme repository with the release workflow and contract-compatible starter theme already wired up.
 
-This repository carries the implementation template input for `Press-Starter` under `templates/press-starter`. The official documentation site remains the full setup guide:
+This repository carries the implementation template input for YAP under `templates/press-starter`. The official documentation site remains the full setup guide:
 
 - Official site: [https://ekilyhq.github.io/Press/](https://ekilyhq.github.io/Press/)
 - Documentation: [Documentation for Press](https://ekilyhq.github.io/Press/?id=post%2Fdoc%2Fv2.1.0%2Fdoc_en.md&lang=en)
@@ -43,7 +43,7 @@ This repository carries the implementation template input for `Press-Starter` un
 - `wwwroot/` - official documentation site content and Markdown regression corpus.
 - `site.yaml` - official documentation site configuration.
 - `scripts/` - repository checks and focused regression scripts.
-- `templates/` - repository template input for `Press-Starter`.
+- `templates/` - repository template input for YAP.
 
 ## Development Workflow
 
@@ -76,7 +76,7 @@ Merges to `main` that change Press runtime files automatically publish a patch r
 
 Official documentation, site content, installed theme registry state, and external theme directories stay out of system update packages. Changes that only touch `wwwroot/` do not create a system release, and update packages must never include `wwwroot/`, `site.yaml`, `CNAME`, `robots.txt`, `sitemap.xml`, repository policy files, workflow files, scripts, site-specific media such as `assets/avatar.png` and `assets/hero.jpeg`, `assets/themes/packs.json`, or arbitrary `assets/themes/<slug>` directories outside `native`.
 
-After a system release is published, the release workflow can dispatch `EkilyHQ/Press-Starter` to rebuild the template from that release package. Configure `STARTER_SYNC_TOKEN` in this repository with permission to call repository dispatch on the starter repository. `STARTER_REPOSITORY` can be set as a repository variable when the starter repository name differs from `EkilyHQ/Press-Starter`.
+After a system release is published, the release workflow can dispatch `EkilyHQ/YAP` to rebuild the template from that release package. Configure `STARTER_SYNC_TOKEN` in this repository with permission to call repository dispatch on the YAP repository. `STARTER_REPOSITORY` can be set as a repository variable when the target repository name differs from `EkilyHQ/YAP`.
 
 ## Branching
 

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -133,13 +133,18 @@ if ! grep -F 'Update static release manifest' "${workflow}" >/dev/null; then
   exit 1
 fi
 
-if ! grep -F 'Notify starter template' "${workflow}" >/dev/null; then
-  echo "system release workflow must notify the Starter template after publishing" >&2
+if ! grep -F 'Notify YAP template' "${workflow}" >/dev/null; then
+  echo "system release workflow must notify the YAP template after publishing" >&2
   exit 1
 fi
 
 if ! grep -F 'STARTER_SYNC_TOKEN' "${workflow}" >/dev/null; then
-  echo "system release workflow must use STARTER_SYNC_TOKEN for cross-repository Starter dispatch" >&2
+  echo "system release workflow must use STARTER_SYNC_TOKEN for cross-repository YAP dispatch" >&2
+  exit 1
+fi
+
+if ! grep -F "STARTER_REPOSITORY: \${{ vars.STARTER_REPOSITORY || 'EkilyHQ/YAP' }}" "${workflow}" >/dev/null; then
+  echo "system release workflow must default dispatches to EkilyHQ/YAP" >&2
   exit 1
 fi
 
@@ -149,12 +154,12 @@ if ! grep -F "event_type: 'press-system-release'" "${workflow}" >/dev/null; then
 fi
 
 if ! grep -F '"repos/${STARTER_REPOSITORY}/dispatches"' "${workflow}" >/dev/null; then
-  echo "system release workflow must call the Starter repository dispatch endpoint" >&2
+  echo "system release workflow must call the YAP repository dispatch endpoint" >&2
   exit 1
 fi
 
 if ! grep -F 'asset_sha256: process.env.ASSET_SHA256' "${workflow}" >/dev/null; then
-  echo "system release workflow must pass the system package digest to Starter" >&2
+  echo "system release workflow must pass the system package digest to YAP" >&2
   exit 1
 fi
 

--- a/templates/press-starter/README.md
+++ b/templates/press-starter/README.md
@@ -1,6 +1,6 @@
-# Press Starter Template
+# YAP Template Input
 
-This is the minimal repository shape for `EkilyHQ/Press-Starter`.
+This is the minimal repository shape for `EkilyHQ/YAP`.
 
 Use the upstream repository as a GitHub template for new sites. It should include the Press runtime, editor, `native`, Theme Manager, `assets/themes/packs.json`, `assets/themes/catalog.json`, and minimal site content. It should not include the Press official documentation corpus or regression posts.
 
@@ -18,6 +18,6 @@ Use the upstream repository as a GitHub template for new sites. It should includ
 
 ## Runtime Sync
 
-The real `Press-Starter` repository is rebuilt from Press system release packages. Its sync workflow listens for `press-system-release` repository dispatch events from `Press`, supports manual runs, and has a scheduled catch-up run.
+The real `YAP` repository is rebuilt from Press system release packages. Its sync workflow listens for `press-system-release` repository dispatch events from `Press`, supports manual runs, and has a scheduled catch-up run.
 
-The workflow overlays system-owned runtime files from `press-system-vX.Y.Z.zip`, then regenerates a native-only `assets/themes/packs.json`. Starter-owned files such as `.nojekyll`, `site.yaml`, `wwwroot`, `README.md`, and repository metadata are preserved.
+The workflow overlays system-owned runtime files from `press-system-vX.Y.Z.zip`, then regenerates a native-only `assets/themes/packs.json`. YAP-owned files such as `.nojekyll`, `site.yaml`, `wwwroot`, `README.md`, and repository metadata are preserved.


### PR DESCRIPTION
## Summary
- Update the system release workflow fallback dispatch target from `EkilyHQ/Press-Starter` to `EkilyHQ/YAP`.
- Refresh workflow warning text, release workflow assertions, and docs to refer to YAP.
- Keep the existing `STARTER_SYNC_TOKEN` and `STARTER_REPOSITORY` override contract intact.

## Validation
- `bash scripts/test-system-release-workflow.sh`
- `git diff --check`
- Confirmed `STARTER_REPOSITORY=EkilyHQ/YAP` on `EkilyHQ/Press`
- Confirmed `STARTER_SYNC_TOKEN` exists on `EkilyHQ/Press`