### PR TITLE
[codex] Autofill YAP starter repository config

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -431,6 +431,29 @@ function isPlaceholderRepoConfig(repo) {
   return ownerIsPlaceholder && nameIsPlaceholder;
 }
 
+function isSameRepoConfig(repo, inferred) {
+  const source = repo && typeof repo === 'object' ? repo : {};
+  const inferredSource = inferred && typeof inferred === 'object' ? inferred : {};
+  const owner = String(source.owner || '').trim().toLowerCase();
+  const name = String(source.name || '').trim().toLowerCase();
+  const inferredOwner = String(inferredSource.owner || '').trim().toLowerCase();
+  const inferredName = String(inferredSource.name || '').trim().toLowerCase();
+  return !!owner && !!name && owner === inferredOwner && name === inferredName;
+}
+
+function shouldAutofillRepoFromPages(site) {
+  const extras = site && site.__extras && typeof site.__extras === 'object' ? site.__extras : {};
+  const value = extras.repoAutofillFromPages;
+  return value === true || String(value || '').trim().toLowerCase() === 'true';
+}
+
+function clearRepoAutofillFromPagesMarker(site) {
+  if (!site.__extras || typeof site.__extras !== 'object') return;
+  if (Object.prototype.hasOwnProperty.call(site.__extras, 'repoAutofillFromPages')) {
+    delete site.__extras.repoAutofillFromPages;
+  }
+}
+
 function applyInferredRepoConfig(site, inferred) {
   if (!site || typeof site !== 'object') return false;
   if (!inferred || typeof inferred !== 'object') return false;
@@ -440,7 +463,9 @@ function applyInferredRepoConfig(site, inferred) {
   if (!owner || !name) return false;
 
   const repo = site.repo && typeof site.repo === 'object' ? site.repo : {};
-  if (!isPlaceholderRepoConfig(repo)) return false;
+  const canAutofill = isPlaceholderRepoConfig(repo)
+    || (shouldAutofillRepoFromPages(site) && !isSameRepoConfig(repo, inferred));
+  if (!canAutofill) return false;
 
   const previousOwner = String(repo.owner || '').trim();
   const previousName = String(repo.name || '').trim();
@@ -449,6 +474,7 @@ function applyInferredRepoConfig(site, inferred) {
   repo.owner = owner;
   repo.name = name;
   if (!previousBranch) repo.branch = branch;
+  clearRepoAutofillFromPagesMarker(site);
 
   return previousOwner !== String(repo.owner || '').trim()
     || previousName !== String(repo.name || '').trim()

--- a/index_editor.html
+++ b/index_editor.html
@@ -2409,7 +2409,7 @@
   </script>
   <script type="module" src="assets/js/editor-boot.js?v=theme-manager-20260507"></script>
   <script type="module" src="assets/js/editor-main.js?v=theme-manager-20260507"></script>
-  <script type="module" src="assets/js/composer.js?v=scoped-editor-state-20260507"></script>
+  <script type="module" src="assets/js/composer.js?v=repo-autofill-marker-20260507"></script>
   <!-- Back to top button -->
   <button id="backToTop" class="back-to-top" aria-label="返回顶部" title="返回顶部" type="button" hidden>
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -75,6 +75,9 @@ function loadRepoInferenceHelpers() {
     extractFunctionDeclaration(source, 'resolveEditorStorageScope'),
     extractFunctionDeclaration(source, 'inferRepoConfigFromGitHubPagesUrl'),
     extractFunctionDeclaration(source, 'isPlaceholderRepoConfig'),
+    extractFunctionDeclaration(source, 'isSameRepoConfig'),
+    extractFunctionDeclaration(source, 'shouldAutofillRepoFromPages'),
+    extractFunctionDeclaration(source, 'clearRepoAutofillFromPagesMarker'),
     extractFunctionDeclaration(source, 'applyInferredRepoConfig')
   ].join('\n');
   return Function(`${helpers}\nreturn { resolveEditorStorageScope, inferRepoConfigFromGitHubPagesUrl, isPlaceholderRepoConfig, applyInferredRepoConfig };`)();
@@ -96,8 +99,8 @@ assert.doesNotMatch(
 
 assert.match(
   editorSource,
-  /assets\/js\/composer\.js\?v=scoped-editor-state-20260507/,
-  'editor HTML should cache-bust composer.js when editor storage scoping changes'
+  /assets\/js\/composer\.js\?v=repo-autofill-marker-20260507/,
+  'editor HTML should cache-bust composer.js when repository autofill marker handling changes'
 );
 
 assert.notEqual(
@@ -205,6 +208,44 @@ assert.equal(
     'empty starter repositories should accept inferred owner and name'
   );
   assert.deepEqual(site.repo, { owner: 'deemoe404', name: 'test1', branch: 'docs' });
+}
+
+{
+  const site = { repo: { owner: 'EkilyHQ', name: 'YAP', branch: 'main' } };
+  assert.equal(
+    repoInference.applyInferredRepoConfig(site, { owner: 'deemoe404', name: 'test1', branch: 'main' }),
+    false,
+    'real YAP repository settings should be preserved without an explicit autofill marker'
+  );
+  assert.deepEqual(site.repo, { owner: 'EkilyHQ', name: 'YAP', branch: 'main' });
+}
+
+{
+  const site = {
+    repo: { owner: 'EkilyHQ', name: 'YAP', branch: 'main' },
+    __extras: { repoAutofillFromPages: true }
+  };
+  assert.equal(
+    repoInference.applyInferredRepoConfig(site, { owner: 'deemoe404', name: 'test1', branch: 'main' }),
+    true,
+    'explicit repo autofill markers should accept inferred repo config on derived Pages sites'
+  );
+  assert.deepEqual(site.repo, { owner: 'deemoe404', name: 'test1', branch: 'main' });
+  assert.deepEqual(site.__extras, {}, 'repo autofill marker should be removed after first use');
+}
+
+{
+  const site = {
+    repo: { owner: 'EkilyHQ', name: 'YAP', branch: 'main' },
+    __extras: { repoAutofillFromPages: true }
+  };
+  assert.equal(
+    repoInference.applyInferredRepoConfig(site, { owner: 'ekilyhq', name: 'YAP', branch: 'main' }),
+    false,
+    'repo autofill markers should not dirty sites when the URL already matches'
+  );
+  assert.deepEqual(site.repo, { owner: 'EkilyHQ', name: 'YAP', branch: 'main' });
+  assert.deepEqual(site.__extras, { repoAutofillFromPages: true });
 }
 
 {


### PR DESCRIPTION
## Summary

- Keep the existing placeholder autofill behavior for empty or `OWNER` / `REPOSITORY` starter repo config.
- Add an explicit `repoAutofillFromPages: true` site marker for templates that need one-time Pages URL repo inference while preserving intentionally configured real repos such as `EkilyHQ/YAP`.
- Remove the autofill marker after it is used, bump the editor `composer.js` cache key, and add focused regression coverage for marker-based autofill plus intentional YAP preservation.

## Root cause

YAP now ships with a real-looking `site.yaml` repo block (`EkilyHQ/YAP`) instead of the old `OWNER` / `REPOSITORY` placeholders. Treating that real repository as an implicit placeholder fixed the starter case but made intentional `EkilyHQ/YAP` settings impossible to persist on other GitHub Pages sites. This update switches the non-placeholder path to explicit marker-based opt-in.

## Validation

- `node --experimental-default-type=module scripts/test-composer-identity-grid.js`
- `bash scripts/test-main-guard.sh`
- `node --check assets/js/composer.js`
- `git diff --check HEAD`