### PR TITLE
Preserve Highlight.js token classes

### DIFF
--- a/assets/js/editor-main.js
+++ b/assets/js/editor-main.js
@@ -1,6 +1,6 @@
 import { configureFetchCachePolicy } from './cache-control.js';
 import { createMarkdownBlocksEditor } from './editor-blocks.js?v=katex-blocks-20260510';
-import { createHiEditor } from './hieditor.js';
+import { createHiEditor } from './hieditor.js?v=highlightjs-common-20260510';
 import { mdParse } from './markdown.js?v=katex-math-20260510';
 import { insertImageMarkdownAtSelection, normalizeDateInputValue } from './editor-markdown-ops.js';
 import {

--- a/assets/js/hieditor.js
+++ b/assets/js/hieditor.js
@@ -284,7 +284,7 @@ function renderHighlight(codeEl, gutterEl, value, language, options = {}) {
     // Fallback to plain escaped if markers still leak
     safeHtml = escapeHtmlInline(raw);
   }
-  // Render using a safe DOM builder that only allows <span class="syntax-*> wrappers
+  // Render using a safe DOM builder that only allows highlight span wrappers
   // and decodes entities for text nodes. This avoids interpreting arbitrary HTML.
   (function safeRender(target, markup) {
     // Minimal entity decoder matching escapeHtmlInline
@@ -298,25 +298,30 @@ function renderHighlight(codeEl, gutterEl, value, language, options = {}) {
     const root = document.createDocumentFragment();
     const stack = [root];
     let i = 0;
-    const openStart = '<span class="syntax-';
-    const openEnd = '">';
     const closeTag = '</span>';
-    const isTypeOk = (t) => /^[a-z-]+$/.test(t);
+    const isClassOk = (cls) => (
+      /^syntax-[a-z-]+$/.test(cls)
+      || /^hljs-[A-Za-z0-9_-]+$/.test(cls)
+      || /^[A-Za-z]+_+$/.test(cls)
+    );
     while (i < markup.length) {
-      if (markup.startsWith(openStart, i)) {
-        const j = markup.indexOf(openEnd, i + openStart.length);
-        if (j !== -1) {
-          const cls = markup.slice(i + openStart.length, j);
-          if (isTypeOk(cls)) {
+      if (markup.startsWith('<span', i)) {
+        const match = markup.slice(i).match(/^<\s*span\b([^>]*)>/i);
+        if (match) {
+          const clsMatch = (match[1] || '').match(/\bclass\s*=\s*("([^"]*)"|'([^']*)'|([^\s>]+))/i);
+          const classes = clsMatch
+            ? (clsMatch[2] || clsMatch[3] || clsMatch[4] || '').split(/\s+/).filter(isClassOk)
+            : [];
+          if (classes.length) {
             const el = document.createElement('span');
-            el.className = 'syntax-' + cls;
+            el.className = classes.join(' ');
             stack[stack.length - 1].appendChild(el);
             stack.push(el);
-            i = j + openEnd.length;
+            i += match[0].length;
             continue;
           }
         }
-        // Not a valid allowed opener; treat '<' as text
+        // Not a valid allowed opener; treat '<' as text and keep moving.
         stack[stack.length - 1].appendChild(document.createTextNode('<'));
         i += 1;
         continue;
@@ -327,6 +332,11 @@ function renderHighlight(codeEl, gutterEl, value, language, options = {}) {
         continue;
       }
       const nextLt = markup.indexOf('<', i);
+      if (nextLt === i) {
+        stack[stack.length - 1].appendChild(document.createTextNode('<'));
+        i += 1;
+        continue;
+      }
       const end = nextLt === -1 ? markup.length : nextLt;
       const chunk = markup.slice(i, end);
       if (chunk) stack[stack.length - 1].appendChild(document.createTextNode(decode(chunk)));

--- a/assets/js/syntax-highlight.js
+++ b/assets/js/syntax-highlight.js
@@ -24,17 +24,72 @@ const LANGUAGE_ALIASES = new Map([
   ['none', 'plaintext'],
   ['nohighlight', 'plaintext']
 ]);
+const HIGHLIGHT_CLASS_ALLOWLIST = new Set([
+  'class_',
+  'constant_',
+  'dispatch_',
+  'escape_',
+  'function_',
+  'hljs-addition',
+  'hljs-attr',
+  'hljs-attribute',
+  'hljs-built_in',
+  'hljs-bullet',
+  'hljs-char',
+  'hljs-class',
+  'hljs-code',
+  'hljs-comment',
+  'hljs-deletion',
+  'hljs-doctag',
+  'hljs-emphasis',
+  'hljs-function',
+  'hljs-keyword',
+  'hljs-label',
+  'hljs-link',
+  'hljs-literal',
+  'hljs-meta',
+  'hljs-name',
+  'hljs-number',
+  'hljs-operator',
+  'hljs-params',
+  'hljs-property',
+  'hljs-punctuation',
+  'hljs-quote',
+  'hljs-regexp',
+  'hljs-section',
+  'hljs-selector-attr',
+  'hljs-selector-class',
+  'hljs-selector-id',
+  'hljs-selector-pseudo',
+  'hljs-selector-tag',
+  'hljs-string',
+  'hljs-strong',
+  'hljs-subst',
+  'hljs-symbol',
+  'hljs-tag',
+  'hljs-template-variable',
+  'hljs-title',
+  'hljs-type',
+  'hljs-variable',
+  'inherited__',
+  'invoke__',
+  'language_',
+  'prompt_'
+]);
 const TOKEN_CLASS_MAP = new Map([
   ['hljs-keyword', 'syntax-keyword'],
   ['hljs-built_in', 'syntax-keyword'],
   ['hljs-literal', 'syntax-keyword'],
   ['hljs-type', 'syntax-keyword'],
   ['hljs-symbol', 'syntax-keyword'],
+  ['hljs-class', 'syntax-keyword'],
+  ['hljs-function', 'syntax-keyword'],
   ['hljs-name', 'syntax-tag'],
   ['hljs-tag', 'syntax-tag'],
   ['hljs-attr', 'syntax-property'],
   ['hljs-attribute', 'syntax-property'],
   ['hljs-property', 'syntax-property'],
+  ['hljs-params', 'syntax-property'],
   ['hljs-variable', 'syntax-variables'],
   ['hljs-template-variable', 'syntax-variables'],
   ['hljs-selector-tag', 'syntax-selector'],
@@ -54,9 +109,11 @@ const TOKEN_CLASS_MAP = new Map([
   ['hljs-meta', 'syntax-preprocessor'],
   ['hljs-meta-keyword', 'syntax-preprocessor'],
   ['hljs-meta-string', 'syntax-string'],
+  ['hljs-label', 'syntax-preprocessor'],
   ['hljs-operator', 'syntax-operator'],
   ['hljs-punctuation', 'syntax-punctuation'],
   ['hljs-bullet', 'syntax-punctuation'],
+  ['hljs-char', 'syntax-string'],
   ['hljs-code', 'syntax-code'],
   ['hljs-emphasis', 'syntax-emphasis'],
   ['hljs-strong', 'syntax-strong'],
@@ -111,10 +168,17 @@ function robotsHighlight(raw) {
 function mapHighlightClasses(classText) {
   const mapped = [];
   String(classText || '').split(/\s+/).forEach((cls) => {
+    if (!cls) return;
+    if (HIGHLIGHT_CLASS_ALLOWLIST.has(cls) && !mapped.includes(cls)) mapped.push(cls);
     const value = TOKEN_CLASS_MAP.get(cls);
     if (value && !mapped.includes(value)) mapped.push(value);
   });
   return mapped;
+}
+
+function isAllowedHighlightClass(className) {
+  const value = String(className || '').trim();
+  return value.startsWith('syntax-') || HIGHLIGHT_CLASS_ALLOWLIST.has(value);
 }
 
 function mapHighlightHtml(html) {
@@ -171,7 +235,6 @@ function simpleHighlight(code, language) {
 function toSafeFragment(html) {
   const allowedTag = 'SPAN';
   const allowedAttr = 'class';
-  const classPrefix = 'syntax-';
 
   try {
     if (typeof window !== 'undefined' && 'Sanitizer' in window && typeof Element.prototype.setHTML === 'function') {
@@ -186,7 +249,7 @@ function toSafeFragment(html) {
           el.replaceWith(document.createTextNode(el.textContent || ''));
           return;
         }
-        const classes = (el.getAttribute('class') || '').split(/\s+/).filter(c => c && c.startsWith(classPrefix));
+        const classes = (el.getAttribute('class') || '').split(/\s+/).filter(isAllowedHighlightClass);
         if (classes.length) el.setAttribute('class', classes.join(' ')); else el.removeAttribute('class');
         for (const attr of Array.from(el.attributes)) {
           if (attr.name !== allowedAttr) el.removeAttribute(attr.name);
@@ -251,7 +314,7 @@ function toSafeFragment(html) {
       let classes = [];
       if (clsMatch) {
         const raw = (clsMatch[2] || clsMatch[3] || clsMatch[4] || '').trim();
-        classes = raw.split(/\s+/).filter(c => c && c.startsWith(classPrefix));
+        classes = raw.split(/\s+/).filter(isAllowedHighlightClass);
       }
       const el = document.createElement('span');
       if (classes.length) el.setAttribute('class', classes.join(' '));

--- a/assets/themes/native/base.css
+++ b/assets/themes/native/base.css
@@ -283,61 +283,163 @@ pre.with-code-scroll { overflow: hidden; }
 .code-scroll .code-gutter span { display: block; line-height: 1.55; }
 .code-scroll code { display: block; white-space: pre; flex: 1 1 auto; min-width: 0; }
 
-/* Syntax tokens are mapped from Highlight.js output into Press-owned classes. */
+/* Syntax tokens keep Highlight.js classes and add Press-owned compatibility classes. */
+.hljs-keyword,
+.hljs-built_in,
+.hljs-literal,
+.hljs-type,
+.hljs-symbol,
+.hljs-class,
+.hljs-function,
+.hljs-function.dispatch_,
 .syntax-keyword,
 .syntax-keywords,
+.hljs-name,
+.hljs-tag,
 .syntax-tag,
 .syntax-tags { color: #8250df; font-weight: 600; }
+.hljs-title,
+.hljs-section,
+.hljs-title.function_,
+.hljs-title.function_.invoke__,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
 .syntax-title { color: #953800; font-weight: 600; }
+.hljs-string,
+.hljs-regexp,
+.hljs-subst,
+.hljs-char,
+.hljs-char.escape_,
+.hljs-link,
 .syntax-string,
 .syntax-strings,
 .syntax-link { color: #116329; }
+.hljs-number,
 .syntax-number,
 .syntax-numbers { color: #0550ae; }
+.hljs-comment,
+.hljs-quote,
 .syntax-comment,
 .syntax-comments { color: #6e7781; font-style: italic; }
+.hljs-attr,
+.hljs-attribute,
+.hljs-property,
+.hljs-params,
 .syntax-property,
 .syntax-properties,
 .syntax-attributes { color: #0550ae; }
+.hljs-selector-tag,
+.hljs-selector-id,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
 .syntax-selector,
 .syntax-selectors { color: #116329; font-weight: 600; }
+.hljs-doctag,
+.hljs-meta,
+.hljs-meta.prompt_,
+.hljs-meta-keyword,
+.hljs-label,
 .syntax-preprocessor { color: #cf222e; font-weight: 600; }
+.hljs-variable,
+.hljs-variable.constant_,
+.hljs-variable.language_,
+.hljs-template-variable,
 .syntax-variables { color: #953800; }
+.hljs-operator,
+.hljs-punctuation,
+.hljs-bullet,
 .syntax-operator,
 .syntax-operators,
 .syntax-punctuation { color: #57606a; }
+.hljs-code,
 .syntax-code { color: #0550ae; }
+.hljs-emphasis,
 .syntax-emphasis { font-style: italic; }
+.hljs-strong,
 .syntax-strong { font-weight: 700; }
+.hljs-addition,
 .syntax-addition { color: #1a7f37; background: rgba(46, 160, 67, 0.12); }
+.hljs-deletion,
 .syntax-deletion { color: #cf222e; background: rgba(248, 81, 73, 0.12); }
+.hljs-formula,
 .syntax-formula { color: #953800; }
 
+[data-theme="dark"] .hljs-keyword,
+[data-theme="dark"] .hljs-built_in,
+[data-theme="dark"] .hljs-literal,
+[data-theme="dark"] .hljs-type,
+[data-theme="dark"] .hljs-symbol,
+[data-theme="dark"] .hljs-class,
+[data-theme="dark"] .hljs-function,
+[data-theme="dark"] .hljs-function.dispatch_,
 [data-theme="dark"] .syntax-keyword,
 [data-theme="dark"] .syntax-keywords,
+[data-theme="dark"] .hljs-name,
+[data-theme="dark"] .hljs-tag,
 [data-theme="dark"] .syntax-tag,
 [data-theme="dark"] .syntax-tags { color: #d2a8ff; }
+[data-theme="dark"] .hljs-title,
+[data-theme="dark"] .hljs-section,
+[data-theme="dark"] .hljs-title.function_,
+[data-theme="dark"] .hljs-title.function_.invoke__,
+[data-theme="dark"] .hljs-title.class_,
+[data-theme="dark"] .hljs-title.class_.inherited__,
 [data-theme="dark"] .syntax-title { color: #ffa657; }
+[data-theme="dark"] .hljs-string,
+[data-theme="dark"] .hljs-regexp,
+[data-theme="dark"] .hljs-subst,
+[data-theme="dark"] .hljs-char,
+[data-theme="dark"] .hljs-char.escape_,
+[data-theme="dark"] .hljs-link,
 [data-theme="dark"] .syntax-string,
 [data-theme="dark"] .syntax-strings,
 [data-theme="dark"] .syntax-link { color: #a5d6ff; }
+[data-theme="dark"] .hljs-number,
 [data-theme="dark"] .syntax-number,
 [data-theme="dark"] .syntax-numbers { color: #79c0ff; }
+[data-theme="dark"] .hljs-comment,
+[data-theme="dark"] .hljs-quote,
 [data-theme="dark"] .syntax-comment,
 [data-theme="dark"] .syntax-comments { color: #8b949e; }
+[data-theme="dark"] .hljs-attr,
+[data-theme="dark"] .hljs-attribute,
+[data-theme="dark"] .hljs-property,
+[data-theme="dark"] .hljs-params,
 [data-theme="dark"] .syntax-property,
 [data-theme="dark"] .syntax-properties,
 [data-theme="dark"] .syntax-attributes { color: #79c0ff; }
+[data-theme="dark"] .hljs-selector-tag,
+[data-theme="dark"] .hljs-selector-id,
+[data-theme="dark"] .hljs-selector-class,
+[data-theme="dark"] .hljs-selector-attr,
+[data-theme="dark"] .hljs-selector-pseudo,
 [data-theme="dark"] .syntax-selector,
 [data-theme="dark"] .syntax-selectors { color: #7ee787; }
+[data-theme="dark"] .hljs-doctag,
+[data-theme="dark"] .hljs-meta,
+[data-theme="dark"] .hljs-meta.prompt_,
+[data-theme="dark"] .hljs-meta-keyword,
+[data-theme="dark"] .hljs-label,
 [data-theme="dark"] .syntax-preprocessor { color: #ff7b72; }
+[data-theme="dark"] .hljs-variable,
+[data-theme="dark"] .hljs-variable.constant_,
+[data-theme="dark"] .hljs-variable.language_,
+[data-theme="dark"] .hljs-template-variable,
 [data-theme="dark"] .syntax-variables { color: #ffa657; }
+[data-theme="dark"] .hljs-operator,
+[data-theme="dark"] .hljs-punctuation,
+[data-theme="dark"] .hljs-bullet,
 [data-theme="dark"] .syntax-operator,
 [data-theme="dark"] .syntax-operators,
 [data-theme="dark"] .syntax-punctuation { color: #c9d1d9; }
+[data-theme="dark"] .hljs-code,
 [data-theme="dark"] .syntax-code { color: #79c0ff; }
+[data-theme="dark"] .hljs-addition,
 [data-theme="dark"] .syntax-addition { color: #7ee787; background: rgba(46, 160, 67, 0.18); }
+[data-theme="dark"] .hljs-deletion,
 [data-theme="dark"] .syntax-deletion { color: #ff7b72; background: rgba(248, 81, 73, 0.18); }
+[data-theme="dark"] .hljs-formula,
 [data-theme="dark"] .syntax-formula { color: #ffa657; }
 
 /* 语言标签样式 */

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -1541,6 +1541,12 @@ assert.match(
   'runtime and editor entrypoints should cache-bust the Highlight.js-backed syntax highlighter'
 );
 
+assert.match(
+  editorMainSource,
+  /from '\.\/hieditor\.js\?v=highlightjs-common-20260510';/,
+  'editor main should cache-bust hi-editor when Highlight.js span output changes'
+);
+
 assert.doesNotMatch(
   [mainSource, editorMainSource, editorBlocksSource, hiEditorSource].join('\n'),
   /syntax-highlight\.js(?:['"]|;)|syntax-highlight\.js\?v=blocks-code-gutter-20260505/,
@@ -1581,6 +1587,20 @@ assert.match(
   syntaxHighlightSource,
   /export function createSafeHighlightFragment\(code, language\) \{[\s\S]*return toSafeFragment\(simpleHighlight\(code \|\| '', language \|\| 'plain'\)\);[\s\S]*\}/,
   'syntax highlighter should expose a safe fragment helper for editor-owned highlight mirrors'
+);
+
+assert.ok(
+  hiEditorSource.includes("const isClassOk = (cls) => (")
+    && hiEditorSource.includes("/^syntax-[a-z-]+$/.test(cls)")
+    && hiEditorSource.includes("/^hljs-[A-Za-z0-9_-]+$/.test(cls)")
+    && hiEditorSource.includes("/^[A-Za-z]+_+$/.test(cls)"),
+  'hi-editor safe renderer should accept Highlight.js classes plus Press syntax classes'
+);
+
+assert.match(
+  hiEditorSource,
+  /if \(markup\.startsWith\('<span', i\)\) \{[\s\S]*split\(\/\\s\+\/\)\.filter\(isClassOk\)[\s\S]*i \+= match\[0\]\.length;[\s\S]*const nextLt = markup\.indexOf\('<', i\);[\s\S]*if \(nextLt === i\) \{[\s\S]*document\.createTextNode\('<'\)[\s\S]*i \+= 1;[\s\S]*continue;[\s\S]*\}/,
+  'hi-editor safe renderer should preserve unknown angle brackets as text and never stall on Highlight.js spans'
 );
 
 assert.match(

--- a/scripts/test-syntax-highlight.js
+++ b/scripts/test-syntax-highlight.js
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import hljs from '../assets/js/vendor/highlightjs/highlight.min.js';
+import { highlightCode } from '../assets/js/syntax-highlight.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const read = (path) => readFileSync(resolve(here, '..', path), 'utf8');
+
+const syntaxSource = read('assets/js/syntax-highlight.js');
+const highlightBundle = read('assets/js/vendor/highlightjs/highlight.min.js');
+const nativeCss = read('assets/themes/native/base.css');
+
+function extractQuotedSet(source, declarationName) {
+  const match = source.match(new RegExp(`const ${declarationName} = new Set\\(\\[([\\s\\S]*?)\\]\\);`));
+  assert.ok(match, `missing ${declarationName}`);
+  return new Set(Array.from(match[1].matchAll(/'([^']+)'/g), m => m[1]));
+}
+
+function classesForScope(scope) {
+  const parts = String(scope || '').split('.').filter(Boolean);
+  if (!parts.length) return [];
+  const [base, ...modifiers] = parts;
+  return [`hljs-${base}`, ...modifiers.map((part, index) => `${part}${'_'.repeat(index + 1)}`)];
+}
+
+function extractBundleClasses(source) {
+  const scopes = new Set();
+  for (const pattern of [/className:"([A-Za-z0-9_.-]+)"/g, /scope:"([A-Za-z0-9_.-]+)"/g]) {
+    for (const match of source.matchAll(pattern)) scopes.add(match[1]);
+  }
+  const classes = new Set();
+  for (const scope of scopes) {
+    for (const cls of classesForScope(scope)) classes.add(cls);
+  }
+  return classes;
+}
+
+function htmlClasses(html) {
+  const classes = new Set();
+  for (const match of String(html || '').matchAll(/\bclass="([^"]+)"/g)) {
+    for (const cls of match[1].split(/\s+/)) {
+      if (cls) classes.add(cls);
+    }
+  }
+  return classes;
+}
+
+function assertHasClasses(html, expected, label) {
+  const classes = htmlClasses(html);
+  for (const cls of expected) {
+    assert.ok(classes.has(cls), `${label} should preserve ${cls}`);
+  }
+}
+
+const expectedBundleClasses = extractBundleClasses(highlightBundle);
+const allowlist = extractQuotedSet(syntaxSource, 'HIGHLIGHT_CLASS_ALLOWLIST');
+
+for (const cls of expectedBundleClasses) {
+  assert.ok(allowlist.has(cls), `highlight allowlist should include current bundle class ${cls}`);
+}
+
+assert.deepEqual(
+  hljs.listLanguages().sort(),
+  [
+    'bash', 'c', 'cpp', 'csharp', 'css', 'diff', 'go', 'graphql', 'ini', 'java',
+    'javascript', 'json', 'kotlin', 'less', 'lua', 'makefile', 'markdown',
+    'objectivec', 'perl', 'php', 'php-template', 'plaintext', 'python',
+    'python-repl', 'r', 'ruby', 'rust', 'scss', 'shell', 'sql', 'swift',
+    'typescript', 'vbnet', 'wasm', 'xml', 'yaml'
+  ],
+  'reviewed Highlight.js common bundle language set should stay fixed'
+);
+
+const samples = {
+  javascript: 'class Foo extends Bar { constructor(x) { this.x = x; } render() { return `${this.x}`; } }\nconst answer = true; console.log(answer);',
+  python: 'class Foo(Bar):\n    def render(self, value: int = 1):\n        return f"value={value}"\n',
+  css: '.post code[class~="language-js"] { color: var(--code); }\n@media screen { #id:hover { display: block; } }',
+  xml: '<section class="hero"><h1>Hello</h1><!-- comment --></section>',
+  json: '{"name":"Native","version":"3.4.0","required":true,"items":[1,2,3]}',
+  yaml: 'name: Native\nversion: 3.4.0\nrequired: true\nitems:\n  - one\n',
+  bash: 'export NODE_ENV=production\necho "hello" | grep h\nif [ -f package.json ]; then npm test; fi',
+  diff: '- old line\n+ new line\n@@ -1,2 +1,2 @@\n context',
+  markdown: '# Heading\n\n```js\nconst x = 1;\n```\n\n[link](https://example.com)'
+};
+
+for (const [language, code] of Object.entries(samples)) {
+  const html = highlightCode(code, language);
+  const classes = htmlClasses(html);
+  assert.ok([...classes].some(cls => cls.startsWith('hljs-')), `${language} should preserve Highlight.js token classes`);
+  assert.ok([...classes].some(cls => cls.startsWith('syntax-')), `${language} should preserve Press compatibility token classes`);
+}
+
+assertHasClasses(highlightCode(samples.javascript, 'javascript'), [
+  'hljs-title',
+  'function_',
+  'class_',
+  'inherited__',
+  'hljs-variable',
+  'language_',
+  'syntax-title',
+  'syntax-variables'
+], 'javascript highlight output');
+
+assertHasClasses(highlightCode(samples.python, 'python'), [
+  'hljs-params',
+  'hljs-built_in',
+  'hljs-number',
+  'syntax-property',
+  'syntax-keyword'
+], 'python highlight output');
+
+assertHasClasses(highlightCode(samples.css, 'css'), [
+  'hljs-selector-class',
+  'hljs-selector-tag',
+  'hljs-selector-attr',
+  'hljs-selector-id',
+  'hljs-selector-pseudo',
+  'syntax-selector'
+], 'css highlight output');
+
+assertHasClasses(highlightCode(samples.xml, 'xml'), [
+  'hljs-tag',
+  'hljs-name',
+  'hljs-attr',
+  'hljs-string',
+  'hljs-comment',
+  'syntax-tag'
+], 'xml highlight output');
+
+assertHasClasses(highlightCode(samples.json, 'json'), [
+  'hljs-punctuation',
+  'hljs-attr',
+  'hljs-literal',
+  'syntax-punctuation',
+  'syntax-property'
+], 'json highlight output');
+
+assertHasClasses(highlightCode(samples.yaml, 'yaml'), [
+  'hljs-attr',
+  'hljs-number',
+  'hljs-literal',
+  'hljs-bullet',
+  'syntax-property'
+], 'yaml highlight output');
+
+assertHasClasses(highlightCode(samples.diff, 'diff'), [
+  'hljs-deletion',
+  'hljs-addition',
+  'hljs-meta',
+  'syntax-deletion',
+  'syntax-addition'
+], 'diff highlight output');
+
+const mainHighlightClasses = [...expectedBundleClasses].filter(cls => cls.startsWith('hljs-'));
+for (const cls of mainHighlightClasses) {
+  const escaped = cls.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  assert.match(nativeCss, new RegExp(`\\.${escaped}(?![A-Za-z0-9_-])`), `native CSS should cover ${cls}`);
+}
+
+for (const selector of [
+  '.hljs-title.function_',
+  '.hljs-title.function_.invoke__',
+  '.hljs-title.class_',
+  '.hljs-title.class_.inherited__',
+  '.hljs-function.dispatch_',
+  '.hljs-variable.language_',
+  '.hljs-variable.constant_',
+  '.hljs-meta.prompt_',
+  '.hljs-char.escape_'
+]) {
+  assert.ok(nativeCss.includes(selector), `native CSS should cover ${selector}`);
+}
+
+console.log('ok - syntax highlight complete class preservation');

--- a/wwwroot/post/doc/v2.1.0/doc_chs.md
+++ b/wwwroot/post/doc/v2.1.0/doc_chs.md
@@ -76,7 +76,7 @@ githubpages:
 
 除了在 `wwwroot/index.yaml` 中指定文章的 Markdown 文件路径外，您还需要在每篇 Markdown 文件的开头添加前言区（Front Matter）来提供文章的元数据。以下是 `wwwroot/post/page/githubpages_chs.md` 的文件节选：
 
-```markdown
+```yaml
 ---
 title: 为 Press 配置 GitHub Pages
 date: 2025-08-21

--- a/wwwroot/post/doc/v2.1.0/doc_cht-hk.md
+++ b/wwwroot/post/doc/v2.1.0/doc_cht-hk.md
@@ -71,7 +71,7 @@ githubpages:
 
 每篇 Markdown 可以喺檔案開頭加入 Front Matter：
 
-```markdown
+```yaml
 ---
 title: 為 Press 設定 GitHub Pages
 date: 2025-08-21

--- a/wwwroot/post/doc/v2.1.0/doc_cht-tw.md
+++ b/wwwroot/post/doc/v2.1.0/doc_cht-tw.md
@@ -71,7 +71,7 @@ githubpages:
 
 每篇 Markdown 可以在檔案開頭加入 Front Matter：
 
-```markdown
+```yaml
 ---
 title: 為 Press 設定 GitHub Pages
 date: 2025-08-21

--- a/wwwroot/post/doc/v2.1.0/doc_en.md
+++ b/wwwroot/post/doc/v2.1.0/doc_en.md
@@ -76,7 +76,7 @@ githubpages:
 
 In addition to listing post paths in `wwwroot/index.yaml`, include front matter at the top of each Markdown file to supply metadata. Here’s an excerpt from `wwwroot/post/page/githubpages_en.md`:
 
-```markdown
+```yaml
 ---
 title: Configure GitHub Pages for Press
 date: 2025-08-21

--- a/wwwroot/post/doc/v2.1.0/doc_ja.md
+++ b/wwwroot/post/doc/v2.1.0/doc_ja.md
@@ -76,7 +76,7 @@ githubpages:
 
 `wwwroot/index.yaml` に記事パスを記載するほか、各 Markdown の先頭に Front Matter を入れてメタデータを提供します。`wwwroot/post/page/githubpages_ja.md` の例：
 
-```markdown
+```yaml
 ---
 title: Press を GitHub Pages で公開する設定
 date: 2025-08-21


### PR DESCRIPTION
## Summary
- preserve current vendored Highlight.js common token classes through Press syntax highlighting
- update native theme CSS and editor highlighter handling for retained hljs/modifier classes
- mark Press docs front matter examples as YAML

## Tests
- node --experimental-default-type=module scripts/test-syntax-highlight.js
- node --experimental-default-type=module scripts/test-ui-components.js
- node scripts/test-content-model.js
- bash scripts/test-frontmatter-roundtrip.sh
- node scripts/test-composer-identity-grid.js
- bash scripts/test-system-release-package.sh
- bash scripts/test-system-release-workflow.sh
- node --experimental-default-type=module scripts/test-system-updates.js