### PR TITLE
[codex] Enable Annotate on Press docs

### DIFF
--- a/site.yaml
+++ b/site.yaml
@@ -74,7 +74,7 @@ repo:
   branch: main
 
 annotate:
-  enabled: false
+  enabled: true
   connectBaseUrl: https://connect-8mr.pages.dev
   discussionCategory: General
 


### PR DESCRIPTION
## Summary
- re-enable Annotate for the official Press docs site now that GitHub Discussions is enabled and the App installation has Discussions permissions

## Validation
- bash scripts/test-main-guard.sh
- node --experimental-default-type=module scripts/test-annotate.js
- production Connect empty comments API returns 200 with an empty list for pressDocs / General
