### PR TITLE
Add comments settings to editor

### DIFF
--- a/assets/i18n/chs.js
+++ b/assets/i18n/chs.js
@@ -572,6 +572,10 @@ const translations = {
               title: '主题',
               description: '设置访问者默认使用的主题方案。'
             },
+            comments: {
+              title: '评论区',
+              description: '配置由 Ekily Connect 支持的 Press Annotate 评论。'
+            },
             repo: {
               title: '仓库',
               description: '配置 GitHub 信息，以启用提交与“报告问题”链接。'
@@ -625,6 +629,12 @@ const translations = {
             themeOverrideHelp: '强制使用所选主题，忽略访问者的切换。',
             repo: 'GitHub 仓库',
             repoHelp: '用于提交、推送到 GitHub 以及“报告问题”链接。',
+            annotateEnabled: '文章评论',
+            annotateEnabledHelp: '在文章页底部启用评论区。',
+            annotateConnectBaseUrl: 'Connect URL',
+            annotateConnectBaseUrlHelp: '提供评论 API 的 Ekily Connect 部署基础地址。',
+            annotateDiscussionCategory: '讨论分类',
+            annotateDiscussionCategoryHelp: '用于文章评论主题的 GitHub Discussions 分类。',
             assetLargeImage: '大图警告',
             assetLargeImageHelp: '当附件图片超过阈值时提醒编辑。',
             assetLargeImageThreshold: '大图阈值（KB）',

--- a/assets/i18n/cht-tw.js
+++ b/assets/i18n/cht-tw.js
@@ -572,6 +572,10 @@ const translations = {
               title: '主題',
               description: '設定訪問者預設使用的主題方案。'
             },
+            comments: {
+              title: '評論區',
+              description: '配置由 Ekily Connect 支援的 Press Annotate 評論。'
+            },
             repo: {
               title: '儲存庫',
               description: '配置 GitHub 資訊，以啟用提交與“報告問題”連結。'
@@ -625,6 +629,12 @@ const translations = {
             themeOverrideHelp: '強制使用所選主題，忽略訪問者的切換。',
             repo: 'GitHub 儲存庫',
             repoHelp: '用於提交、推送到 GitHub 以及“報告問題”連結。',
+            annotateEnabled: '文章評論',
+            annotateEnabledHelp: '在文章頁底部啟用評論區。',
+            annotateConnectBaseUrl: 'Connect URL',
+            annotateConnectBaseUrlHelp: '提供評論 API 的 Ekily Connect 部署基礎地址。',
+            annotateDiscussionCategory: '討論分類',
+            annotateDiscussionCategoryHelp: '用於文章評論主題的 GitHub Discussions 分類。',
             assetLargeImage: '大圖警告',
             assetLargeImageHelp: '當附件圖片超過閾值時提醒編輯。',
             assetLargeImageThreshold: '大圖閾值（KB）',

--- a/assets/i18n/en.js
+++ b/assets/i18n/en.js
@@ -579,6 +579,10 @@ const translations = {
               title: 'Theme',
               description: 'Pick default theme settings applied to visitors.'
             },
+            comments: {
+              title: 'Comments',
+              description: 'Configure Press Annotate comments backed by Ekily Connect.'
+            },
             repo: {
               title: 'Repository',
               description: 'Configure GitHub details for commits and issue links.'
@@ -632,6 +636,12 @@ const translations = {
             themeOverrideHelp: 'Force the selected theme even if visitors change it.',
             repo: 'GitHub repository',
             repoHelp: 'Required for commits, push to GitHub, and issue links.',
+            annotateEnabled: 'Article comments',
+            annotateEnabledHelp: 'Enable comments below article pages.',
+            annotateConnectBaseUrl: 'Connect URL',
+            annotateConnectBaseUrlHelp: 'Base URL for the Ekily Connect deployment that serves comment APIs.',
+            annotateDiscussionCategory: 'Discussion category',
+            annotateDiscussionCategoryHelp: 'GitHub Discussions category used for article comment threads.',
             assetLargeImage: 'Warn about large images',
             assetLargeImageHelp: 'Show a warning when attached images exceed the threshold.',
             assetLargeImageThreshold: 'Large image threshold (KB)',

--- a/assets/i18n/ja.js
+++ b/assets/i18n/ja.js
@@ -572,6 +572,10 @@ const translations = {
               title: 'テーマ',
               description: '訪問者に適用される既定のテーマ設定です。'
             },
+            comments: {
+              title: 'コメント',
+              description: 'Ekily Connect による Press Annotate コメントを設定します。'
+            },
             repo: {
               title: 'リポジトリ',
               description: 'GitHub へのコミットや「問題を報告」リンクに必要な情報です。'
@@ -625,6 +629,12 @@ const translations = {
             themeOverrideHelp: '訪問者が変更しても選択したテーマを強制します。',
             repo: 'GitHub リポジトリ',
             repoHelp: 'コミット、GitHub へのプッシュ、問題報告リンクに必要です。',
+            annotateEnabled: '記事コメント',
+            annotateEnabledHelp: '記事ページの末尾にコメント欄を表示します。',
+            annotateConnectBaseUrl: 'Connect URL',
+            annotateConnectBaseUrlHelp: 'コメント API を提供する Ekily Connect デプロイのベース URL。',
+            annotateDiscussionCategory: 'Discussion カテゴリ',
+            annotateDiscussionCategoryHelp: '記事コメントのスレッドに使う GitHub Discussions カテゴリ。',
             assetLargeImage: '大きな画像の警告',
             assetLargeImageHelp: '添付画像がしきい値を超えた際に警告します。',
             assetLargeImageThreshold: '画像のしきい値 (KB)',

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -618,6 +618,7 @@ const SITE_FIELD_LABEL_MAP = {
   showAllPosts: { i18nKey: 'editor.composer.site.fields.showAllPosts' },
   landingTab: { i18nKey: 'editor.composer.site.fields.landingTab' },
   repo: { i18nKey: 'editor.composer.site.fields.repo' },
+  annotate: { i18nKey: 'editor.composer.site.sections.comments.title', fallback: 'Comments' },
   assetWarnings: { i18nKey: 'editor.composer.site.sections.assets.title', fallback: 'Asset warnings' },
   __extras: { i18nKey: 'editor.composer.site.fields.extras', fallback: 'Extras' }
 };
@@ -2662,6 +2663,12 @@ function prepareSiteState(raw) {
     name: safeString(repo.name || ''),
     branch: safeString(repo.branch || '')
   };
+  const annotate = (src.annotate && typeof src.annotate === 'object') ? src.annotate : {};
+  site.annotate = {
+    enabled: normalizeBoolean(annotate.enabled),
+    connectBaseUrl: safeString(annotate.connectBaseUrl || ''),
+    discussionCategory: safeString(annotate.discussionCategory || '')
+  };
   const assetWarnings = (src.assetWarnings && typeof src.assetWarnings === 'object') ? src.assetWarnings : {};
   const largeImage = (assetWarnings.largeImage && typeof assetWarnings.largeImage === 'object') ? assetWarnings.largeImage : {};
   site.assetWarnings = {
@@ -2674,7 +2681,7 @@ function prepareSiteState(raw) {
   const recognized = new Set([
     'siteTitle', 'siteSubtitle', 'siteDescription', 'siteKeywords', 'avatar', 'resourceURL', 'contentRoot',
     'profileLinks', 'contentOutdatedDays', 'cardCoverFallback', 'errorOverlay', 'pageSize', 'postsPerPage',
-    'defaultLanguage', 'themeMode', 'themePack', 'themeOverride', 'repo', 'assetWarnings', 'landingTab', 'showAllPosts',
+    'defaultLanguage', 'themeMode', 'themePack', 'themeOverride', 'repo', 'annotate', 'assetWarnings', 'landingTab', 'showAllPosts',
     'enableAllPosts', 'disableAllPosts', 'connect'
   ]);
   const deprecated = new Set(['links']);
@@ -2712,6 +2719,7 @@ function cloneSiteState(state) {
     showAllPosts: normalizeBoolean(state.showAllPosts),
     landingTab: safeString(state.landingTab || ''),
     repo: deepClone(state.repo || { owner: '', name: '', branch: '' }),
+    annotate: deepClone(state.annotate || { enabled: null, connectBaseUrl: '', discussionCategory: '' }),
     assetWarnings: deepClone(state.assetWarnings || { largeImage: { enabled: null, thresholdKB: null } }),
     __extras: deepClone(state.__extras || {})
   };
@@ -2782,6 +2790,19 @@ function repoForOutput(repo) {
   return Object.keys(out).length ? out : null;
 }
 
+function annotateForOutput(annotate) {
+  if (!annotate || typeof annotate !== 'object') return null;
+  const enabled = normalizeBoolean(annotate.enabled);
+  const connectBaseUrl = safeString(annotate.connectBaseUrl || '').trim();
+  const discussionCategory = safeString(annotate.discussionCategory || '').trim();
+  if (enabled == null && !connectBaseUrl && !discussionCategory) return null;
+  const out = {};
+  if (enabled != null) out.enabled = enabled;
+  if (connectBaseUrl) out.connectBaseUrl = connectBaseUrl;
+  if (discussionCategory) out.discussionCategory = discussionCategory;
+  return Object.keys(out).length ? out : null;
+}
+
 function buildSiteSnapshot(state) {
   const site = cloneSiteState(state);
   const snapshot = {};
@@ -2813,6 +2834,8 @@ function buildSiteSnapshot(state) {
   if (site.landingTab) snapshot.landingTab = site.landingTab;
   const repo = repoForOutput(site.repo);
   if (repo) snapshot.repo = repo;
+  const annotate = annotateForOutput(site.annotate);
+  if (annotate) snapshot.annotate = annotate;
   const warnings = assetWarningsForOutput(site.assetWarnings);
   if (warnings) snapshot.assetWarnings = warnings;
 
@@ -2926,6 +2949,17 @@ function computeSiteDiff(current, baseline) {
   if (safeString(repoCur.branch) !== safeString(repoBase.branch)) repoFields.branch = true;
   if (Object.keys(repoFields).length) {
     diff.fields.repo = { type: 'object', fields: repoFields };
+    diff.hasChanges = true;
+  }
+
+  const annotateCur = cur.annotate || {};
+  const annotateBase = base.annotate || {};
+  const annotateFields = {};
+  if (normalizeBoolean(annotateCur.enabled) !== normalizeBoolean(annotateBase.enabled)) annotateFields.enabled = true;
+  if (safeString(annotateCur.connectBaseUrl) !== safeString(annotateBase.connectBaseUrl)) annotateFields.connectBaseUrl = true;
+  if (safeString(annotateCur.discussionCategory) !== safeString(annotateBase.discussionCategory)) annotateFields.discussionCategory = true;
+  if (Object.keys(annotateFields).length) {
+    diff.fields.annotate = { type: 'object', fields: annotateFields };
     diff.hasChanges = true;
   }
 
@@ -3062,7 +3096,7 @@ function toSiteYaml(data) {
   const keysInOrder = [
     'siteTitle', 'siteSubtitle', 'siteDescription', 'siteKeywords', 'avatar', 'profileLinks', 'resourceURL',
     'contentRoot', 'contentOutdatedDays', 'cardCoverFallback', 'errorOverlay', 'pageSize', 'defaultLanguage',
-    'themeMode', 'themePack', 'themeOverride', 'showAllPosts', 'landingTab', 'repo', 'connect', 'assetWarnings'
+    'themeMode', 'themePack', 'themeOverride', 'showAllPosts', 'landingTab', 'repo', 'annotate', 'connect', 'assetWarnings'
   ];
   const ordered = {};
   keysInOrder.forEach((key) => {
@@ -16194,6 +16228,16 @@ function buildSiteUI(root, state) {
     return site.repo;
   };
 
+  const ensureAnnotate = () => {
+    if (!site.annotate || typeof site.annotate !== 'object') {
+      site.annotate = { enabled: null, connectBaseUrl: '', discussionCategory: '' };
+    }
+    if (!Object.prototype.hasOwnProperty.call(site.annotate, 'enabled')) site.annotate.enabled = null;
+    if (!Object.prototype.hasOwnProperty.call(site.annotate, 'connectBaseUrl')) site.annotate.connectBaseUrl = '';
+    if (!Object.prototype.hasOwnProperty.call(site.annotate, 'discussionCategory')) site.annotate.discussionCategory = '';
+    return site.annotate;
+  };
+
   const ensureAssetWarnings = () => {
     if (!site.assetWarnings || typeof site.assetWarnings !== 'object') site.assetWarnings = {};
     if (!site.assetWarnings.largeImage || typeof site.assetWarnings.largeImage !== 'object') {
@@ -17607,6 +17651,78 @@ function buildSiteUI(root, state) {
     syncSwitchState(checkbox, toggle, site.themeOverride, true);
   };
 
+  const renderAnnotateGrid = (section) => {
+    const annotate = ensureAnnotate();
+    const { addRow } = createSingleGridFieldset(section);
+    const rows = [];
+    const addAnnotateRow = (item) => {
+      const row = addRow(item, rows.length);
+      rows.push(row);
+      return row;
+    };
+
+    const { row: enabledRow, controlCell: enabledControl } = addAnnotateRow({
+      dataKey: 'annotate',
+      label: t('editor.composer.site.fields.annotateEnabled'),
+      description: t('editor.composer.site.fields.annotateEnabledHelp'),
+      checkboxLabel: t('editor.composer.site.toggleEnabled')
+    });
+    const { toggle, checkbox } = createSwitchControl(
+      enabledRow,
+      t('editor.composer.site.toggleEnabled'),
+      {
+        target: enabledControl,
+        classes: ['cs-single-grid-switch']
+      }
+    );
+    toggle.dataset.field = 'annotate';
+    toggle.dataset.subfield = 'enabled';
+    checkbox.addEventListener('change', () => {
+      annotate.enabled = checkbox.checked;
+      syncSwitchState(checkbox, toggle, checkbox.checked, true);
+      markDirty();
+    });
+    syncSwitchState(checkbox, toggle, annotate.enabled, true);
+
+    const createTextRow = (item) => {
+      const { controlCell, controlId } = addAnnotateRow(item);
+      const input = document.createElement('input');
+      input.id = controlId;
+      input.type = 'text';
+      input.className = 'cs-input';
+      input.dataset.field = 'annotate';
+      input.dataset.subfield = item.subfield;
+      input.value = item.get() || '';
+      input.placeholder = item.placeholder || '';
+      input.addEventListener('input', () => {
+        item.set(input.value);
+        markDirty();
+      });
+      controlCell.appendChild(input);
+      return input;
+    };
+
+    createTextRow({
+      dataKey: 'annotate',
+      subfield: 'connectBaseUrl',
+      label: t('editor.composer.site.fields.annotateConnectBaseUrl'),
+      description: t('editor.composer.site.fields.annotateConnectBaseUrlHelp'),
+      placeholder: 'https://connect.example.com',
+      get: () => annotate.connectBaseUrl,
+      set: (value) => { annotate.connectBaseUrl = value; }
+    });
+
+    createTextRow({
+      dataKey: 'annotate',
+      subfield: 'discussionCategory',
+      label: t('editor.composer.site.fields.annotateDiscussionCategory'),
+      description: t('editor.composer.site.fields.annotateDiscussionCategoryHelp'),
+      placeholder: 'General',
+      get: () => annotate.discussionCategory,
+      set: (value) => { annotate.discussionCategory = value; }
+    });
+  };
+
   const renderAssetWarningsGrid = (section) => {
     const warnings = ensureAssetWarnings();
     const { addRow } = createSingleGridFieldset(section);
@@ -18105,6 +18221,13 @@ function buildSiteUI(root, state) {
     t('editor.composer.site.sections.theme.description')
   );
   renderThemeGrid(themeSubsection);
+
+  const commentsSubsection = createConfigSubsection(
+    siteConfigSection,
+    t('editor.composer.site.sections.comments.title'),
+    t('editor.composer.site.sections.comments.description')
+  );
+  renderAnnotateGrid(commentsSubsection);
 
   const assetsSubsection = createConfigSubsection(
     siteConfigSection,

--- a/index_editor.html
+++ b/index_editor.html
@@ -2484,7 +2484,7 @@
   </script>
   <script type="module" src="assets/js/editor-boot.js?v=local-connect-settings-20260508"></script>
   <script type="module" src="assets/js/editor-main.js?v=katex-math-20260510"></script>
-  <script type="module" src="assets/js/composer.js?v=katex-math-20260510"></script>
+  <script type="module" src="assets/js/composer.js?v=annotate-settings-20260510"></script>
   <!-- Back to top button -->
   <button id="backToTop" class="back-to-top" aria-label="返回顶部" title="返回顶部" type="button" hidden>
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -111,8 +111,8 @@ assert.match(
 
 assert.match(
   editorSource,
-  /assets\/js\/composer\.js\?v=katex-math-20260510/,
-  'editor HTML should cache-bust composer.js when exported runtime and system update imports change'
+  /assets\/js\/composer\.js\?v=annotate-settings-20260510/,
+  'editor HTML should cache-bust composer.js when site settings UI changes'
 );
 
 assert.match(

--- a/scripts/test-ui-components.js
+++ b/scripts/test-ui-components.js
@@ -148,7 +148,7 @@ assert.match(themeLayout, /clearFailedThemeArtifacts\(pack\)/, 'theme layout fal
 assert.match(indexHtml, /src="assets\/js\/theme-boot\.js\?v=theme-switch-fix-20260508"/, 'index should cache-bust theme boot after external fallback changes');
 assert.match(indexEditorHtml, /src="assets\/js\/theme-boot\.js\?v=theme-switch-fix-20260508"/, 'editor should cache-bust theme boot after external fallback changes');
 assert.match(indexEditorHtml, /src="assets\/js\/editor-main\.js\?v=katex-math-20260510"/, 'editor should cache-bust editor-main after math wiring changes');
-assert.match(indexEditorHtml, /src="assets\/js\/composer\.js\?v=katex-math-20260510"/, 'editor should cache-bust composer after math update wiring changes');
+assert.match(indexEditorHtml, /src="assets\/js\/composer\.js\?v=annotate-settings-20260510"/, 'editor should cache-bust composer after site settings UI changes');
 assert.match(search, /addEventListener\('press:search'[\s\S]*navigateSearch/, 'search routing should listen for press:search');
 assert.doesNotMatch(search, /input\.onkeydown\s*=/, 'search.js should not own the component input via onkeydown');
 assert.match(read('assets/js/tags.js'), /press:tag-select/, 'tag sidebar should emit press:tag-select');


### PR DESCRIPTION
## Summary
- Add visual site settings controls for Press Annotate comments.
- Preserve annotate fields through site state normalization, YAML output, and diff highlighting.
- Bump the editor composer cache key and update related cache-bust assertions.

## Validation
- node --check assets/js/composer.js
- node --experimental-default-type=module scripts/test-composer-identity-grid.js
- node --experimental-default-type=module scripts/test-annotate.js
- node scripts/test-content-model.js
- node scripts/test-ui-components.js
- bash scripts/test-main-guard.sh
- bash scripts/test-system-release-package.sh
- bash scripts/test-system-release-workflow.sh