### PR TITLE
[codex] Disable Annotate until app permissions are approved

### DIFF
--- a/site.yaml
+++ b/site.yaml
@@ -74,7 +74,7 @@ repo:
   branch: main
 
 annotate:
-  enabled: true
+  enabled: false
   connectBaseUrl: https://connect-8mr.pages.dev
   discussionCategory: General
 


### PR DESCRIPTION
## Summary
- keep the Annotate runtime code merged
- temporarily disable the official Press docs site config because the production Connect API reports the GitHub App installation is missing Discussions permissions

## Validation
- bash scripts/test-main-guard.sh
- node --experimental-default-type=module scripts/test-annotate.js

## Deployment note
Once the Ekily Connect GitHub App has Repository Discussions: Read and write and the Press installation is re-approved, flip annotate.enabled back to true.