### PR TITLE
Add Annotate combobox defaults

### DIFF
--- a/assets/i18n/cht-hk.js
+++ b/assets/i18n/cht-hk.js
@@ -1,4 +1,4 @@
-import chtTwTranslations from './cht-tw.js?v=local-connect-settings-20260508';
+import chtTwTranslations from './cht-tw.js?v=annotate-i18n-20260510';
 
 export const languageMeta = { label: '繁體中文（香港）' };
 

--- a/assets/i18n/languages.json
+++ b/assets/i18n/languages.json
@@ -1,7 +1,7 @@
 [
-  { "value": "en", "label": "English", "module": "./en.js?v=local-connect-settings-20260508" },
-  { "value": "chs", "label": "简体中文", "module": "./chs.js?v=local-connect-settings-20260508" },
-  { "value": "cht-tw", "label": "正體中文（台灣）", "module": "./cht-tw.js?v=local-connect-settings-20260508" },
-  { "value": "cht-hk", "label": "繁體中文（香港）", "module": "./cht-hk.js?v=local-connect-settings-20260508" },
-  { "value": "ja", "label": "日本語", "module": "./ja.js?v=local-connect-settings-20260508" }
+  { "value": "en", "label": "English", "module": "./en.js?v=annotate-i18n-20260510" },
+  { "value": "chs", "label": "简体中文", "module": "./chs.js?v=annotate-i18n-20260510" },
+  { "value": "cht-tw", "label": "正體中文（台灣）", "module": "./cht-tw.js?v=annotate-i18n-20260510" },
+  { "value": "cht-hk", "label": "繁體中文（香港）", "module": "./cht-hk.js?v=annotate-i18n-20260510" },
+  { "value": "ja", "label": "日本語", "module": "./ja.js?v=annotate-i18n-20260510" }
 ]

--- a/assets/js/composer.js
+++ b/assets/js/composer.js
@@ -8,8 +8,8 @@ import {
   resolveSiteRepoConfig,
   parseYAML
 } from './yaml.js';
-import { t, getAvailableLangs, getLanguageLabel } from './i18n.js?v=local-connect-settings-20260508';
-import { generateSitemapData, resolveSiteBaseUrl } from './seo.js?v=local-connect-settings-20260508';
+import { t, getAvailableLangs, getLanguageLabel } from './i18n.js?v=annotate-i18n-20260510';
+import { generateSitemapData, resolveSiteBaseUrl } from './seo.js?v=annotate-i18n-20260510';
 import { initSystemUpdates, getSystemUpdateSummaryEntries, getSystemUpdateCommitFiles, clearSystemUpdateState } from './system-updates.js?v=katex-math-20260510';
 import { initThemeManager, getThemeManagerSummaryEntries, getThemeManagerCommitFiles, clearThemeManagerState } from './theme-manager.js?v=theme-switch-fix-20260508';
 import { buildEditorContentTree, findEditorContentTreeNode, flattenEditorContentTree } from './editor-content-tree.js?v=theme-manager-20260507';
@@ -251,6 +251,9 @@ const CONNECT_PUBLISH_MESSAGE_TYPE = 'press-connect-publish-authorized';
 const CONNECT_PUBLISH_PRESETS = [
   { value: 'https://connect-8mr.pages.dev', label: 'Ekily Connect' },
   { value: 'http://127.0.0.1:8788', label: 'Local Connect' }
+];
+const ANNOTATE_DISCUSSION_CATEGORY_PRESETS = [
+  { value: 'General', label: 'General' }
 ];
 
 let markdownPushButton = null;
@@ -17688,17 +17691,31 @@ function buildSiteUI(root, state) {
       const { controlCell, controlId } = addAnnotateRow(item);
       const input = document.createElement('input');
       input.id = controlId;
-      input.type = 'text';
+      input.type = item.type || 'text';
       input.className = 'cs-input';
       input.dataset.field = 'annotate';
       input.dataset.subfield = item.subfield;
       input.value = item.get() || '';
       input.placeholder = item.placeholder || '';
+      if (item.listId) input.setAttribute('list', item.listId);
+      input.spellcheck = false;
+      input.autocomplete = 'off';
       input.addEventListener('input', () => {
         item.set(input.value);
         markDirty();
       });
       controlCell.appendChild(input);
+      if (item.listId && Array.isArray(item.options)) {
+        const list = document.createElement('datalist');
+        list.id = item.listId;
+        item.options.forEach((entry) => {
+          const option = document.createElement('option');
+          option.value = entry.value;
+          option.label = entry.label || entry.value;
+          list.appendChild(option);
+        });
+        controlCell.appendChild(list);
+      }
       return input;
     };
 
@@ -17707,7 +17724,10 @@ function buildSiteUI(root, state) {
       subfield: 'connectBaseUrl',
       label: t('editor.composer.site.fields.annotateConnectBaseUrl'),
       description: t('editor.composer.site.fields.annotateConnectBaseUrlHelp'),
-      placeholder: 'https://connect.example.com',
+      type: 'url',
+      listId: 'siteAnnotateConnectBaseUrlPresets',
+      options: CONNECT_PUBLISH_PRESETS,
+      placeholder: CONNECT_PUBLISH_PRESETS[0].value,
       get: () => annotate.connectBaseUrl,
       set: (value) => { annotate.connectBaseUrl = value; }
     });
@@ -17717,6 +17737,8 @@ function buildSiteUI(root, state) {
       subfield: 'discussionCategory',
       label: t('editor.composer.site.fields.annotateDiscussionCategory'),
       description: t('editor.composer.site.fields.annotateDiscussionCategoryHelp'),
+      listId: 'siteAnnotateDiscussionCategoryPresets',
+      options: ANNOTATE_DISCUSSION_CATEGORY_PRESETS,
       placeholder: 'General',
       get: () => annotate.discussionCategory,
       set: (value) => { annotate.discussionCategory = value; }

--- a/assets/js/editor-boot.js
+++ b/assets/js/editor-boot.js
@@ -1,5 +1,5 @@
 import './cache-control.js';
-import { initI18n, t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=local-connect-settings-20260508';
+import { initI18n, t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=annotate-i18n-20260510';
 
 function applyAttributeTranslation(el, target, value) {
   if (value == null) return;

--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -19,7 +19,7 @@ import { applyLazyLoadingIn, hydratePostImages, hydratePostVideos } from './post
 import { hydrateInternalLinkCards } from './link-cards.js?v=encrypted-demo-20260508';
 import { applyLangHints } from './typography.js';
 import { fetchConfigWithYamlFallback, fetchMergedSiteConfig } from './yaml.js';
-import { t, withLangParam, loadContentJsonWithRaw, getCurrentLang, normalizeLangKey } from './i18n.js?v=local-connect-settings-20260508';
+import { t, withLangParam, loadContentJsonWithRaw, getCurrentLang, normalizeLangKey } from './i18n.js?v=annotate-i18n-20260510';
 import { resolveLocalMarkdownAssetReference } from './repository-deletions.js?v=asset-deletions-20260508';
 
 const LS_WRAP_KEY = 'press_editor_wrap_enabled';

--- a/assets/js/errors.js
+++ b/assets/js/errors.js
@@ -1,5 +1,5 @@
 // errors.js — lightweight global error overlay and reporter
-import { t } from './i18n.js?v=local-connect-settings-20260508';
+import { t } from './i18n.js?v=annotate-i18n-20260510';
 
 let reporterConfig = {
   reportUrl: null,

--- a/assets/js/i18n.js
+++ b/assets/js/i18n.js
@@ -14,7 +14,7 @@ import { isEncryptedMarkdown } from './encrypted-content.js?v=encrypted-demo-202
 import { getContentRoot } from './utils.js';
 import { fetchConfigWithYamlFallback } from './yaml.js';
 import { getThemeRegion } from './theme-regions.js';
-import enTranslations, { languageMeta as enLanguageMeta } from '../i18n/en.js?v=local-connect-settings-20260508';
+import enTranslations, { languageMeta as enLanguageMeta } from '../i18n/en.js?v=annotate-i18n-20260510';
 
 // Content fetch cache modes are normalized by cache-control.js.
 

--- a/assets/js/post-nav.js
+++ b/assets/js/post-nav.js
@@ -1,4 +1,4 @@
-import { withLangParam, t } from './i18n.js?v=local-connect-settings-20260508';
+import { withLangParam, t } from './i18n.js?v=annotate-i18n-20260510';
 import { escapeHtml } from './utils.js';
 
 export function renderPostNav(container, postsIndex, postname) {

--- a/assets/js/seo.js
+++ b/assets/js/seo.js
@@ -1,8 +1,8 @@
 // seo.js - Dynamic SEO meta tag management for client-side routing
 // This maintains SEO benefits while keeping the "no compilation needed" philosophy
 
-import { getCurrentLang, DEFAULT_LANG } from './i18n.js?v=local-connect-settings-20260508';
-import { getAvailableLangs } from './i18n.js?v=local-connect-settings-20260508';
+import { getCurrentLang, DEFAULT_LANG } from './i18n.js?v=annotate-i18n-20260510';
+import { getAvailableLangs } from './i18n.js?v=annotate-i18n-20260510';
 import { parseFrontMatter } from './content.js';
 
 function ensureTrailingSlash(value) {

--- a/assets/js/system-updates.js
+++ b/assets/js/system-updates.js
@@ -1,7 +1,7 @@
 import { mdParse } from './markdown.js?v=katex-math-20260510';
 import { renderPressMath } from './math-render.js?v=katex-math-20260510';
 import { setSafeHtml } from './safe-html.js?v=katex-math-20260510';
-import { t } from './i18n.js?v=local-connect-settings-20260508';
+import { t } from './i18n.js?v=annotate-i18n-20260510';
 import { unzipSync, strFromU8 } from './vendor/fflate.browser.js';
 
 const TEXT_EXTENSIONS = new Set([

--- a/assets/js/tags.js
+++ b/assets/js/tags.js
@@ -1,5 +1,5 @@
 // Tag utilities: aggregation, rendering (collapsible), and tooltips for truncated tags
-import { t, withLangParam } from './i18n.js?v=local-connect-settings-20260508';
+import { t, withLangParam } from './i18n.js?v=annotate-i18n-20260510';
 import { getThemeRegion } from './theme-regions.js';
 import { getQueryVariable, escapeHtml } from './utils.js';
 

--- a/assets/js/templates.js
+++ b/assets/js/templates.js
@@ -1,5 +1,5 @@
 // Template renderers (pure functions returning HTML strings)
-import { t } from './i18n.js?v=local-connect-settings-20260508';
+import { t } from './i18n.js?v=annotate-i18n-20260510';
 import { computeReadTime } from './content.js';
 import { escapeHtml, renderTags, formatDisplayDate } from './utils.js';
 

--- a/assets/js/theme-layout.js
+++ b/assets/js/theme-layout.js
@@ -13,7 +13,7 @@ import {
   ensureLanguageBundle,
   getAvailableLangs,
   getLanguageLabel
-} from './i18n.js?v=local-connect-settings-20260508';
+} from './i18n.js?v=annotate-i18n-20260510';
 import {
   createThemeRegionRegistry,
   ensureThemeRegionRegistry,

--- a/assets/js/theme-manager.js
+++ b/assets/js/theme-manager.js
@@ -1,4 +1,4 @@
-import { t } from './i18n.js?v=local-connect-settings-20260508';
+import { t } from './i18n.js?v=annotate-i18n-20260510';
 import { unzipSync, strFromU8 } from './vendor/fflate.browser.js';
 
 const THEME_ROOT = 'assets/themes';

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,4 +1,4 @@
-import { t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=local-connect-settings-20260508';
+import { t, getAvailableLangs, getLanguageLabel, getCurrentLang, switchLanguage, ensureLanguageBundle } from './i18n.js?v=annotate-i18n-20260510';
 import { getThemeRegion } from './theme-regions.js';
 
 const PACK_LINK_ID = 'theme-pack';

--- a/assets/js/toc.js
+++ b/assets/js/toc.js
@@ -1,4 +1,4 @@
-import { t } from './i18n.js?v=local-connect-settings-20260508';
+import { t } from './i18n.js?v=annotate-i18n-20260510';
 import { getThemeRegion } from './theme-regions.js';
 
 // Anchors and Table of Contents enhancements

--- a/assets/main.js
+++ b/assets/main.js
@@ -7,7 +7,7 @@ import {
   stripEncryptedBodyForPublicUse
 } from './js/encrypted-content.js?v=encrypted-demo-20260508';
 import { mdParse } from './js/markdown.js?v=katex-math-20260510';
-import { setupAnchors, setupTOC } from './js/toc.js?v=local-connect-settings-20260508';
+import { setupAnchors, setupTOC } from './js/toc.js?v=annotate-i18n-20260510';
 import { applySavedTheme, bindThemeToggle, bindThemePackPicker, mountThemeControls, refreshLanguageSelector, applyThemeConfig, bindPostEditor } from './js/theme.js?v=theme-switch-fix-20260508';
 import { createThemeI18nContext, ensureThemeLayout, getThemeApiHandler, getThemeLayoutContext, getThemeRegion } from './js/theme-layout.js?v=theme-switch-fix-20260508';
 import { setupSearch } from './js/search.js';
@@ -24,15 +24,15 @@ import {
   getCurrentLang,
   normalizeLangKey,
   POSTS_METADATA_READY_EVENT
-} from './js/i18n.js?v=local-connect-settings-20260508';
-import { updateSEO, extractSEOFromMarkdown } from './js/seo.js?v=local-connect-settings-20260508';
-import { initErrorReporter, setReporterContext, showErrorOverlay } from './js/errors.js?v=local-connect-settings-20260508';
+} from './js/i18n.js?v=annotate-i18n-20260510';
+import { updateSEO, extractSEOFromMarkdown } from './js/seo.js?v=annotate-i18n-20260510';
+import { initErrorReporter, setReporterContext, showErrorOverlay } from './js/errors.js?v=annotate-i18n-20260510';
 import { initSyntaxHighlighting } from './js/syntax-highlight.js';
 import { renderPressMath } from './js/math-render.js?v=katex-math-20260510';
 import { fetchConfigWithYamlFallback } from './js/yaml.js';
 import { applyMasonry, updateMasonryItem, calcAndSetSpan, toPx, debounce } from './js/masonry.js';
-import { aggregateTags, renderTagSidebar, setupTagTooltips } from './js/tags.js?v=local-connect-settings-20260508';
-import { renderPostNav } from './js/post-nav.js?v=local-connect-settings-20260508';
+import { aggregateTags, renderTagSidebar, setupTagTooltips } from './js/tags.js?v=annotate-i18n-20260510';
+import { renderPostNav } from './js/post-nav.js?v=annotate-i18n-20260510';
 import { getArticleTitleFromMain } from './js/dom-utils.js';
 import { applyLangHints } from './js/typography.js';
 import { mountAnnotateComments, resolveAnnotateArticleContext } from './js/annotate.js?v=katex-math-20260510';

--- a/assets/themes/native/modules/interactions.js
+++ b/assets/themes/native/modules/interactions.js
@@ -1,11 +1,11 @@
 import { installLightbox } from '../../../js/lightbox.js';
 import { sanitizeImageUrl, setSafeHtml } from '../../../js/safe-html.js';
 import { slugifyTab, escapeHtml, getQueryVariable, renderTags, cardImageSrc, fallbackCover, formatDisplayDate, formatBytes, renderSkeletonArticle } from '../../../js/utils.js';
-import { attachHoverTooltip } from '../../../js/tags.js?v=local-connect-settings-20260508';
+import { attachHoverTooltip } from '../../../js/tags.js?v=annotate-i18n-20260510';
 import { prefersReducedMotion, getArticleTitleFromMain } from '../../../js/dom-utils.js';
-import { renderPostMetaCard, renderOutdatedCard } from '../../../js/templates.js?v=local-connect-settings-20260508';
-import { showErrorOverlay } from '../../../js/errors.js?v=local-connect-settings-20260508';
-import { renderPostNav } from '../../../js/post-nav.js?v=local-connect-settings-20260508';
+import { renderPostMetaCard, renderOutdatedCard } from '../../../js/templates.js?v=annotate-i18n-20260510';
+import { showErrorOverlay } from '../../../js/errors.js?v=annotate-i18n-20260510';
+import { renderPostNav } from '../../../js/post-nav.js?v=annotate-i18n-20260510';
 import { hydratePostImages, hydratePostVideos, applyLazyLoadingIn } from '../../../js/post-render.js';
 import { hydrateInternalLinkCards } from '../../../js/link-cards.js?v=encrypted-demo-20260508';
 import { applyLangHints } from '../../../js/typography.js';

--- a/index_editor.html
+++ b/index_editor.html
@@ -2482,9 +2482,9 @@
       updateOffset();
     })();
   </script>
-  <script type="module" src="assets/js/editor-boot.js?v=local-connect-settings-20260508"></script>
+  <script type="module" src="assets/js/editor-boot.js?v=annotate-i18n-20260510"></script>
   <script type="module" src="assets/js/editor-main.js?v=katex-math-20260510"></script>
-  <script type="module" src="assets/js/composer.js?v=annotate-settings-20260510"></script>
+  <script type="module" src="assets/js/composer.js?v=annotate-combobox-20260510"></script>
   <!-- Back to top button -->
   <button id="backToTop" class="back-to-top" aria-label="返回顶部" title="返回顶部" type="button" hidden>
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -10,6 +10,7 @@ const editorMainPath = resolve(here, '../assets/js/editor-main.js');
 const editorBlocksPath = resolve(here, '../assets/js/editor-blocks.js');
 const syntaxHighlightPath = resolve(here, '../assets/js/syntax-highlight.js');
 const editorPath = resolve(here, '../index_editor.html');
+const starterSitePath = resolve(here, '../templates/press-starter/site.yaml');
 const nativeBasePath = resolve(here, '../assets/themes/native/base.css');
 const nativeThemePath = resolve(here, '../assets/themes/native/theme.css');
 const enI18nPath = resolve(here, '../assets/i18n/en.js');
@@ -25,6 +26,7 @@ const editorMainSource = readFileSync(editorMainPath, 'utf8');
 const editorBlocksSource = readFileSync(editorBlocksPath, 'utf8');
 const syntaxHighlightSource = readFileSync(syntaxHighlightPath, 'utf8');
 const editorSource = readFileSync(editorPath, 'utf8');
+const starterSiteSource = readFileSync(starterSitePath, 'utf8');
 const nativeBaseSource = readFileSync(nativeBasePath, 'utf8');
 const nativeThemeSource = readFileSync(nativeThemePath, 'utf8');
 const i18nSource = readFileSync(i18nPath, 'utf8');
@@ -99,7 +101,7 @@ assert.doesNotMatch(
 
 assert.match(
   editorSource,
-  /assets\/js\/editor-boot\.js\?v=local-connect-settings-20260508/,
+  /assets\/js\/editor-boot\.js\?v=annotate-i18n-20260510/,
   'editor HTML should cache-bust editor boot when asset deletion i18n boundaries change'
 );
 
@@ -111,7 +113,7 @@ assert.match(
 
 assert.match(
   editorSource,
-  /assets\/js\/composer\.js\?v=annotate-settings-20260510/,
+  /assets\/js\/composer\.js\?v=annotate-combobox-20260510/,
   'editor HTML should cache-bust composer.js when site settings UI changes'
 );
 
@@ -1888,19 +1890,19 @@ assert.match(
 
 assert.match(
   chtHkI18nSource,
-  /import chtTwTranslations from '\.\/cht-tw\.js\?v=local-connect-settings-20260508';/,
+  /import chtTwTranslations from '\.\/cht-tw\.js\?v=annotate-i18n-20260510';/,
   'Hong Kong Traditional Chinese should inherit the cache-busted Traditional Chinese asset deletion strings'
 );
 
 assert.match(
   languagesManifestSource,
-  /"\.\/en\.js\?v=local-connect-settings-20260508"[\s\S]*"\.\/chs\.js\?v=local-connect-settings-20260508"[\s\S]*"\.\/cht-tw\.js\?v=local-connect-settings-20260508"[\s\S]*"\.\/cht-hk\.js\?v=local-connect-settings-20260508"[\s\S]*"\.\/ja\.js\?v=local-connect-settings-20260508"/,
+  /"\.\/en\.js\?v=annotate-i18n-20260510"[\s\S]*"\.\/chs\.js\?v=annotate-i18n-20260510"[\s\S]*"\.\/cht-tw\.js\?v=annotate-i18n-20260510"[\s\S]*"\.\/cht-hk\.js\?v=annotate-i18n-20260510"[\s\S]*"\.\/ja\.js\?v=annotate-i18n-20260510"/,
   'language manifest should cache-bust language bundles changed by editor asset deletion labels'
 );
 
 assert.match(
   i18nSource,
-  /from '\.\.\/i18n\/en\.js\?v=local-connect-settings-20260508'/,
+  /from '\.\.\/i18n\/en\.js\?v=annotate-i18n-20260510'/,
   'default English bundle import should be cache-busted when editor asset deletion labels change'
 );
 
@@ -3165,6 +3167,18 @@ assert.match(
   source,
   /const CONNECT_PUBLISH_ENABLED_STORAGE_KEY = 'press_connect_publish_enabled';[\s\S]*const CONNECT_PUBLISH_BASE_URL_STORAGE_KEY = 'press_connect_publish_base_url';[\s\S]*const CONNECT_PUBLISH_PRESETS = \[[\s\S]*https:\/\/connect-8mr\.pages\.dev[\s\S]*http:\/\/127\.0\.0\.1:8788/,
   'Connect publish settings should use scoped local browser storage with built-in remote presets'
+);
+
+assert.match(
+  source,
+  /const ANNOTATE_DISCUSSION_CATEGORY_PRESETS = \[[\s\S]*value: 'General'[\s\S]*renderAnnotateGrid[\s\S]*type: 'url'[\s\S]*listId: 'siteAnnotateConnectBaseUrlPresets'[\s\S]*options: CONNECT_PUBLISH_PRESETS[\s\S]*listId: 'siteAnnotateDiscussionCategoryPresets'[\s\S]*options: ANNOTATE_DISCUSSION_CATEGORY_PRESETS/,
+  'Annotate settings should expose editable datalist inputs for Connect URL and Discussion category'
+);
+
+assert.match(
+  starterSiteSource,
+  /annotate:\n  enabled: true\n  connectBaseUrl: https:\/\/connect-8mr\.pages\.dev\n  discussionCategory: General/,
+  'Press starter site.yaml should default new YAP sites to enabled Annotate comments'
 );
 
 assert.match(

--- a/scripts/test-ui-components.js
+++ b/scripts/test-ui-components.js
@@ -98,22 +98,22 @@ assert.match(indexEditorHtml, /blocks-math-editor[\s\S]*blocks-math-editor texta
 assert.match(editorBlocks, /mathSource\.className = 'blocks-math-source'/, 'block editor should create a math source popover field');
 assert.match(main, /from '\.\/js\/theme-layout\.js\?v=theme-switch-fix-20260508';/, 'main should cache-bust theme layout when native module cache keys change');
 assert.match(main, /from '\.\/js\/theme\.js\?v=theme-switch-fix-20260508';/, 'main should cache-bust theme helpers when native i18n dependencies change');
-assert.match(main, /from '\.\/js\/i18n\.js\?v=local-connect-settings-20260508';/, 'main should use the same versioned i18n module instance as shared UI modules');
+assert.match(main, /from '\.\/js\/i18n\.js\?v=annotate-i18n-20260510';/, 'main should use the same versioned i18n module instance as shared UI modules');
 assert.match(main, /from '\.\/js\/link-cards\.js\?v=encrypted-demo-20260508';/, 'main should cache-bust internal link cards when protected preview handling changes');
-assert.match(main, /from '\.\/js\/seo\.js\?v=local-connect-settings-20260508';/, 'main should cache-bust SEO helpers after their i18n dependency changes');
-assert.match(main, /from '\.\/js\/toc\.js\?v=local-connect-settings-20260508';/, 'main should cache-bust TOC helpers after their i18n dependency changes');
-assert.match(main, /from '\.\/js\/tags\.js\?v=local-connect-settings-20260508';/, 'main should cache-bust tag helpers after their i18n dependency changes');
-assert.match(main, /from '\.\/js\/errors\.js\?v=local-connect-settings-20260508';/, 'main should cache-bust error helpers after their i18n dependency changes');
-assert.match(main, /from '\.\/js\/post-nav\.js\?v=local-connect-settings-20260508';/, 'main should cache-bust post navigation helpers after their i18n dependency changes');
+assert.match(main, /from '\.\/js\/seo\.js\?v=annotate-i18n-20260510';/, 'main should cache-bust SEO helpers after their i18n dependency changes');
+assert.match(main, /from '\.\/js\/toc\.js\?v=annotate-i18n-20260510';/, 'main should cache-bust TOC helpers after their i18n dependency changes');
+assert.match(main, /from '\.\/js\/tags\.js\?v=annotate-i18n-20260510';/, 'main should cache-bust tag helpers after their i18n dependency changes');
+assert.match(main, /from '\.\/js\/errors\.js\?v=annotate-i18n-20260510';/, 'main should cache-bust error helpers after their i18n dependency changes');
+assert.match(main, /from '\.\/js\/post-nav\.js\?v=annotate-i18n-20260510';/, 'main should cache-bust post navigation helpers after their i18n dependency changes');
 assert.match(main, /from '\.\/js\/annotate\.js\?v=katex-math-20260510';/, 'main should cache-bust annotate runtime helpers when comments are mounted');
-assert.match(composer, /from '\.\/i18n\.js\?v=local-connect-settings-20260508';/, 'composer should share the repository deletion docs i18n cache key');
-assert.match(composer, /from '\.\/seo\.js\?v=local-connect-settings-20260508';/, 'composer should cache-bust SEO helpers after editor i18n dependency changes');
+assert.match(composer, /from '\.\/i18n\.js\?v=annotate-i18n-20260510';/, 'composer should share the repository deletion docs i18n cache key');
+assert.match(composer, /from '\.\/seo\.js\?v=annotate-i18n-20260510';/, 'composer should cache-bust SEO helpers after editor i18n dependency changes');
 assert.match(composer, /from '\.\/system-updates\.js\?v=katex-math-20260510';/, 'composer should cache-bust system updates after math renderer changes');
 assert.match(read('assets/js/system-updates.js'), /from '\.\/safe-html\.js\?v=katex-math-20260510';/, 'system updates should cache-bust sanitizer when release notes can contain math');
 assert.match(composer, /from '\.\/theme-manager\.js\?v=theme-switch-fix-20260508';/, 'composer should cache-bust theme manager after editor i18n dependency changes');
 assert.match(composer, /from '\.\/encrypted-content\.js\?v=encrypted-demo-20260508';/, 'composer should use the encrypted markdown envelope helpers for protected editor flows');
-assert.match(themeLayout, /from '\.\/i18n\.js\?v=local-connect-settings-20260508';/, 'theme layout should share the repository deletion docs i18n cache key');
-assert.match(languageManifest, /en\.js\?v=local-connect-settings-20260508/, 'language manifest should cache-bust bundles when editor asset deletion strings change');
+assert.match(themeLayout, /from '\.\/i18n\.js\?v=annotate-i18n-20260510';/, 'theme layout should share the repository deletion docs i18n cache key');
+assert.match(languageManifest, /en\.js\?v=annotate-i18n-20260510/, 'language manifest should cache-bust bundles when editor asset deletion strings change');
 assert.doesNotMatch(
   [main, composer, themeLayout, theme, toc, read('assets/js/seo.js'), read('assets/js/editor-boot.js'), read('assets/js/system-updates.js')].join('\n'),
   /i18n\.js\?v=20260506theme/,
@@ -148,7 +148,7 @@ assert.match(themeLayout, /clearFailedThemeArtifacts\(pack\)/, 'theme layout fal
 assert.match(indexHtml, /src="assets\/js\/theme-boot\.js\?v=theme-switch-fix-20260508"/, 'index should cache-bust theme boot after external fallback changes');
 assert.match(indexEditorHtml, /src="assets\/js\/theme-boot\.js\?v=theme-switch-fix-20260508"/, 'editor should cache-bust theme boot after external fallback changes');
 assert.match(indexEditorHtml, /src="assets\/js\/editor-main\.js\?v=katex-math-20260510"/, 'editor should cache-bust editor-main after math wiring changes');
-assert.match(indexEditorHtml, /src="assets\/js\/composer\.js\?v=annotate-settings-20260510"/, 'editor should cache-bust composer after site settings UI changes');
+assert.match(indexEditorHtml, /src="assets\/js\/composer\.js\?v=annotate-combobox-20260510"/, 'editor should cache-bust composer after site settings UI changes');
 assert.match(search, /addEventListener\('press:search'[\s\S]*navigateSearch/, 'search routing should listen for press:search');
 assert.doesNotMatch(search, /input\.onkeydown\s*=/, 'search.js should not own the component input via onkeydown');
 assert.match(read('assets/js/tags.js'), /press:tag-select/, 'tag sidebar should emit press:tag-select');
@@ -168,10 +168,10 @@ assert.match(toc, /typeof tocRoot\.enhance === 'function'/, 'legacy setupTOC sho
 
 assert.match(nativeInteractions, /renderPressPostCardHtml\(/, 'native cards should render through press-post-card');
 assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/theme\.js\?v=theme-switch-fix-20260508'/, 'native interactions should cache-bust theme helper imports');
-assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/tags\.js\?v=local-connect-settings-20260508'/, 'native interactions should cache-bust tag helper imports');
-assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/templates\.js\?v=local-connect-settings-20260508'/, 'native interactions should cache-bust template helper imports');
-assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/errors\.js\?v=local-connect-settings-20260508'/, 'native interactions should cache-bust error helper imports');
-assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/post-nav\.js\?v=local-connect-settings-20260508'/, 'native interactions should cache-bust post navigation helper imports');
+assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/tags\.js\?v=annotate-i18n-20260510'/, 'native interactions should cache-bust tag helper imports');
+assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/templates\.js\?v=annotate-i18n-20260510'/, 'native interactions should cache-bust template helper imports');
+assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/errors\.js\?v=annotate-i18n-20260510'/, 'native interactions should cache-bust error helper imports');
+assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/post-nav\.js\?v=annotate-i18n-20260510'/, 'native interactions should cache-bust post navigation helper imports');
 assert.match(nativeInteractions, /from '\.\.\/\.\.\/\.\.\/js\/link-cards\.js\?v=encrypted-demo-20260508'/, 'native interactions should cache-bust internal link-card hydration');
 assert.match(nativeInteractions, /if \(meta && meta\.protected\) \{[\s\S]*ui\.protectedExcerpt[\s\S]*updateMasonryItem[\s\S]*return;/, 'native cards should not fetch protected article bodies for previews and should refresh masonry spans');
 assert.match(linkCards, /if \(meta && meta\.protected\) return;/, 'internal link cards should not fetch protected article bodies when public metadata marks protection');

--- a/templates/press-starter/site.yaml
+++ b/templates/press-starter/site.yaml
@@ -4,6 +4,10 @@ contentRoot: wwwroot
 defaultLanguage: en
 themeMode: auto
 themePack: native
+annotate:
+  enabled: true
+  connectBaseUrl: https://connect-8mr.pages.dev
+  discussionCategory: General
 repo:
   provider: github
   owner: OWNER


### PR DESCRIPTION
## Summary
- Add editable datalist inputs for Annotate Connect URL and Discussion category.
- Default the Press starter site to enabled Annotate comments.
- Bump the shared i18n cache key so new comment-setting labels cannot render as raw translation paths for returning users.

## Validation
- node --check assets/js/composer.js
- node --experimental-default-type=module scripts/test-composer-identity-grid.js
- node scripts/test-ui-components.js
- node --experimental-default-type=module scripts/test-annotate.js
- bash scripts/test-main-guard.sh