### PR TITLE
Cache-bust editor highlight entrypoint

### DIFF
--- a/index_editor.html
+++ b/index_editor.html
@@ -2483,7 +2483,7 @@
     })();
   </script>
   <script type="module" src="assets/js/editor-boot.js?v=annotate-i18n-20260510"></script>
-  <script type="module" src="assets/js/editor-main.js?v=katex-math-20260510"></script>
+  <script type="module" src="assets/js/editor-main.js?v=highlightjs-common-20260510"></script>
   <script type="module" src="assets/js/composer.js?v=annotate-combobox-20260510"></script>
   <!-- Back to top button -->
   <button id="backToTop" class="back-to-top" aria-label="返回顶部" title="返回顶部" type="button" hidden>

--- a/scripts/test-composer-identity-grid.js
+++ b/scripts/test-composer-identity-grid.js
@@ -107,8 +107,8 @@ assert.match(
 
 assert.match(
   editorSource,
-  /assets\/js\/editor-main\.js\?v=katex-math-20260510/,
-  'editor HTML should cache-bust editor-main.js when Markdown math rendering changes'
+  /assets\/js\/editor-main\.js\?v=highlightjs-common-20260510/,
+  'editor HTML should cache-bust editor-main.js when Highlight.js editor handling changes'
 );
 
 assert.match(
@@ -131,8 +131,8 @@ assert.match(
 
 assert.match(
   editorSource,
-  /assets\/js\/editor-main\.js\?v=katex-math-20260510/,
-  'editor HTML should cache-bust editor-main.js when Markdown math rendering changes'
+  /assets\/js\/editor-main\.js\?v=highlightjs-common-20260510/,
+  'editor HTML should cache-bust editor-main.js when Highlight.js editor handling changes'
 );
 
 assert.match(

--- a/scripts/test-ui-components.js
+++ b/scripts/test-ui-components.js
@@ -151,7 +151,7 @@ assert.doesNotMatch(themeLayout, /loadThemePack\(DEFAULT_PACK\)/, 'theme layout 
 assert.match(themeLayout, /clearFailedThemeArtifacts\(pack\)/, 'theme layout fallback should clear partial external theme DOM and styles');
 assert.match(indexHtml, /src="assets\/js\/theme-boot\.js\?v=theme-switch-fix-20260508"/, 'index should cache-bust theme boot after external fallback changes');
 assert.match(indexEditorHtml, /src="assets\/js\/theme-boot\.js\?v=theme-switch-fix-20260508"/, 'editor should cache-bust theme boot after external fallback changes');
-assert.match(indexEditorHtml, /src="assets\/js\/editor-main\.js\?v=katex-math-20260510"/, 'editor should cache-bust editor-main after math wiring changes');
+assert.match(indexEditorHtml, /src="assets\/js\/editor-main\.js\?v=highlightjs-common-20260510"/, 'editor should cache-bust editor-main after hi-editor Highlight.js handling changes');
 assert.match(indexEditorHtml, /src="assets\/js\/composer\.js\?v=annotate-combobox-20260510"/, 'editor should cache-bust composer after site settings UI changes');
 assert.match(search, /addEventListener\('press:search'[\s\S]*navigateSearch/, 'search routing should listen for press:search');
 assert.doesNotMatch(search, /input\.onkeydown\s*=/, 'search.js should not own the component input via onkeydown');


### PR DESCRIPTION
## Summary
- bump index_editor.html editor-main module URL for the Highlight.js editor fix
- update cache-bust regression assertions

## Tests
- node --experimental-default-type=module scripts/test-ui-components.js
- node scripts/test-composer-identity-grid.js
- bash scripts/test-system-release-package.sh
- bash scripts/test-system-release-workflow.sh