### PR TITLE
[codex] Fix Annotate grant token storage

### DIFF
--- a/assets/js/annotate.js
+++ b/assets/js/annotate.js
@@ -148,7 +148,7 @@ function readStoredGrant(windowRef, config) {
     const raw = windowRef.localStorage.getItem(getGrantStorageKey(config));
     if (!raw) return '';
     const parsed = JSON.parse(raw);
-    return asTrimmedString(parsed && parsed.grant);
+    return normalizeGrantToken(parsed && parsed.grant);
   } catch (_) {
     return '';
   }
@@ -156,12 +156,20 @@ function readStoredGrant(windowRef, config) {
 
 function writeStoredGrant(windowRef, config, grant) {
   try {
-    windowRef.localStorage.setItem(getGrantStorageKey(config), JSON.stringify({ grant, savedAt: Date.now() }));
+    const token = normalizeGrantToken(grant);
+    if (!token) return;
+    windowRef.localStorage.setItem(getGrantStorageKey(config), JSON.stringify({ grant: token, savedAt: Date.now() }));
   } catch (_) {}
 }
 
 function clearStoredGrant(windowRef, config) {
   try { windowRef.localStorage.removeItem(getGrantStorageKey(config)); } catch (_) {}
+}
+
+export function normalizeGrantToken(grant) {
+  if (typeof grant === 'string') return grant.trim();
+  if (asObject(grant)) return asTrimmedString(grant.token);
+  return '';
 }
 
 function injectAnnotateStyle(documentRef) {
@@ -394,11 +402,12 @@ export function mountAnnotateComments(options = {}) {
     if (event.origin !== expected) return;
     const data = event.data || {};
     if (data.source !== 'ekily-connect' || data.type !== 'press-annotate-grant') return;
-    if (!data.ok || !data.grant) {
+    const grantToken = normalizeGrantToken(data.grant);
+    if (!data.ok || !grantToken) {
       setStatus('GitHub sign in failed.');
       return;
     }
-    state.grant = String(data.grant);
+    state.grant = grantToken;
     writeStoredGrant(windowRef, config, state.grant);
     setStatus('Signed in with GitHub.');
   });

--- a/scripts/test-annotate.js
+++ b/scripts/test-annotate.js
@@ -4,6 +4,7 @@ import {
   buildAnnotateCommentsUrl,
   isAnnotateEnabled,
   mountAnnotateComments,
+  normalizeGrantToken,
   normalizeAnnotateConfig,
   resolveAnnotateArticleContext
 } from '../assets/js/annotate.js';
@@ -117,6 +118,9 @@ assert.equal(config.connectBaseUrl, 'https://connect.example.com');
 assert.equal(config.repository.owner, 'EkilyHQ');
 assert.equal(isAnnotateEnabled(siteConfig), true);
 assert.equal(isAnnotateEnabled({ ...siteConfig, annotate: { enabled: false } }), false);
+assert.equal(normalizeGrantToken(' grant-token '), 'grant-token');
+assert.equal(normalizeGrantToken({ token: ' object-grant-token ', expiresAt: 123 }), 'object-grant-token');
+assert.equal(normalizeGrantToken({ expiresAt: 123 }), '');
 
 const context = resolveAnnotateArticleContext({
   rawIndex: {


### PR DESCRIPTION
## Summary
- read the opaque Annotate token from the callback grant object instead of stringifying the object
- keep stored grants as plain opaque token strings
- add focused coverage for string and object grant payloads

## Validation
- node --experimental-default-type=module scripts/test-annotate.js
- node --experimental-default-type=module scripts/test-ui-components.js
- bash scripts/test-main-guard.sh

## Bug
Before this fix, Press stored `String(data.grant)` from the Connect callback. Connect sends `{ token, expiresAt, owner, name }`, so comments were posted with `Bearer [object Object]` and always looked expired.