### PR TITLE
Block deletion-only markdown drafts

### DIFF
--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -5286,7 +5286,8 @@ function collectDirtyMarkdownPathsForDeletion() {
         if (!entry || typeof entry !== 'object') return;
         const hasContent = entry.content != null && normalizeMarkdownContent(entry.content);
         const hasAssets = Array.isArray(entry.assets) && entry.assets.length;
-        if (hasContent || hasAssets) paths.add(key);
+        const hasDeletedAssets = draftHasAssetDeletions(entry);
+        if (hasContent || hasAssets || hasDeletedAssets) paths.add(key);
       });
     }
   } catch (_) {}

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -1793,6 +1793,12 @@ assert.match(
 
 assert.match(
   source,
+  /function collectDirtyMarkdownPathsForDeletion\(\) \{[\s\S]*const hasContent = entry\.content != null && normalizeMarkdownContent\(entry\.content\);[\s\S]*const hasAssets = Array\.isArray\(entry\.assets\) && entry\.assets\.length;[\s\S]*const hasDeletedAssets = draftHasAssetDeletions\(entry\);[\s\S]*if \(hasContent \|\| hasAssets \|\| hasDeletedAssets\) paths\.add\(key\);/,
+  'repository deletion blockers should treat stored deletion-only asset drafts as pending local draft state'
+);
+
+assert.match(
+  source,
   /const markdownDeletedAssetStore = new Map\(\);[\s\S]*function normalizeAssetDeletionDescriptor\(asset, markdownPath\) \{[\s\S]*resolveLocalMarkdownAssetReference\(markdown, relativePath, getContentRootSafe\(\)\)[\s\S]*if \(assetPath && assetPath !== resolved\.contentPath\) return null;[\s\S]*function stageMarkdownAssetDeletion\(path, resolved\) \{[\s\S]*bucket\.set\(assetPath, entry\);[\s\S]*updateMarkdownDraftStoreAssetDeletions\(norm, exportMarkdownAssetDeletionBucket\(norm\)\);[\s\S]*function handleEditorAssetDeleteRequested\(event\) \{[\s\S]*resolveLocalMarkdownAssetReference\(markdownPath, source, getContentRootSafe\(\)\)[\s\S]*stageMarkdownAssetDeletion\(markdownPath, resolved\)[\s\S]*window\.addEventListener\('press-editor-asset-delete-requested', handleEditorAssetDeleteRequested\);/,
   'composer should stage and persist explicit local markdown asset deletions from visual image blocks'
 );


### PR DESCRIPTION
## Summary

Fixes the deletion blocker gap from the repository-deletion follow-up review: stored Markdown drafts that only contain `deletedAssets` are now treated as pending local draft state when planning managed content file deletions.

## Root Cause

`collectDirtyMarkdownPathsForDeletion()` only looked at stored draft `content` and `assets`. A closed Markdown tab with only staged image-resource deletions could be missed, allowing Publish to delete the Markdown file and clean up pending local draft metadata.

## Changes

- Includes `deletedAssets` in stored draft dirty-path collection for repository deletion planning.
- Adds a composer contract regression so deletion-only asset drafts remain part of the deletion blocker path.

## Validation

- `node scripts/test-composer-identity-grid.js`
- `node scripts/test-repository-deletions.js`
- `node scripts/test-editor-content-tree.js`
- `node --experimental-default-type=module scripts/test-theme-manager.js`
- `node --experimental-default-type=module scripts/test-system-updates.js`
- `bash scripts/test-main-guard.sh`
- `bash scripts/test-frontmatter-roundtrip.sh`
- `node scripts/test-content-model.js`
- `bash scripts/test-system-release-package.sh`
- `bash scripts/test-system-release-workflow.sh`
- `git diff --check`
- Chrome local debug: opened `http://127.0.0.1:8100/index_editor.html`, confirmed editor load and no console errors

## Review

- Subagent deletion safety/path semantics review: no findings.
- Subagent regression/publish boundary review: no findings.