### PR TITLE
[codex] Add one-click system update staging

### DIFF
--- a/.github/workflows/system-release.yml
+++ b/.github/workflows/system-release.yml
@@ -89,6 +89,41 @@ jobs:
             echo "archive_sha256=${archive_sha256}"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Publish fetchable artifact
+        if: steps.plan.outputs.should_release == 'true'
+        id: artifact
+        run: |
+          set -euo pipefail
+          tag="${{ steps.plan.outputs.next_tag }}"
+          asset="${{ steps.plan.outputs.asset_name }}"
+          artifact_branch="release-artifacts"
+          artifact_path="${tag}/${asset}"
+          artifact_url="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${artifact_branch}/${artifact_path}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin "${artifact_branch}" || true
+          rm -rf artifacts-worktree
+          if git show-ref --verify --quiet "refs/remotes/origin/${artifact_branch}"; then
+            git worktree add artifacts-worktree "origin/${artifact_branch}"
+          else
+            git worktree add --detach artifacts-worktree
+            git -C artifacts-worktree checkout --orphan "${artifact_branch}"
+            git -C artifacts-worktree rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          mkdir -p "artifacts-worktree/${tag}"
+          cp "${{ steps.package.outputs.archive_path }}" "artifacts-worktree/${artifact_path}"
+          git -C artifacts-worktree add "${artifact_path}"
+          if git -C artifacts-worktree diff --cached --quiet; then
+            echo "Artifact ${artifact_path} is already published."
+          else
+            git -C artifacts-worktree commit -m "Publish ${asset}"
+            git -C artifacts-worktree push origin "HEAD:${artifact_branch}"
+          fi
+          git worktree remove artifacts-worktree --force
+          echo "url=${artifact_url}" >> "${GITHUB_OUTPUT}"
+
       - name: Create draft release
         if: steps.plan.outputs.should_release == 'true'
         id: create
@@ -312,6 +347,7 @@ jobs:
           EXPECTED_ASSET: ${{ steps.plan.outputs.asset_name }}
           EXPECTED_SIZE: ${{ steps.package.outputs.archive_size }}
           EXPECTED_SHA256: ${{ steps.package.outputs.archive_sha256 }}
+          FETCHABLE_ASSET_URL: ${{ steps.artifact.outputs.url }}
         run: |
           set -euo pipefail
           gh api "repos/${GITHUB_REPOSITORY}/releases/${{ steps.create.outputs.release_id }}" > dist/release-published.json
@@ -342,7 +378,7 @@ jobs:
               "htmlUrl": release.get("html_url") or "",
               "asset": {
                   "name": asset.get("name") or expected_name,
-                  "url": asset.get("browser_download_url") or f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/releases/download/{release.get('tag_name')}/{expected_name}",
+                  "url": os.environ["FETCHABLE_ASSET_URL"],
                   "size": int(asset.get("size") or expected_size),
                   "digest": digest
               }

--- a/assets/i18n/chs.js
+++ b/assets/i18n/chs.js
@@ -222,6 +222,7 @@ const translations = {
         openDownload: '下载发布 ZIP',
         downloadAssetLink: ({ name }) => `下载 ${name}`,
         openReleasePage: '在 GitHub 查看发布页',
+        downloadAndCheck: '下载并检查更新',
         selectArchive: '选择已下载的 ZIP',
         filesHeading: '待更新的系统文件',
         releaseNotes: '发布说明',
@@ -232,7 +233,8 @@ const translations = {
         assetWithHash: ({ name, size, hash }) => `附件：${name}（${size}） — SHA-256 ${hash}`,
         noAsset: '此发布没有可下载的 Press 系统更新包。',
         status: {
-          idle: '先下载最新的发布 ZIP，然后选择该文件以检查更新。',
+          idle: '下载并检查最新发布，或选择已下载的 ZIP。',
+          downloading: '正在下载最新发布 ZIP…',
           reading: '正在读取压缩包…',
           verifying: '正在校验压缩包…',
           noChanges: '系统文件已是最新状态。',
@@ -244,6 +246,7 @@ const translations = {
           releaseRateLimited: 'GitHub API 已限流。请稍后重试，或手动选择已下载的 ZIP。',
           emptyFile: '选择的文件为空。',
           invalidArchive: '选中的 ZIP 无法作为 Press 发布读取。',
+          downloadFailed: '无法下载最新系统更新包。请改为选择已下载的 ZIP。',
           sizeMismatch: ({ expected, actual }) => `选中的压缩包大小（${actual}）与发布附件（${expected}）不一致。`,
           digestMismatch: '选中的压缩包 SHA-256 与发布附件不一致。',
           generic: '系统更新失败，请重试。'

--- a/assets/i18n/cht-tw.js
+++ b/assets/i18n/cht-tw.js
@@ -222,6 +222,7 @@ const translations = {
         openDownload: '下載釋出 ZIP',
         downloadAssetLink: ({ name }) => `下載 ${name}`,
         openReleasePage: '在 GitHub 檢視釋出頁',
+        downloadAndCheck: '下載並檢查更新',
         selectArchive: '選擇已下載的 ZIP',
         filesHeading: '待更新的系統檔案',
         releaseNotes: '釋出說明',
@@ -232,7 +233,8 @@ const translations = {
         assetWithHash: ({ name, size, hash }) => `附件：${name}（${size}） — SHA-256 ${hash}`,
         noAsset: '此釋出沒有可下載的 Press 系統更新包。',
         status: {
-          idle: '先下載最新的釋出 ZIP，然後選擇該檔案以檢查更新。',
+          idle: '下載並檢查最新釋出，或選擇已下載的 ZIP。',
+          downloading: '正在下載最新釋出 ZIP…',
           reading: '正在讀取壓縮包…',
           verifying: '正在校驗壓縮包…',
           noChanges: '系統檔案已是最新狀態。',
@@ -244,6 +246,7 @@ const translations = {
           releaseRateLimited: 'GitHub API 已限流。請稍後重試，或手動選擇已下載的 ZIP。',
           emptyFile: '選擇的檔案為空。',
           invalidArchive: '選中的 ZIP 無法作為 Press 釋出讀取。',
+          downloadFailed: '無法下載最新系統更新包。請改為選擇已下載的 ZIP。',
           sizeMismatch: ({ expected, actual }) => `選中的壓縮包大小（${actual}）與釋出附件（${expected}）不一致。`,
           digestMismatch: '選中的壓縮包 SHA-256 與釋出附件不一致。',
           generic: '系統更新失敗，請重試。'

--- a/assets/i18n/en.js
+++ b/assets/i18n/en.js
@@ -224,6 +224,7 @@ const translations = {
         openDownload: 'Download release ZIP',
         downloadAssetLink: ({ name }) => `Download ${name}`,
         openReleasePage: 'View release on GitHub',
+        downloadAndCheck: 'Download and check',
         selectArchive: 'Select downloaded ZIP',
         filesHeading: 'Pending system files',
         releaseNotes: 'Release notes',
@@ -234,7 +235,8 @@ const translations = {
         assetWithHash: ({ name, size, hash }) => `Asset: ${name} (${size}) — SHA-256 ${hash}`,
         noAsset: 'No Press system update package was attached to this release.',
         status: {
-          idle: 'Download the latest release ZIP, then select it to check for updates.',
+          idle: 'Download and check the latest release, or select a downloaded ZIP.',
+          downloading: 'Downloading latest release ZIP…',
           reading: 'Reading archive…',
           verifying: 'Verifying archive…',
           noChanges: 'System files are up to date.',
@@ -246,6 +248,7 @@ const translations = {
           releaseRateLimited: 'GitHub API is rate limited. Try again later, or manually select a downloaded ZIP.',
           emptyFile: 'The selected file is empty.',
           invalidArchive: 'The selected ZIP could not be read as a Press release.',
+          downloadFailed: 'Unable to download the latest system update package. Select a downloaded ZIP instead.',
           sizeMismatch: ({ expected, actual }) => `The selected archive size (${actual}) does not match the release asset (${expected}).`,
           digestMismatch: 'The selected archive SHA-256 does not match the release asset.',
           generic: 'System update failed. Please try again.'

--- a/assets/i18n/ja.js
+++ b/assets/i18n/ja.js
@@ -222,6 +222,7 @@ const translations = {
         openDownload: 'リリース ZIP をダウンロード',
         downloadAssetLink: ({ name }) => `${name} をダウンロード`,
         openReleasePage: 'GitHub でリリースを開く',
+        downloadAndCheck: 'ダウンロードして確認',
         selectArchive: 'ダウンロードした ZIP を選択',
         filesHeading: '更新待ちのシステムファイル',
         releaseNotes: 'リリースノート',
@@ -232,7 +233,8 @@ const translations = {
         assetWithHash: ({ name, size, hash }) => `アセット：${name}（${size}） — SHA-256 ${hash}`,
         noAsset: 'このリリースにはダウンロード可能な Press システム更新パッケージがありません。',
         status: {
-          idle: '最新のリリース ZIP をダウンロードしてから、更新を確認するために選択してください。',
+          idle: '最新リリースをダウンロードして確認するか、ダウンロード済み ZIP を選択してください。',
+          downloading: '最新リリース ZIP をダウンロードしています…',
           reading: 'アーカイブを読み込み中…',
           verifying: 'アーカイブを検証しています…',
           noChanges: 'システムファイルは最新です。',
@@ -244,6 +246,7 @@ const translations = {
           releaseRateLimited: 'GitHub API のレート制限に達しました。しばらくしてから再試行するか、ダウンロード済み ZIP を手動で選択してください。',
           emptyFile: '選択したファイルは空です。',
           invalidArchive: '選択した ZIP を Press リリースとして読み込めませんでした。',
+          downloadFailed: '最新のシステム更新パッケージをダウンロードできませんでした。ダウンロード済み ZIP を選択してください。',
           sizeMismatch: ({ expected, actual }) => `選択したアーカイブのサイズ（${actual}）がリリースアセット（${expected}）と一致しません。`,
           digestMismatch: '選択したアーカイブの SHA-256 がリリースアセットと一致しません。',
           generic: 'システム更新に失敗しました。再試行してください。'

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -274,6 +274,27 @@ export function selectSystemUpdateAsset(releaseData) {
   };
 }
 
+function parseReleaseTag(tag) {
+  const match = String(tag || '').trim().match(/^v(\d+)\.(\d+)\.(\d+)$/i);
+  if (!match) return null;
+  return match.slice(1).map((part) => Number(part));
+}
+
+function compareReleaseTags(a, b) {
+  const left = parseReleaseTag(a);
+  const right = parseReleaseTag(b);
+  if (!left || !right) return String(a || '') === String(b || '') ? 0 : null;
+  for (let i = 0; i < left.length; i += 1) {
+    if (left[i] !== right[i]) return left[i] > right[i] ? 1 : -1;
+  }
+  return 0;
+}
+
+function isFetchableSystemUpdateAssetUrl(url) {
+  return /^https:\/\/raw\.githubusercontent\.com\/[^/]+\/Press\/release-artifacts\/v\d+\.\d+\.\d+\/press-system-v\d+\.\d+\.\d+\.zip$/i
+    .test(String(url || '').trim());
+}
+
 function isObject(value) {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
@@ -294,7 +315,7 @@ function normalizeReleaseCache(data) {
     publishedAt: data.published_at || data.created_at || '',
     notes: data.body || '',
     htmlUrl: data.html_url || '',
-    asset
+    asset: asset ? { ...asset, fetchable: false } : asset
   };
 }
 
@@ -331,7 +352,8 @@ export function normalizeSystemReleaseManifest(manifest) {
     asset: {
       ...asset,
       size,
-      digest
+      digest,
+      fetchable: isFetchableSystemUpdateAssetUrl(asset.url)
     }
   };
 }
@@ -437,23 +459,37 @@ async function fetchLatestReleaseFromManifest() {
 
 async function fetchLatestRelease() {
   if (releaseCache) return releaseCache;
+  let apiRelease = null;
+  let apiError = null;
+  let manifestRelease = null;
   let manifestError = null;
   try {
-    releaseCache = await fetchLatestReleaseFromManifest();
+    apiRelease = await fetchLatestReleaseFromApi();
+  } catch (err) {
+    apiError = err;
+  }
+  try {
+    manifestRelease = await fetchLatestReleaseFromManifest();
   } catch (err) {
     manifestError = err;
-    try {
-      releaseCache = await fetchLatestReleaseFromApi();
-    } catch (apiError) {
-      const message = apiError && apiError.rateLimited
-        ? t('editor.systemUpdates.errors.releaseRateLimited')
-        : t('editor.systemUpdates.errors.releaseFetch');
-      const error = new Error(message);
-      error.apiError = apiError;
-      error.manifestError = manifestError;
-      throw error;
-    }
   }
+
+  if (apiRelease && manifestRelease && compareReleaseTags(apiRelease.tag, manifestRelease.tag) === 0) {
+    releaseCache = manifestRelease;
+  } else if (apiRelease) {
+    releaseCache = apiRelease;
+  } else if (manifestRelease) {
+    releaseCache = manifestRelease;
+  } else {
+    const message = apiError && apiError.rateLimited
+      ? t('editor.systemUpdates.errors.releaseRateLimited')
+      : t('editor.systemUpdates.errors.releaseFetch');
+    const error = new Error(message);
+    error.apiError = apiError;
+    error.manifestError = manifestError;
+    throw error;
+  }
+
   renderRelease();
   return releaseCache;
 }
@@ -637,6 +673,9 @@ export async function stageLatestSystemUpdate() {
   const release = await fetchLatestRelease();
   if (!release || !release.asset || !release.asset.url) {
     throw new Error(t('editor.systemUpdates.noAsset'));
+  }
+  if (release.asset.fetchable !== true) {
+    throw new Error(t('editor.systemUpdates.errors.downloadFailed'));
   }
   const fileName = release.asset.name || release.name || 'press-system.zip';
   setStatus(t('editor.systemUpdates.status.downloading'));

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -474,7 +474,10 @@ async function fetchLatestRelease() {
     manifestError = err;
   }
 
-  if (apiRelease && manifestRelease && compareReleaseTags(apiRelease.tag, manifestRelease.tag) === 0) {
+  const manifestComparison = apiRelease && manifestRelease
+    ? compareReleaseTags(manifestRelease.tag, apiRelease.tag)
+    : null;
+  if (apiRelease && manifestRelease && manifestComparison !== null && manifestComparison >= 0) {
     releaseCache = manifestRelease;
   } else if (apiRelease) {
     releaseCache = apiRelease;

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -31,6 +31,7 @@ const elements = {
   root: null,
   status: null,
   downloadLink: null,
+  downloadButton: null,
   selectButton: null,
   fileInput: null,
   fileSection: null,
@@ -122,6 +123,10 @@ function setStatus(text, options = {}) {
 
 function setBusy(flag) {
   busy = !!flag;
+  if (elements.downloadButton) {
+    elements.downloadButton.disabled = busy;
+    elements.downloadButton.dataset.state = busy ? 'busy' : 'idle';
+  }
   if (elements.selectButton) {
     elements.selectButton.disabled = busy;
     elements.selectButton.dataset.state = busy ? 'busy' : 'idle';
@@ -432,14 +437,14 @@ async function fetchLatestReleaseFromManifest() {
 
 async function fetchLatestRelease() {
   if (releaseCache) return releaseCache;
-  let apiError = null;
+  let manifestError = null;
   try {
-    releaseCache = await fetchLatestReleaseFromApi();
+    releaseCache = await fetchLatestReleaseFromManifest();
   } catch (err) {
-    apiError = err;
+    manifestError = err;
     try {
-      releaseCache = await fetchLatestReleaseFromManifest();
-    } catch (manifestError) {
+      releaseCache = await fetchLatestReleaseFromApi();
+    } catch (apiError) {
       const message = apiError && apiError.rateLimited
         ? t('editor.systemUpdates.errors.releaseRateLimited')
         : t('editor.systemUpdates.errors.releaseFetch');
@@ -451,6 +456,21 @@ async function fetchLatestRelease() {
   }
   renderRelease();
   return releaseCache;
+}
+
+async function fetchSystemUpdateAsset(url) {
+  let response = null;
+  try {
+    response = await fetch(url, { cache: 'no-store' });
+  } catch (err) {
+    const error = new Error(t('editor.systemUpdates.errors.downloadFailed'));
+    error.cause = err;
+    throw error;
+  }
+  if (!response || !response.ok) {
+    throw new Error(t('editor.systemUpdates.errors.downloadFailed'));
+  }
+  return response.arrayBuffer();
 }
 
 function renderReleaseMeta() {
@@ -613,9 +633,36 @@ export async function analyzeArchive(buffer, filename) {
   setStatus(t('editor.systemUpdates.status.changes', { count }), { tone: 'warn' });
 }
 
+export async function stageLatestSystemUpdate() {
+  const release = await fetchLatestRelease();
+  if (!release || !release.asset || !release.asset.url) {
+    throw new Error(t('editor.systemUpdates.noAsset'));
+  }
+  const fileName = release.asset.name || release.name || 'press-system.zip';
+  setStatus(t('editor.systemUpdates.status.downloading'));
+  applySummary([], []);
+  const buffer = await fetchSystemUpdateAsset(release.asset.url);
+  await analyzeArchive(buffer, fileName);
+}
+
 function handleSelectClick() {
   if (busy || !elements.fileInput) return;
   elements.fileInput.click();
+}
+
+async function handleDownloadClick() {
+  if (busy) return;
+  setBusy(true);
+  try {
+    await stageLatestSystemUpdate();
+  } catch (err) {
+    console.error('System update download failed', err);
+    const message = err && err.message ? err.message : t('editor.systemUpdates.errors.downloadFailed');
+    setStatus(message, { tone: 'error' });
+    applySummary([], []);
+  } finally {
+    setBusy(false);
+  }
 }
 
 async function handleFileInputChange(event) {
@@ -650,6 +697,7 @@ export function initSystemUpdates(options = {}) {
   elements.root = document.getElementById('mode-updates');
   elements.status = document.getElementById('systemUpdateStatus');
   elements.downloadLink = document.getElementById('systemUpdateDownloadLink');
+  elements.downloadButton = document.getElementById('btnSystemDownload');
   elements.selectButton = document.getElementById('btnSystemSelect');
   elements.fileInput = document.getElementById('systemUpdateFileInput');
   elements.fileSection = document.getElementById('systemUpdateFileSection');
@@ -661,6 +709,10 @@ export function initSystemUpdates(options = {}) {
 
   if (options && typeof options.onStateChange === 'function') listeners.add(options.onStateChange);
 
+  if (elements.downloadButton) {
+    elements.downloadButton.dataset.state = 'idle';
+    elements.downloadButton.addEventListener('click', handleDownloadClick);
+  }
   if (elements.selectButton) {
     elements.selectButton.dataset.state = 'idle';
     elements.selectButton.addEventListener('click', handleSelectClick);

--- a/index_editor.html
+++ b/index_editor.html
@@ -329,8 +329,8 @@
     .updates-meta { display:flex; flex-direction:column; gap:.15rem; font-size:.92rem; color: color-mix(in srgb, var(--muted) 80%, transparent); }
     .updates-meta span { line-height:1.4; }
     .updates-header-actions { display:flex; align-items:center; gap:.75rem; flex-wrap:wrap; }
-    #btnSystemSelect[data-state="busy"] { pointer-events:none; opacity:.82; }
-    #btnSystemSelect[data-state="busy"]::after { content:''; display:inline-block; width:1rem; height:1rem; margin-left:.5rem; border:2px solid color-mix(in srgb, var(--primary) 40%, transparent); border-top-color: color-mix(in srgb, var(--primary) 86%, transparent); border-radius:50%; animation: press-updates-spin .85s linear infinite; vertical-align:middle; }
+    #btnSystemDownload[data-state="busy"], #btnSystemSelect[data-state="busy"] { pointer-events:none; opacity:.82; }
+    #btnSystemDownload[data-state="busy"]::after, #btnSystemSelect[data-state="busy"]::after { content:''; display:inline-block; width:1rem; height:1rem; margin-left:.5rem; border:2px solid color-mix(in srgb, var(--primary) 40%, transparent); border-top-color: color-mix(in srgb, var(--primary) 86%, transparent); border-radius:50%; animation: press-updates-spin .85s linear infinite; vertical-align:middle; }
     .updates-download[aria-disabled="true"] { pointer-events:none; opacity:.55; }
     @keyframes press-updates-spin { to { transform: rotate(360deg); } }
     .updates-status { margin:0; font-size:.95rem; color: color-mix(in srgb, var(--muted) 82%, transparent); }
@@ -2253,7 +2253,8 @@
               <input type="file" id="themeImportFileInput" accept=".zip,application/zip,application/x-zip-compressed" hidden>
             </div>
             <div class="editor-modal-header-actions" id="editorModalUpdateActions" hidden>
-              <button class="btn-primary" type="button" id="btnSystemSelect" data-i18n="editor.systemUpdates.selectArchive">Select downloaded ZIP</button>
+              <button class="btn-primary" type="button" id="btnSystemDownload" data-i18n="editor.systemUpdates.downloadAndCheck">Download and check</button>
+              <button class="btn-secondary" type="button" id="btnSystemSelect" data-i18n="editor.systemUpdates.selectArchive">Select downloaded ZIP</button>
               <input type="file" id="systemUpdateFileInput" accept=".zip,application/zip,application/x-zip-compressed" hidden>
             </div>
             <div class="editor-modal-header-actions" id="editorModalSyncActions" hidden>

--- a/scripts/test-system-release-workflow.sh
+++ b/scripts/test-system-release-workflow.sh
@@ -133,6 +133,31 @@ if ! grep -F 'Update static release manifest' "${workflow}" >/dev/null; then
   exit 1
 fi
 
+if ! grep -F 'Publish fetchable artifact' "${workflow}" >/dev/null; then
+  echo "system release workflow must publish a CORS-readable system package artifact" >&2
+  exit 1
+fi
+
+if ! grep -F 'artifact_branch="release-artifacts"' "${workflow}" >/dev/null; then
+  echo "system release workflow must publish system packages to the release-artifacts branch" >&2
+  exit 1
+fi
+
+if ! grep -F 'artifact_url="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${artifact_branch}/${artifact_path}"' "${workflow}" >/dev/null; then
+  echo "system release workflow must expose system packages through raw.githubusercontent.com" >&2
+  exit 1
+fi
+
+if ! grep -F 'FETCHABLE_ASSET_URL: ${{ steps.artifact.outputs.url }}' "${workflow}" >/dev/null; then
+  echo "system release manifest must receive the fetchable artifact URL" >&2
+  exit 1
+fi
+
+if ! grep -F '"url": os.environ["FETCHABLE_ASSET_URL"]' "${workflow}" >/dev/null; then
+  echo "system release manifest must point asset.url at the fetchable artifact URL" >&2
+  exit 1
+fi
+
 if ! grep -F 'Notify YAP template' "${workflow}" >/dev/null; then
   echo "system release workflow must notify the YAP template after publishing" >&2
   exit 1

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -28,8 +28,10 @@ const {
   collectSystemUpdateArchiveEntries,
   clearSystemUpdateState,
   getDisplayReleaseNotes,
+  getSystemUpdateCommitFiles,
   normalizeSystemReleaseManifest,
   selectSystemUpdateAsset,
+  stageLatestSystemUpdate,
   verifySystemUpdateAsset
 } = await import('../assets/js/system-updates.js?system-updates-test');
 
@@ -65,6 +67,20 @@ function jsonResponse(data, options = {}) {
     },
     json: async () => data,
     arrayBuffer: async () => new ArrayBuffer(0)
+  };
+}
+
+function arrayBufferResponse(buffer, options = {}) {
+  const {
+    ok = true,
+    status = ok ? 200 : 500
+  } = options;
+  return {
+    ok,
+    status,
+    headers: { get: () => null },
+    json: async () => ({}),
+    arrayBuffer: async () => buffer
   };
 }
 
@@ -176,7 +192,7 @@ await run('hides stale release notes when no Press system package is attached', 
   }), 'Use `press-system-v3.3.37.zip`.');
 });
 
-await run('falls back to the static release manifest when the GitHub API is rate limited', async () => {
+await run('uses the static release manifest before the GitHub API', async () => {
   clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
   const buffer = makeZip({ 'press-system-v3.3.5/index.html': '<!doctype html><p>manifest</p>' });
   const digest = await sha256(buffer);
@@ -218,8 +234,47 @@ await run('falls back to the static release manifest when the GitHub API is rate
 
   await analyzeArchive(buffer, 'press-system-v3.3.5.zip');
 
-  assert.equal(apiCalls, 1);
+  assert.equal(apiCalls, 0);
   assert.equal(manifestCalls, 1);
+  delete globalThis.fetch;
+});
+
+await run('falls back to the GitHub API when the static manifest is unavailable', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  const buffer = makeZip({ 'press-system-v3.3.5/index.html': '<!doctype html><p>api</p>' });
+  const digest = await sha256(buffer);
+  let apiCalls = 0;
+  let manifestCalls = 0;
+
+  globalThis.fetch = async (input) => {
+    const url = String(input || '');
+    if (url.includes('assets/system-release.json')) {
+      manifestCalls += 1;
+      return jsonResponse({ message: 'not found' }, { ok: false, status: 404 });
+    }
+    if (url.includes('/repos/EkilyHQ/Press/releases/latest')) {
+      apiCalls += 1;
+      return jsonResponse({
+        name: 'v3.3.5',
+        tag_name: 'v3.3.5',
+        assets: [{
+          name: 'press-system-v3.3.5.zip',
+          browser_download_url: 'https://example.test/press-system-v3.3.5.zip',
+          size: buffer.byteLength,
+          digest: `sha256:${digest}`
+        }]
+      });
+    }
+    return {
+      ok: false,
+      arrayBuffer: async () => new ArrayBuffer(0)
+    };
+  };
+
+  await analyzeArchive(buffer, 'press-system-v3.3.5.zip');
+
+  assert.ok(manifestCalls >= 1);
+  assert.equal(apiCalls, 1);
   delete globalThis.fetch;
 });
 
@@ -261,6 +316,95 @@ await run('uses the static manifest digest when verifying a selected archive', a
     () => analyzeArchive(buffer, 'press-system-v3.3.5.zip'),
     /sha-?256|digest|hash/i
   );
+  delete globalThis.fetch;
+});
+
+await run('downloads the manifest asset and stages system files', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  const buffer = makeZip({ 'press-system-v3.3.5/index.html': '<!doctype html><p>downloaded</p>' });
+  const digest = await sha256(buffer);
+  const assetUrl = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/v3.3.5/press-system-v3.3.5.zip';
+  let apiCalls = 0;
+  let assetCalls = 0;
+
+  globalThis.fetch = async (input) => {
+    const url = String(input || '');
+    if (url.includes('/repos/EkilyHQ/Press/releases/latest')) {
+      apiCalls += 1;
+      return jsonResponse({ message: 'api should not be needed' });
+    }
+    if (url.includes('assets/system-release.json')) {
+      return jsonResponse({
+        schemaVersion: 1,
+        name: 'v3.3.5',
+        tag: 'v3.3.5',
+        publishedAt: '2026-04-29T08:18:39Z',
+        notes: 'Manifest release notes',
+        htmlUrl: 'https://github.com/EkilyHQ/Press/releases/tag/v3.3.5',
+        asset: {
+          name: 'press-system-v3.3.5.zip',
+          url: assetUrl,
+          size: buffer.byteLength,
+          digest: `sha256:${digest}`
+        }
+      });
+    }
+    if (url === assetUrl) {
+      assetCalls += 1;
+      return arrayBufferResponse(buffer);
+    }
+    return {
+      ok: false,
+      arrayBuffer: async () => new ArrayBuffer(0)
+    };
+  };
+
+  await stageLatestSystemUpdate();
+
+  const files = getSystemUpdateCommitFiles();
+  assert.equal(apiCalls, 0);
+  assert.equal(assetCalls, 1);
+  assert.deepEqual(files.map((file) => file.path), ['index.html']);
+  assert.equal(files[0].kind, 'system');
+  delete globalThis.fetch;
+});
+
+await run('keeps manual fallback available when automatic download fails', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  const assetUrl = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/v3.3.5/press-system-v3.3.5.zip';
+
+  globalThis.fetch = async (input) => {
+    const url = String(input || '');
+    if (url.includes('assets/system-release.json')) {
+      return jsonResponse({
+        schemaVersion: 1,
+        name: 'v3.3.5',
+        tag: 'v3.3.5',
+        publishedAt: '2026-04-29T08:18:39Z',
+        notes: 'Manifest release notes',
+        htmlUrl: 'https://github.com/EkilyHQ/Press/releases/tag/v3.3.5',
+        asset: {
+          name: 'press-system-v3.3.5.zip',
+          url: assetUrl,
+          size: 123,
+          digest: 'sha256:535de2ddd3c612310760365196c21bb7ab7a5ffacbebb0dcdbd17f59bedc861a'
+        }
+      });
+    }
+    if (url === assetUrl) {
+      return arrayBufferResponse(new ArrayBuffer(0), { ok: false, status: 503 });
+    }
+    return {
+      ok: false,
+      arrayBuffer: async () => new ArrayBuffer(0)
+    };
+  };
+
+  await assert.rejects(
+    () => stageLatestSystemUpdate(),
+    /download|下载|ダウンロード/i
+  );
+  assert.deepEqual(getSystemUpdateCommitFiles(), []);
   delete globalThis.fetch;
 });
 

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -192,7 +192,7 @@ await run('hides stale release notes when no Press system package is attached', 
   }), 'Use `press-system-v3.3.37.zip`.');
 });
 
-await run('uses the static release manifest before the GitHub API', async () => {
+await run('uses the static manifest artifact when the GitHub API tag matches', async () => {
   clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
   const buffer = makeZip({ 'press-system-v3.3.5/index.html': '<!doctype html><p>manifest</p>' });
   const digest = await sha256(buffer);
@@ -203,10 +203,15 @@ await run('uses the static release manifest before the GitHub API', async () => 
     const url = String(input || '');
     if (url.includes('/repos/EkilyHQ/Press/releases/latest')) {
       apiCalls += 1;
-      return jsonResponse({ message: 'rate limited' }, {
-        ok: false,
-        status: 403,
-        headers: { 'x-ratelimit-remaining': '0' }
+      return jsonResponse({
+        name: 'v3.3.5',
+        tag_name: 'v3.3.5',
+        assets: [{
+          name: 'press-system-v3.3.5.zip',
+          browser_download_url: 'https://github.com/EkilyHQ/Press/releases/download/v3.3.5/press-system-v3.3.5.zip',
+          size: buffer.byteLength,
+          digest: `sha256:${digest}`
+        }]
       });
     }
     if (url.includes('assets/system-release.json')) {
@@ -234,8 +239,68 @@ await run('uses the static release manifest before the GitHub API', async () => 
 
   await analyzeArchive(buffer, 'press-system-v3.3.5.zip');
 
-  assert.equal(apiCalls, 0);
+  assert.equal(apiCalls, 1);
   assert.equal(manifestCalls, 1);
+  delete globalThis.fetch;
+});
+
+await run('uses GitHub API metadata when the static manifest is stale', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  const oldBuffer = makeZip({ 'press-system-v3.3.5/index.html': '<!doctype html><p>old</p>' });
+  const newBuffer = makeZip({ 'press-system-v3.3.6/index.html': '<!doctype html><p>new</p>' });
+  const oldDigest = await sha256(oldBuffer);
+  const newDigest = await sha256(newBuffer);
+  const oldAssetUrl = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/v3.3.5/press-system-v3.3.5.zip';
+  let oldAssetCalls = 0;
+
+  globalThis.fetch = async (input) => {
+    const url = String(input || '');
+    if (url.includes('/repos/EkilyHQ/Press/releases/latest')) {
+      return jsonResponse({
+        name: 'v3.3.6',
+        tag_name: 'v3.3.6',
+        assets: [{
+          name: 'press-system-v3.3.6.zip',
+          browser_download_url: 'https://github.com/EkilyHQ/Press/releases/download/v3.3.6/press-system-v3.3.6.zip',
+          size: newBuffer.byteLength,
+          digest: `sha256:${newDigest}`
+        }]
+      });
+    }
+    if (url.includes('assets/system-release.json')) {
+      return jsonResponse({
+        schemaVersion: 1,
+        name: 'v3.3.5',
+        tag: 'v3.3.5',
+        publishedAt: '2026-04-29T08:18:39Z',
+        notes: 'Old manifest release notes',
+        htmlUrl: 'https://github.com/EkilyHQ/Press/releases/tag/v3.3.5',
+        asset: {
+          name: 'press-system-v3.3.5.zip',
+          url: oldAssetUrl,
+          size: oldBuffer.byteLength,
+          digest: `sha256:${oldDigest}`
+        }
+      });
+    }
+    if (url === oldAssetUrl) {
+      oldAssetCalls += 1;
+      return arrayBufferResponse(oldBuffer);
+    }
+    return {
+      ok: false,
+      arrayBuffer: async () => new ArrayBuffer(0)
+    };
+  };
+
+  await analyzeArchive(newBuffer, 'press-system-v3.3.6.zip');
+  assert.deepEqual(getSystemUpdateCommitFiles().map((file) => file.path), ['index.html']);
+  assert.equal(oldAssetCalls, 0);
+  await assert.rejects(
+    () => stageLatestSystemUpdate(),
+    /download|下载|ダウンロード/i
+  );
+  assert.equal(oldAssetCalls, 0);
   delete globalThis.fetch;
 });
 
@@ -248,10 +313,6 @@ await run('falls back to the GitHub API when the static manifest is unavailable'
 
   globalThis.fetch = async (input) => {
     const url = String(input || '');
-    if (url.includes('assets/system-release.json')) {
-      manifestCalls += 1;
-      return jsonResponse({ message: 'not found' }, { ok: false, status: 404 });
-    }
     if (url.includes('/repos/EkilyHQ/Press/releases/latest')) {
       apiCalls += 1;
       return jsonResponse({
@@ -264,6 +325,10 @@ await run('falls back to the GitHub API when the static manifest is unavailable'
           digest: `sha256:${digest}`
         }]
       });
+    }
+    if (url.includes('assets/system-release.json')) {
+      manifestCalls += 1;
+      return jsonResponse({ message: 'not found' }, { ok: false, status: 404 });
     }
     return {
       ok: false,
@@ -331,7 +396,16 @@ await run('downloads the manifest asset and stages system files', async () => {
     const url = String(input || '');
     if (url.includes('/repos/EkilyHQ/Press/releases/latest')) {
       apiCalls += 1;
-      return jsonResponse({ message: 'api should not be needed' });
+      return jsonResponse({
+        name: 'v3.3.5',
+        tag_name: 'v3.3.5',
+        assets: [{
+          name: 'press-system-v3.3.5.zip',
+          browser_download_url: 'https://github.com/EkilyHQ/Press/releases/download/v3.3.5/press-system-v3.3.5.zip',
+          size: buffer.byteLength,
+          digest: `sha256:${digest}`
+        }]
+      });
     }
     if (url.includes('assets/system-release.json')) {
       return jsonResponse({
@@ -362,7 +436,7 @@ await run('downloads the manifest asset and stages system files', async () => {
   await stageLatestSystemUpdate();
 
   const files = getSystemUpdateCommitFiles();
-  assert.equal(apiCalls, 0);
+  assert.equal(apiCalls, 1);
   assert.equal(assetCalls, 1);
   assert.deepEqual(files.map((file) => file.path), ['index.html']);
   assert.equal(files[0].kind, 'system');

--- a/scripts/test-system-updates.js
+++ b/scripts/test-system-updates.js
@@ -304,6 +304,62 @@ await run('uses GitHub API metadata when the static manifest is stale', async ()
   delete globalThis.fetch;
 });
 
+await run('uses newer fetchable manifest metadata when the GitHub API lags', async () => {
+  clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
+  const oldBuffer = makeZip({ 'press-system-v3.3.5/index.html': '<!doctype html><p>old</p>' });
+  const newBuffer = makeZip({ 'press-system-v3.3.6/index.html': '<!doctype html><p>new</p>' });
+  const oldDigest = await sha256(oldBuffer);
+  const newDigest = await sha256(newBuffer);
+  const newAssetUrl = 'https://raw.githubusercontent.com/EkilyHQ/Press/release-artifacts/v3.3.6/press-system-v3.3.6.zip';
+  let newAssetCalls = 0;
+
+  globalThis.fetch = async (input) => {
+    const url = String(input || '');
+    if (url.includes('/repos/EkilyHQ/Press/releases/latest')) {
+      return jsonResponse({
+        name: 'v3.3.5',
+        tag_name: 'v3.3.5',
+        assets: [{
+          name: 'press-system-v3.3.5.zip',
+          browser_download_url: 'https://github.com/EkilyHQ/Press/releases/download/v3.3.5/press-system-v3.3.5.zip',
+          size: oldBuffer.byteLength,
+          digest: `sha256:${oldDigest}`
+        }]
+      });
+    }
+    if (url.includes('assets/system-release.json')) {
+      return jsonResponse({
+        schemaVersion: 1,
+        name: 'v3.3.6',
+        tag: 'v3.3.6',
+        publishedAt: '2026-04-29T08:18:39Z',
+        notes: 'New manifest release notes',
+        htmlUrl: 'https://github.com/EkilyHQ/Press/releases/tag/v3.3.6',
+        asset: {
+          name: 'press-system-v3.3.6.zip',
+          url: newAssetUrl,
+          size: newBuffer.byteLength,
+          digest: `sha256:${newDigest}`
+        }
+      });
+    }
+    if (url === newAssetUrl) {
+      newAssetCalls += 1;
+      return arrayBufferResponse(newBuffer);
+    }
+    return {
+      ok: false,
+      arrayBuffer: async () => new ArrayBuffer(0)
+    };
+  };
+
+  await stageLatestSystemUpdate();
+
+  assert.equal(newAssetCalls, 1);
+  assert.deepEqual(getSystemUpdateCommitFiles().map((file) => file.path), ['index.html']);
+  delete globalThis.fetch;
+});
+
 await run('falls back to the GitHub API when the static manifest is unavailable', async () => {
   clearSystemUpdateState({ clearReleaseCache: true, keepStatus: true });
   const buffer = makeZip({ 'press-system-v3.3.5/index.html': '<!doctype html><p>api</p>' });


### PR DESCRIPTION
## Summary

- Publish system update ZIPs to a CORS-readable `release-artifacts` branch and write the raw artifact URL into `assets/system-release.json`.
- Make the Press Updates panel manifest-first and add a one-click "Download and check" path that downloads, verifies, compares, and stages system files through the existing sync flow.
- Keep manual ZIP selection as fallback and preserve the current system-update file boundary.

## Impact

After the first release containing this change is manually applied, later Press system updates can be staged from the editor without manually downloading and selecting the ZIP. The release manifest schema stays at version 1; only `asset.url` changes to a fetchable artifact URL.

## Validation

- `node --experimental-default-type=module scripts/test-system-updates.js`
- `bash scripts/test-system-release-workflow.sh`
- `bash scripts/test-system-release-package.sh`
- `node --experimental-default-type=module scripts/test-theme-manager.js`
- `bash scripts/test-main-guard.sh`
- `git diff --check`
- Ruby YAML parse for `.github/workflows/system-release.yml`