### PR TITLE
[codex] Fix code scanning alerts

### DIFF
--- a/.github/workflows/main-guard.yml
+++ b/.github/workflows/main-guard.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   guard:
     runs-on: ubuntu-latest

--- a/assets/js/components.js
+++ b/assets/js/components.js
@@ -52,6 +52,14 @@ function hasAssignedSlot(element, name) {
   }
 }
 
+function slottedNodeHtml(node) {
+  if (!node) return '';
+  const outerHtml = typeof node.outerHTML === 'string' ? node.outerHTML : '';
+  if (outerHtml) return outerHtml;
+  // Text-only fallbacks are text content, not explicit theme markup.
+  return safe(node.textContent || '');
+}
+
 export class PressSearch extends HTMLElement {
   static get observedAttributes() {
     return ['placeholder', 'value', 'label', 'field-class', 'icon-class', 'icon', 'use-shadow', 'render-root'];
@@ -841,7 +849,7 @@ export class PressPostCard extends HTMLElement {
       const template = this.querySelector(`template[data-slot="${name}"], template[slot="${name}"]`);
       const slotted = Array.from(this.querySelectorAll(`[slot="${name}"]`))
         .filter((node) => node.tagName !== 'TEMPLATE')
-        .map((node) => node.outerHTML || node.textContent || '')
+        .map((node) => slottedNodeHtml(node))
         .join('');
       const html = template ? (template.innerHTML || '') : slotted;
       if (name === 'cover' && html) this._coverHtml = html;

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -4519,7 +4519,7 @@ function buildDefaultIndexHtml(metaBlock, lang) {
   html += '  <link rel="stylesheet" id="theme-pack">\n';
   html += '</head>\n\n';
   html += '<body>\n';
-  html += '  <script type="module" src="assets/main.js?v=theme-manager-20260507"></script>\n';
+  html += '  <script type="module" src="assets/main.js?v=post-card-slot-safety-20260507"></script>\n';
   html += '</body>\n\n';
   html += '</html>\n';
   return html;

--- a/index.html
+++ b/index.html
@@ -18,6 +18,6 @@
   <link rel="stylesheet" id="theme-pack">
 </head>
 <body>
-  <script type="module" src="assets/main.js?v=theme-manager-20260507"></script>
+  <script type="module" src="assets/main.js?v=post-card-slot-safety-20260507"></script>
 </body>
 </html>

--- a/scripts/test-post-card-slot-safety.js
+++ b/scripts/test-post-card-slot-safety.js
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+
+globalThis.window = {};
+globalThis.document = { title: 'Press' };
+globalThis.customElements = {
+  get() { return null; },
+  define() {}
+};
+globalThis.HTMLElement = class {
+  constructor() {
+    this._attributes = new Map();
+    this.style = {};
+    this.shadowRoot = null;
+    this.innerHTML = '';
+  }
+
+  setAttribute(name, value) {
+    this._attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    return this._attributes.has(name) ? this._attributes.get(name) : null;
+  }
+
+  hasAttribute(name) {
+    return this._attributes.has(name);
+  }
+
+  attachShadow() {
+    this.shadowRoot = { innerHTML: '' };
+    return this.shadowRoot;
+  }
+
+  addEventListener() {}
+  removeEventListener() {}
+  contains() { return false; }
+  querySelector() { return null; }
+  querySelectorAll() { return []; }
+};
+
+const { PressPostCard } = await import('../assets/js/components.js');
+
+function makeCard({ shadow = false, templateHtml = null, nodes = [] } = {}) {
+  const card = new PressPostCard();
+  card.setAttribute('title', 'Slot safety');
+  card.querySelector = (selector) => {
+    if (templateHtml == null || !selector.includes('cover')) return null;
+    return { innerHTML: templateHtml };
+  };
+  card.querySelectorAll = (selector) => selector.includes('cover') ? nodes : [];
+  if (shadow) card.setAttribute('use-shadow', '');
+  return card;
+}
+
+const textOnlySlot = Object.freeze({
+  tagName: 'SPAN',
+  outerHTML: '',
+  textContent: '<img src=x onerror=alert(1)>'
+});
+const lightCard = makeCard({ nodes: [textOnlySlot] });
+lightCard.render();
+assert.match(lightCard.innerHTML, /&lt;img src=x onerror=alert\(1\)&gt;/, 'light DOM text-only slot fallback should be escaped');
+assert.doesNotMatch(lightCard.innerHTML, /<img src=x onerror=alert\(1\)>/, 'light DOM text-only slot fallback should not become markup');
+
+const shadowCard = makeCard({ shadow: true, nodes: [textOnlySlot] });
+shadowCard.render();
+assert.match(shadowCard.shadowRoot.innerHTML, /&lt;img src=x onerror=alert\(1\)&gt;/, 'shadow DOM text-only slot fallback should be escaped');
+assert.doesNotMatch(shadowCard.shadowRoot.innerHTML, /<img src=x onerror=alert\(1\)>/, 'shadow DOM text-only slot fallback should not become markup');
+
+const elementSlot = Object.freeze({
+  tagName: 'SPAN',
+  outerHTML: '<span class="badge"><strong>Draft</strong></span>',
+  textContent: '<strong>ignored</strong>'
+});
+const elementCard = makeCard({ nodes: [elementSlot] });
+elementCard.render();
+assert.match(elementCard.innerHTML, /<span class="badge"><strong>Draft<\/strong><\/span>/, 'slotted element HTML should keep existing markup semantics');
+
+const templateCard = makeCard({ templateHtml: '<picture><img src="cover.jpg" alt=""></picture>' });
+templateCard.render();
+assert.match(templateCard.innerHTML, /<picture><img src="cover\.jpg" alt=""><\/picture>/, 'template slot HTML should remain explicit theme markup');
+
+console.log('ok - post card slot safety');

--- a/scripts/test-ui-components.js
+++ b/scripts/test-ui-components.js
@@ -79,8 +79,8 @@ assert.ok(tocMapSet < tocBoundGuard, 'press-toc should rebuild _idToLink before 
 
 assert.match(main, /import '\.\/js\/components\.js';/, 'main should register custom elements before theme layout mounting');
 assert.match(main, /from '\.\/js\/i18n\.js\?v=20260506theme';/, 'main should use the same versioned i18n module instance as shared UI modules');
-assert.match(indexHtml, /src="assets\/main\.js\?v=20260506theme"/, 'index should bump the main module URL when runtime imports change');
-assert.match(composer, /src="assets\/main\.js\?v=20260506theme"/, 'composer export template should use the same main module URL as index');
+assert.match(indexHtml, /src="assets\/main\.js\?v=post-card-slot-safety-20260507"/, 'index should bump the main module URL when runtime imports change');
+assert.match(composer, /src="assets\/main\.js\?v=post-card-slot-safety-20260507"/, 'composer export template should use the same main module URL as index');
 assert.match(search, /addEventListener\('press:search'[\s\S]*navigateSearch/, 'search routing should listen for press:search');
 assert.doesNotMatch(search, /input\.onkeydown\s*=/, 'search.js should not own the component input via onkeydown');
 assert.match(read('assets/js/tags.js'), /press:tag-select/, 'tag sidebar should emit press:tag-select');


### PR DESCRIPTION
## Summary

Fixes the three open CodeQL code-scanning alerts on `main` without changing intended Press behavior.

- Escape text-only `press-post-card` slot fallbacks before they are rendered through the card HTML path.
- Preserve existing explicit template and slotted element markup semantics for theme-authored card slots.
- Add the minimal `contents: read` workflow permission to the Main Guard workflow.
- Bump the runtime entrypoint query in `index.html` and the composer export template so deployed sites load the fixed `components.js`.

## Root Cause

`PressPostCard` preserved slotted element HTML for theme slots, but its `textContent` fallback was also fed into the same HTML rendering path. Text-only fallback content could therefore be reinterpreted as markup. The workflow alert came from an implicit default `GITHUB_TOKEN` permission set in `.github/workflows/main-guard.yml`.

## Validation

- `node --experimental-default-type=module scripts/test-post-card-slot-safety.js`
- `node --experimental-default-type=module scripts/test-ui-components.js`
- `bash scripts/test-main-guard.sh`
- `node --experimental-default-type=module scripts/test-theme-contracts.js`
- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-system-release-workflow.sh`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `node --experimental-default-type=module scripts/test-theme-manager.js`
- `node scripts/test-content-model.js`
- `bash scripts/test-frontmatter-roundtrip.sh`
- `git diff --check`